### PR TITLE
perf(html): lazy node rendering for pages root

### DIFF
--- a/src/elm/Logs.elm
+++ b/src/elm/Logs.elm
@@ -9,6 +9,7 @@ module Logs exposing
     , focusFragmentToFocusId
     , focusLogs
     , focusStep
+    , logFocusExists
     , logFocusFragment
     , stepAndLineToFocusId
     , stepToFocusId
@@ -391,6 +392,21 @@ logFocusStyles logFocus lineNumber =
 
         _ ->
             class ""
+
+
+{-| logFocusExists : takes steps and returns if a line or range has already been focused
+-}
+logFocusExists : WebData Steps -> Bool
+logFocusExists steps =
+    (Maybe.withDefault ( Nothing, Nothing ) <|
+        List.head <|
+            List.map (\step -> step.logFocus) <|
+                List.filter
+                    (\step -> step.logFocus /= ( Nothing, Nothing ))
+                <|
+                    RemoteData.withDefault [] steps
+    )
+        /= ( Nothing, Nothing )
 
 
 {-| decodeLogLine : takes maybe log and decodes it based on

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1194,7 +1194,7 @@ viewContent model =
 
         Pages.Build org repo buildNumber _ ->
             ( "Build #" ++ buildNumber ++ " - " ++ String.join "/" [ org, repo ]
-            , lazy4 Pages.Build.viewBuild model org repo buildActions
+            , lazy4 Pages.Build.viewBuild model org repo buildMsgs
             )
 
         Pages.Login ->
@@ -1391,11 +1391,6 @@ viewThemeToggle theme =
 
 
 -- HELPERS
-
-
-buildActions : Pages.Build.Actions Msg
-buildActions =
-    Pages.Build.Actions ClickStep UpdateUrl
 
 
 buildUrl : String -> List String -> List QueryParameter -> String
@@ -1821,6 +1816,13 @@ clickHook model org repo buildNumber =
         ( Dict.update ( org, repo, buildNumber ) (\_ -> Just buildInfo) model.hookBuilds
         , action
         )
+
+
+{-| buildMsgs : prepares the input record required for the Build page to route Msgs back to Main.elm
+-}
+buildMsgs : Pages.Build.Msgs Msg
+buildMsgs =
+    Pages.Build.Msgs ClickStep UpdateUrl
 
 
 {-| addReposMsgs : prepares the input record required for the AddRepos page to route Msgs back to Main.elm

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1285,15 +1285,15 @@ viewNav : Model -> Html Msg
 viewNav model =
     nav [ class "navigation", attribute "aria-label" "Navigation" ]
         [ Crumbs.view model.page
-        , navButton model
+        , navButton { user = model.user, page = model.page, sourceRepos = model.sourceRepos }
         ]
 
 
 {-| navButton : uses current page to build the commonly used button on the right side of the nav
 -}
-navButton : Model -> Html Msg
-navButton model =
-    case model.page of
+navButton : { user : WebData CurrentUser, page : Page, sourceRepos : WebData SourceRepositories } -> Html Msg
+navButton { user, page, sourceRepos } =
+    case page of
         Pages.Overview ->
             a
                 [ class "button"
@@ -1310,10 +1310,10 @@ navButton model =
                     , ( "-outline", True )
                     ]
                 , onClick FetchSourceRepositories
-                , disabled (model.sourceRepos == Loading)
+                , disabled (sourceRepos == Loading)
                 , Util.testAttribute "refresh-source-repos"
                 ]
-                [ case model.sourceRepos of
+                [ case sourceRepos of
                     Loading ->
                         text "Loading…"
 
@@ -1323,7 +1323,7 @@ navButton model =
 
         Pages.RepositoryBuilds org repo maybePage maybePerPage ->
             div [ class "buttons" ]
-                [ starToggle org repo ToggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo
+                [ starToggle org repo ToggleFavorite <| isFavorited user <| org ++ "/" ++ repo
                 , a
                     [ class "button"
                     , class "-outline"
@@ -1342,7 +1342,7 @@ navButton model =
 
         Pages.Settings org repo ->
             div [ class "buttons" ]
-                [ starToggle org repo ToggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo
+                [ starToggle org repo ToggleFavorite <| isFavorited user <| org ++ "/" ++ repo
                 , button
                     [ classList
                         [ ( "button", True )
@@ -1369,7 +1369,7 @@ navButton model =
 
         Pages.Hooks org repo _ _ ->
             div [ class "nav-buttons" ]
-                [ starToggle org repo ToggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo
+                [ starToggle org repo ToggleFavorite <| isFavorited user <| org ++ "/" ++ repo
                 , a
                     [ class "-btn"
                     , class "-inverted"

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -44,7 +44,7 @@ import Html.Attributes
         , href
         )
 import Html.Events exposing (onClick)
-import Html.Lazy exposing (lazy2)
+import Html.Lazy exposing (lazy, lazy2, lazy3, lazy4)
 import Http exposing (Error(..))
 import Http.Detailed
 import Interop
@@ -1127,7 +1127,7 @@ view model =
     { title = "Vela - " ++ title
     , body =
         [ lazy2 viewHeader model.session { feedbackLink = model.velaFeedbackURL, docsLink = model.velaDocsURL, theme = model.theme }
-        , viewNav model
+        , lazy viewNav model
         , div [ class "util" ] [ Pages.Build.viewBuildHistory model.time model.zone model.page model.builds.org model.builds.repo model.builds.builds 10 ]
         , main_ []
             [ div [ class "content-wrap" ] [ content ] ]
@@ -1141,12 +1141,12 @@ viewContent model =
     case model.page of
         Pages.Overview ->
             ( "Overview"
-            , Pages.Home.view model.user ToggleFavorite
+            , lazy2 Pages.Home.view model.user ToggleFavorite
             )
 
         Pages.AddRepositories ->
             ( "Add Repositories"
-            , Pages.AddRepos.view model addReposMsgs
+            , lazy2 Pages.AddRepos.view model addReposMsgs
             )
 
         Pages.Hooks org repo maybePage _ ->
@@ -1163,14 +1163,14 @@ viewContent model =
             ( String.join "/" [ org, repo ] ++ " hooks" ++ page
             , div []
                 [ Pager.view model.hooks.pager Pager.defaultLabels GotoPage
-                , Pages.Hooks.view model.hooks model.hookBuilds model.time org repo ClickHook
+                , lazy4 Pages.Hooks.view model org repo ClickHook
                 , Pager.view model.hooks.pager Pager.defaultLabels GotoPage
                 ]
             )
 
         Pages.Settings org repo ->
             ( String.join "/" [ org, repo ] ++ " settings"
-            , Pages.Settings.view model.repo model.inTimeout repoSettingsMsgs
+            , lazy3 Pages.Settings.view model.repo model.inTimeout repoSettingsMsgs
             )
 
         Pages.RepositoryBuilds org repo maybePage _ ->
@@ -1187,14 +1187,14 @@ viewContent model =
             ( String.join "/" [ org, repo ] ++ " builds" ++ page
             , div []
                 [ Pager.view model.builds.pager Pager.defaultLabels GotoPage
-                , Pages.Builds.view model.builds model.time org repo
+                , lazy4 Pages.Builds.view model.builds model.time org repo
                 , Pager.view model.builds.pager Pager.defaultLabels GotoPage
                 ]
             )
 
         Pages.Build org repo buildNumber _ ->
             ( "Build #" ++ buildNumber ++ " - " ++ String.join "/" [ org, repo ]
-            , Pages.Build.viewBuild model.time org repo model.build model.steps model.logs ClickStep UpdateUrl model.shift
+            , lazy4 Pages.Build.viewBuild model org repo buildActions
             )
 
         Pages.Login ->
@@ -1391,6 +1391,11 @@ viewThemeToggle theme =
 
 
 -- HELPERS
+
+
+buildActions : Pages.Build.Actions Msg
+buildActions =
+    Pages.Build.Actions ClickStep UpdateUrl
 
 
 buildUrl : String -> List String -> List QueryParameter -> String

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1141,7 +1141,7 @@ viewContent model =
     case model.page of
         Pages.Overview ->
             ( "Overview"
-            , lazy2 Pages.Home.view model.user ToggleFavorite
+            , lazy2 Pages.Home.view model.user homeMsgs
             )
 
         Pages.AddRepositories ->
@@ -1163,7 +1163,7 @@ viewContent model =
             ( String.join "/" [ org, repo ] ++ " hooks" ++ page
             , div []
                 [ Pager.view model.hooks.pager Pager.defaultLabels GotoPage
-                , lazy4 Pages.Hooks.view model org repo ClickHook
+                , lazy4 Pages.Hooks.view model org repo hooksMsgs
                 , Pager.view model.hooks.pager Pager.defaultLabels GotoPage
                 ]
             )
@@ -1818,6 +1818,13 @@ clickHook model org repo buildNumber =
         )
 
 
+{-| homeMsgs : prepares the input record required for the Home page to route Msgs back to Main.elm
+-}
+homeMsgs : Org -> Maybe Repo -> Msg
+homeMsgs =
+    ToggleFavorite
+
+
 {-| buildMsgs : prepares the input record required for the Build page to route Msgs back to Main.elm
 -}
 buildMsgs : Pages.Build.Msgs Msg
@@ -1830,6 +1837,13 @@ buildMsgs =
 addReposMsgs : Pages.AddRepos.Msgs Msg
 addReposMsgs =
     Pages.AddRepos.Msgs SearchSourceRepos EnableRepo EnableRepos ToggleFavorite
+
+
+{-| hooksMsgs : prepares the input record required for the Hooks page to route Msgs back to Main.elm
+-}
+hooksMsgs : Org -> Repo -> BuildNumber -> Msg
+hooksMsgs =
+    ClickHook
 
 
 {-| repoSettingsMsgs : prepares the input record required for the Settings page to route Msgs back to Main.elm

--- a/src/elm/Pages/AddRepos.elm
+++ b/src/elm/Pages/AddRepos.elm
@@ -4,7 +4,7 @@ Use of this source code is governed by the LICENSE file in this repository.
 --}
 
 
-module Pages.AddRepos exposing (Model, Msgs, view)
+module Pages.AddRepos exposing (Msgs, PartialModel, view)
 
 import Dict
 import Favorites
@@ -64,9 +64,9 @@ import Vela
 -- TYPES
 
 
-{-| Model : an abbreviated version of the main model
+{-| PartialModel : an abbreviated version of the main model
 -}
-type alias Model a =
+type alias PartialModel a =
     { a
         | user : WebData CurrentUser
         , sourceRepos : WebData SourceRepositories
@@ -90,7 +90,7 @@ type alias Msgs msg =
 
 {-| view : takes model and renders account page for adding repos to overview
 -}
-view : Model a -> Msgs msg -> Html msg
+view : PartialModel a -> Msgs msg -> Html msg
 view model actions =
     let
         ( sourceRepos, filters ) =
@@ -133,7 +133,7 @@ view model actions =
 
 {-| viewSourceRepos : takes model and source repos and renders them based on user search
 -}
-viewSourceRepos : Model a -> SourceRepositories -> Msgs msg -> Html msg
+viewSourceRepos : PartialModel a -> SourceRepositories -> Msgs msg -> Html msg
 viewSourceRepos model sourceRepos actions =
     let
         filters =
@@ -314,7 +314,7 @@ enableRepoButton repo enableRepo toggleFavorite favorited =
 
 {-| searchReposGlobal : takes source repositories and search filters and renders filtered repos
 -}
-searchReposGlobal : Model a -> SourceRepositories -> EnableRepo msg -> ToggleFavorite msg -> Html msg
+searchReposGlobal : PartialModel a -> SourceRepositories -> EnableRepo msg -> ToggleFavorite msg -> Html msg
 searchReposGlobal model repos enableRepo toggleFavorite =
     let
         ( user, filters ) =

--- a/src/elm/Pages/AddRepos.elm
+++ b/src/elm/Pages/AddRepos.elm
@@ -66,11 +66,10 @@ import Vela
 
 {-| PartialModel : an abbreviated version of the main model
 -}
-type alias PartialModel a =
-    { a
-        | user : WebData CurrentUser
-        , sourceRepos : WebData SourceRepositories
-        , filters : RepoSearchFilters
+type alias PartialModel =
+    { user : WebData CurrentUser
+    , sourceRepos : WebData SourceRepositories
+    , filters : RepoSearchFilters
     }
 
 
@@ -90,7 +89,7 @@ type alias Msgs msg =
 
 {-| view : takes model and renders account page for adding repos to overview
 -}
-view : PartialModel a -> Msgs msg -> Html msg
+view : PartialModel -> Msgs msg -> Html msg
 view model actions =
     let
         ( sourceRepos, filters ) =
@@ -133,7 +132,7 @@ view model actions =
 
 {-| viewSourceRepos : takes model and source repos and renders them based on user search
 -}
-viewSourceRepos : PartialModel a -> SourceRepositories -> Msgs msg -> Html msg
+viewSourceRepos : PartialModel -> SourceRepositories -> Msgs msg -> Html msg
 viewSourceRepos model sourceRepos actions =
     let
         filters =
@@ -314,7 +313,7 @@ enableRepoButton repo enableRepo toggleFavorite favorited =
 
 {-| searchReposGlobal : takes source repositories and search filters and renders filtered repos
 -}
-searchReposGlobal : PartialModel a -> SourceRepositories -> EnableRepo msg -> ToggleFavorite msg -> Html msg
+searchReposGlobal : PartialModel -> SourceRepositories -> EnableRepo msg -> ToggleFavorite msg -> Html msg
 searchReposGlobal model repos enableRepo toggleFavorite =
     let
         ( user, filters ) =

--- a/src/elm/Pages/Build.elm
+++ b/src/elm/Pages/Build.elm
@@ -5,7 +5,7 @@ Use of this source code is governed by the LICENSE file in this repository.
 
 
 module Pages.Build exposing
-    ( Actions
+    ( Msgs
     , clickLogLine
     , clickStep
     , statusToClass
@@ -96,9 +96,9 @@ type alias PartialModel a =
     }
 
 
-{-| Actions : record for routing msg updates to Main.elm
+{-| Msgs : record for routing msg updates to Main.elm
 -}
-type alias Actions msg =
+type alias Msgs msg =
     { expandAction : ExpandStep msg
     , logFocusAction : FocusLogs msg
     }
@@ -111,7 +111,7 @@ type alias Actions msg =
 
 {-| viewBuild : renders entire build based on current application time
 -}
-viewBuild : PartialModel a -> Org -> Repo -> Actions msg -> Html msg
+viewBuild : PartialModel a -> Org -> Repo -> Msgs msg -> Html msg
 viewBuild { time, build, steps, logs, shift } org repo { expandAction, logFocusAction } =
     let
         ( buildPreview, buildNumber ) =

--- a/src/elm/Pages/Hooks.elm
+++ b/src/elm/Pages/Hooks.elm
@@ -48,22 +48,32 @@ import Vela
         )
 
 
+{-| PartialModel : type alias for passing in the main model with partial fields
+-}
+type alias PartialModel a =
+    { a
+        | hooks : HooksModel
+        , hookBuilds : HookBuilds
+        , time : Posix
+    }
+
+
 
 -- VIEW
 
 
 {-| view : renders hooks
 -}
-view : HooksModel -> HookBuilds -> Posix -> String -> String -> (Org -> Repo -> BuildNumber -> msg) -> Html msg
-view hooksModel hookBuilds now org repo clickAction =
-    case hooksModel.hooks of
-        RemoteData.Success hooks ->
-            if List.length hooks == 0 then
+view : PartialModel a -> String -> String -> (Org -> Repo -> BuildNumber -> msg) -> Html msg
+view { hooks, hookBuilds, time } org repo clickAction =
+    case hooks.hooks of
+        RemoteData.Success hooks_ ->
+            if List.length hooks_ == 0 then
                 noHooks
 
             else
                 div [ class "hooks", Util.testAttribute "hooks" ] <|
-                    hooksTable now org repo hookBuilds hooks clickAction
+                    hooksTable time org repo hookBuilds hooks_ clickAction
 
         RemoteData.Loading ->
             Util.largeLoader

--- a/src/elm/Pages/Hooks.elm
+++ b/src/elm/Pages/Hooks.elm
@@ -50,11 +50,10 @@ import Vela
 
 {-| PartialModel : type alias for passing in the main model with partial fields
 -}
-type alias PartialModel a =
-    { a
-        | hooks : HooksModel
-        , hookBuilds : HookBuilds
-        , time : Posix
+type alias PartialModel =
+    { hooks : HooksModel
+    , hookBuilds : HookBuilds
+    , time : Posix
     }
 
 
@@ -64,7 +63,7 @@ type alias PartialModel a =
 
 {-| view : renders hooks
 -}
-view : PartialModel a -> String -> String -> (Org -> Repo -> BuildNumber -> msg) -> Html msg
+view : PartialModel -> String -> String -> (Org -> Repo -> BuildNumber -> msg) -> Html msg
 view { hooks, hookBuilds, time } org repo clickAction =
     case hooks.hooks of
         RemoteData.Success hooks_ ->


### PR DESCRIPTION
Added lazy rendering to all pages.
https://guide.elm-lang.org/optimization/lazy.html

When wrapped in Html.lazyN, Elm will check the input used for the last frame render and compare it to the input for the current frame render. If the input and function have not changed, then the virtual DOM doesnt need to be updated and Elm will ignore that frame.

Best when used at the root of the application where the model is parsed and used as view input, so I added it to the Pages controller.