### PR TITLE
build(make): change order of clean cmds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ compose-down:
 .PHONY: clean
 clean:
 	@echo "cleaning crew, coming through..."
-	@rm -rf ./{elm-stuff,node_modules}
 	@npm run clean
+	@rm -rf ./{elm-stuff,node_modules}
 	@echo "nice and shiny; don't forget to run 'npm install'"
 
 .PHONY: build


### PR DESCRIPTION
prior to this we deleted node_modules first and then ran an npm script that executes something that resides in one of the deleted folders 🐛 