### PR TITLE
fix(build): focus outline offset for svg

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -559,6 +559,15 @@ nav {
   position: relative;
 }
 
+.build-history .recent-build:focus,
+.build-history .recent-build:active  {
+  outline: none;
+  > svg {
+    outline: var(--color-secondary) dotted var(--line-width);
+    outline-offset: var(--line-width);
+  }
+}
+
 .recent-build.-current > svg {
   transform: translateX(5px);
 


### PR DESCRIPTION
fixing a bug where the method of moving the build history items to the right was not matching with the parent element's focus outline

