### PR TITLE
fix(history): removing sticky tooltip overlap

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -641,14 +641,22 @@ nav {
   visibility: hidden;
 }
 
-.recent-build:hover .recent-build-tooltip,
-.recent-build-link:focus + .recent-build-tooltip {
+.recent-build:hover .recent-build-tooltip {
+  visibility: visible;
+}
+
+.recent-build .recent-build-link:focus + .recent-build-tooltip {
   visibility: visible;
 }
 
 .recent-build:hover .recent-build-tooltip {
   z-index: 10000; // one more than .recent-build-tooltip z-index
 }
+
+.recent-build:hover ~ .recent-build .recent-build-link:focus + .recent-build-tooltip {
+  visibility: hidden;
+}
+
 
 .recent-build:hover .recent-build-tooltip::after,
 .recent-build-link:focus .recent-build-tooltip::after,

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -647,11 +647,12 @@ nav {
 }
 
 .recent-build:hover .recent-build-tooltip {
-  z-index: 99999;
+  z-index: 10000; // one more than .recent-build-tooltip z-index
 }
 
 .recent-build:hover .recent-build-tooltip::after,
-.recent-build-link:focus .recent-build-tooltip::after {
+.recent-build-link:focus .recent-build-tooltip::after,
+.recent-build-link:focus + .recent-build-tooltip::after {
   position: absolute;
   bottom: 100%;
 

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -646,8 +646,7 @@ nav {
 }
 
 .recent-build:hover .recent-build-tooltip::after,
-.recent-build-link:focus .recent-build-tooltip::after,
-.recent-build-link:focus + .recent-build-tooltip::after {
+.recent-build-link:focus .recent-build-tooltip::after {
   position: absolute;
   bottom: 100%;
 

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -645,19 +645,6 @@ nav {
   visibility: visible;
 }
 
-.recent-build .recent-build-link:focus + .recent-build-tooltip {
-  visibility: visible;
-}
-
-.recent-build:hover .recent-build-tooltip {
-  z-index: 10000; // one more than .recent-build-tooltip z-index
-}
-
-.recent-build:hover ~ .recent-build .recent-build-link:focus + .recent-build-tooltip {
-  visibility: hidden;
-}
-
-
 .recent-build:hover .recent-build-tooltip::after,
 .recent-build-link:focus .recent-build-tooltip::after,
 .recent-build-link:focus + .recent-build-tooltip::after {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -641,7 +641,8 @@ nav {
   visibility: hidden;
 }
 
-.recent-build:hover .recent-build-tooltip {
+.recent-build:hover .recent-build-tooltip,
+.recent-build:focus .recent-build-tooltip {
   visibility: visible;
 }
 

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -646,6 +646,10 @@ nav {
   visibility: visible;
 }
 
+.recent-build:hover .recent-build-tooltip {
+  z-index: 99999;
+}
+
 .recent-build:hover .recent-build-tooltip::after,
 .recent-build-link:focus .recent-build-tooltip::after {
   position: absolute;


### PR DESCRIPTION
fixes:
<img width="637" alt="Screen Shot 2020-02-13 at 12 40 11 PM" src="https://user-images.githubusercontent.com/48764154/74467139-23a30500-4e5e-11ea-9f42-3001c53c52fc.png">
<img width="515" alt="Screen Shot 2020-02-13 at 12 40 15 PM" src="https://user-images.githubusercontent.com/48764154/74467140-243b9b80-4e5e-11ea-8a78-5e777a015a44.png">
