### PR TITLE
fix(alerts): add override animation classes to config comments

### DIFF
--- a/src/elm/Alerts.elm
+++ b/src/elm/Alerts.elm
@@ -110,6 +110,8 @@ copyButton copyContent copy =
 
     config delays automatic dismissal x seconds and applies unique container and item styles
 
+    config applies animation overrides for pablen / toasty Elm package animations for bounceInRight and fadeOutRightBig
+
 -}
 config : Float -> Alerting.Config msg
 config timeoutSeconds =

--- a/src/elm/Alerts.elm
+++ b/src/elm/Alerts.elm
@@ -110,7 +110,7 @@ copyButton copyContent copy =
 
     config delays automatic dismissal x seconds and applies unique container and item styles
 
-    config applies animation overrides for pablen / toasty Elm package animations for bounceInRight and fadeOutRightBig
+    config applies animation overrides for pablen / toasty Elm package animations, bounceInRight and fadeOutRightBig
 
 -}
 config : Float -> Alerting.Config msg


### PR DESCRIPTION
adding bounceInRight and fadeOutRightBig to the comments will stop these override classes from being scrubbed by our production build minification process