### PR TITLE
feat: add repo comment event to settings page

### DIFF
--- a/cypress/fixtures/add_repo_response.json
+++ b/cypress/fixtures/add_repo_response.json
@@ -15,5 +15,6 @@
   "allow_pull": false,
   "allow_push": true,
   "allow_deploy": false,
-  "allow_tag": false
+  "allow_tag": false,
+  "allow_comment": false
 }

--- a/cypress/fixtures/repositories.json
+++ b/cypress/fixtures/repositories.json
@@ -16,7 +16,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 18,
@@ -35,7 +36,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 17,
@@ -54,7 +56,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 16,
@@ -73,6 +76,7 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   }
 ]

--- a/cypress/fixtures/repositories_100.json
+++ b/cypress/fixtures/repositories_100.json
@@ -16,7 +16,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 1,
@@ -35,7 +36,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 2,
@@ -54,7 +56,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 3,
@@ -73,7 +76,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 4,
@@ -92,7 +96,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 5,
@@ -111,7 +116,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 6,
@@ -130,7 +136,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 7,
@@ -149,7 +156,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 8,
@@ -168,7 +176,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 9,
@@ -187,7 +196,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 10,
@@ -206,7 +216,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 11,
@@ -225,7 +236,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 12,
@@ -244,7 +256,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 13,
@@ -263,7 +276,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 14,
@@ -282,7 +296,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 15,
@@ -301,7 +316,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 16,
@@ -320,7 +336,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 17,
@@ -339,7 +356,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 18,
@@ -358,7 +376,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 19,
@@ -377,7 +396,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 20,
@@ -396,7 +416,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 21,
@@ -415,7 +436,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 22,
@@ -434,7 +456,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 23,
@@ -453,7 +476,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 24,
@@ -472,7 +496,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 25,
@@ -491,7 +516,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 26,
@@ -510,7 +536,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 27,
@@ -529,7 +556,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 28,
@@ -548,7 +576,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 29,
@@ -567,7 +596,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 30,
@@ -586,7 +616,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 31,
@@ -605,7 +636,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 32,
@@ -624,7 +656,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 33,
@@ -643,7 +676,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 34,
@@ -662,7 +696,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 35,
@@ -681,7 +716,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 36,
@@ -700,7 +736,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 37,
@@ -719,7 +756,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 38,
@@ -738,7 +776,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 39,
@@ -757,7 +796,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 40,
@@ -776,7 +816,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 41,
@@ -795,7 +836,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 42,
@@ -814,7 +856,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 43,
@@ -833,7 +876,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 44,
@@ -852,7 +896,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 45,
@@ -871,7 +916,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 46,
@@ -890,7 +936,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 47,
@@ -909,7 +956,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 48,
@@ -928,7 +976,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 49,
@@ -947,7 +996,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 50,
@@ -966,7 +1016,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 51,
@@ -985,7 +1036,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 52,
@@ -1004,7 +1056,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 53,
@@ -1023,7 +1076,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 54,
@@ -1042,7 +1096,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 55,
@@ -1061,7 +1116,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 56,
@@ -1080,7 +1136,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 57,
@@ -1099,7 +1156,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 58,
@@ -1118,7 +1176,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 59,
@@ -1137,7 +1196,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 60,
@@ -1156,7 +1216,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 61,
@@ -1175,7 +1236,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 62,
@@ -1194,7 +1256,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 63,
@@ -1213,7 +1276,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 64,
@@ -1232,7 +1296,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 65,
@@ -1251,7 +1316,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 66,
@@ -1270,7 +1336,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 67,
@@ -1289,7 +1356,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 68,
@@ -1308,7 +1376,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 69,
@@ -1327,7 +1396,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 70,
@@ -1346,7 +1416,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 71,
@@ -1365,7 +1436,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 72,
@@ -1384,7 +1456,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 73,
@@ -1403,7 +1476,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 74,
@@ -1422,7 +1496,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 75,
@@ -1441,7 +1516,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 76,
@@ -1460,7 +1536,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 77,
@@ -1479,7 +1556,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 78,
@@ -1498,7 +1576,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 79,
@@ -1517,7 +1596,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 80,
@@ -1536,7 +1616,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 81,
@@ -1555,7 +1636,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 82,
@@ -1574,7 +1656,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 83,
@@ -1593,7 +1676,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 84,
@@ -1612,7 +1696,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 85,
@@ -1631,7 +1716,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 86,
@@ -1650,7 +1736,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 87,
@@ -1669,7 +1756,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 88,
@@ -1688,7 +1776,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 89,
@@ -1707,7 +1796,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 90,
@@ -1726,7 +1816,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 91,
@@ -1745,7 +1836,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 92,
@@ -1764,7 +1856,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 93,
@@ -1783,7 +1876,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 94,
@@ -1802,7 +1896,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 95,
@@ -1821,7 +1916,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 96,
@@ -1840,7 +1936,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 97,
@@ -1859,7 +1956,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 98,
@@ -1878,7 +1976,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 99,
@@ -1897,6 +1996,7 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   }
 ]

--- a/cypress/fixtures/repositories_5.json
+++ b/cypress/fixtures/repositories_5.json
@@ -16,7 +16,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 102,
@@ -35,7 +36,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 103,
@@ -54,7 +56,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 104,
@@ -73,7 +76,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   },
   {
     "id": 105,
@@ -92,6 +96,7 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_comment": false
   }
 ]

--- a/cypress/fixtures/repository.json
+++ b/cypress/fixtures/repository.json
@@ -15,5 +15,6 @@
   "allow_pull": true,
   "allow_push": true,
   "allow_deploy": false,
-  "allow_tag": false
+  "allow_tag": false,
+  "allow_comment": false
 }

--- a/cypress/fixtures/repository_updated.json
+++ b/cypress/fixtures/repository_updated.json
@@ -15,5 +15,6 @@
   "allow_pull": false,
   "allow_push": false,
   "allow_deploy": true,
-  "allow_tag": true
+  "allow_tag": true,
+  "allow_comment": true
 }

--- a/cypress/fixtures/source_repos.json
+++ b/cypress/fixtures/source_repos.json
@@ -17,7 +17,8 @@
       "allow_pull": false,
       "allow_push": true,
       "allow_deploy": false,
-      "allow_tag": false
+      "allow_tag": false,
+      "allow_comment": false
     },
     {
       "id": 22,
@@ -36,7 +37,8 @@
       "allow_pull": false,
       "allow_push": true,
       "allow_deploy": false,
-      "allow_tag": false
+      "allow_tag": false,
+      "allow_comment": false
     },
     {
       "id": 21,
@@ -55,7 +57,8 @@
       "allow_pull": false,
       "allow_push": true,
       "allow_deploy": false,
-      "allow_tag": false
+      "allow_tag": false,
+      "allow_comment": false
     },
     {
       "id": 20,
@@ -74,7 +77,8 @@
       "allow_pull": false,
       "allow_push": true,
       "allow_deploy": false,
-      "allow_tag": false
+      "allow_tag": false,
+      "allow_comment": false
     }
   ],
   "DavidVader": [
@@ -95,7 +99,8 @@
       "allow_pull": false,
       "allow_push": true,
       "allow_deploy": false,
-      "allow_tag": false
+      "allow_tag": false,
+      "allow_comment": false
     }
   ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       VELA_PORT: ':8080'
       VELA_SECRET: zB7mrKDTZqNeNTD8z47yG4DHywspAh
       VELA_SOURCE_DRIVER: github
-      VELA_SOURCE_URL: https://github.com/
+      VELA_SOURCE_URL: https://git.target.com/
       VELA_SECRET_VAULT: 'true'
       VELA_SECRET_VAULT_ADDR: http://vault:8200
       VELA_SECRET_VAULT_TOKEN: vela

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       VELA_PORT: ':8080'
       VELA_SECRET: zB7mrKDTZqNeNTD8z47yG4DHywspAh
       VELA_SOURCE_DRIVER: github
-      VELA_SOURCE_URL: https://git.target.com/
+      VELA_SOURCE_URL: https://github.com/
       VELA_SECRET_VAULT: 'true'
       VELA_SECRET_VAULT_ADDR: http://vault:8200
       VELA_SECRET_VAULT_TOKEN: vela

--- a/src/elm/Pages/RepoSettings.elm
+++ b/src/elm/Pages/RepoSettings.elm
@@ -286,6 +286,11 @@ events repo msg =
                 repo.allow_tag
               <|
                 msg repo.org repo.name "allow_tag"
+            , checkbox "Comment"
+                "allow_comment"
+                repo.allow_comment
+              <|
+                msg repo.org repo.name "allow_comment"
             ]
         ]
 
@@ -584,6 +589,7 @@ validEventsUpdate originalRepo repoUpdate =
                 || Maybe.withDefault repo.allow_pull repoUpdate.allow_pull
                 || Maybe.withDefault repo.allow_deploy repoUpdate.allow_deploy
                 || Maybe.withDefault repo.allow_tag repoUpdate.allow_tag
+                || Maybe.withDefault repo.allow_comment repoUpdate.allow_comment
 
         _ ->
             False
@@ -630,6 +636,9 @@ msgPrefix field =
         "allow_tag" ->
             "Tag events for $ "
 
+        "allow_comment" ->
+            "Comment events for $ "    
+
         "timeout" ->
             "Build timeout for $ "
 
@@ -660,8 +669,8 @@ msgSuffix field repo =
         "allow_deploy" ->
             toggleText "allow_deploy" repo.allow_deploy
 
-        "allow_tag" ->
-            toggleText "allow_tag" repo.allow_tag
+        "allow_comment" ->
+            toggleText "allow_comment" repo.allow_comment
 
         "timeout" ->
             "set to " ++ String.fromInt repo.timeout ++ " minute(s)."

--- a/src/elm/Pages/RepoSettings.elm
+++ b/src/elm/Pages/RepoSettings.elm
@@ -637,7 +637,7 @@ msgPrefix field =
             "Tag events for $ "
 
         "allow_comment" ->
-            "Comment events for $ "    
+            "Comment events for $ "
 
         "timeout" ->
             "Build timeout for $ "

--- a/src/elm/Pages/RepoSettings.elm
+++ b/src/elm/Pages/RepoSettings.elm
@@ -276,11 +276,6 @@ events repo msg =
                 repo.allow_pull
               <|
                 msg repo.org repo.name "allow_pull"
-            , checkbox "Deploy"
-                "allow_deploy"
-                repo.allow_deploy
-              <|
-                msg repo.org repo.name "allow_deploy"
             , checkbox "Tag"
                 "allow_tag"
                 repo.allow_tag
@@ -291,6 +286,11 @@ events repo msg =
                 repo.allow_comment
               <|
                 msg repo.org repo.name "allow_comment"
+            , checkbox "Deploy"
+                "allow_deploy"
+                repo.allow_deploy
+              <|
+                msg repo.org repo.name "allow_deploy"
             ]
         ]
 

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -296,6 +296,7 @@ type alias Repository =
     , allow_push : Bool
     , allow_deploy : Bool
     , allow_tag : Bool
+    , allow_comment : Bool
     , enabled : Enabled
     , enabling : Enabling
     }
@@ -316,7 +317,7 @@ type Enabling
 
 defaultRepository : Repository
 defaultRepository =
-    Repository -1 -1 "" "" "" "" "" "" 0 "" False False False False False False False NotAsked NotAsked_
+    Repository -1 -1 "" "" "" "" "" "" 0 "" False False False False False False False False NotAsked NotAsked_
 
 
 decodeRepository : Decoder Repository
@@ -339,6 +340,7 @@ decodeRepository =
         |> optional "allow_push" bool False
         |> optional "allow_deploy" bool False
         |> optional "allow_tag" bool False
+        |> optional "allow_comment" bool False
         -- "enabled"
         |> optional "active" enabledDecoder NotAsked
         -- "enabling"
@@ -418,6 +420,7 @@ encodeEnableRepository repo =
         , ( "allow_push", Encode.bool <| repo.allow_push )
         , ( "allow_deploy", Encode.bool <| repo.allow_deploy )
         , ( "allow_tag", Encode.bool <| repo.allow_tag )
+        , ( "allow_comment", Encode.bool <| repo.allow_comment )
         ]
 
 
@@ -434,12 +437,13 @@ type alias EnableRepositoryPayload =
     , allow_push : Bool
     , allow_deploy : Bool
     , allow_tag : Bool
+    , allow_comment : Bool
     }
 
 
 defaultEnableRepositoryPayload : EnableRepositoryPayload
 defaultEnableRepositoryPayload =
-    EnableRepositoryPayload "" "" "" "" "" False True True True True False False
+    EnableRepositoryPayload "" "" "" "" "" False True True True True False False False
 
 
 type alias UpdateRepositoryPayload =
@@ -450,6 +454,7 @@ type alias UpdateRepositoryPayload =
     , allow_push : Maybe Bool
     , allow_deploy : Maybe Bool
     , allow_tag : Maybe Bool
+    , allow_comment : Maybe Bool
     , visibility : Maybe String
     , timeout : Maybe Int
     }
@@ -461,7 +466,7 @@ type alias Field =
 
 defaultUpdateRepositoryPayload : UpdateRepositoryPayload
 defaultUpdateRepositoryPayload =
-    UpdateRepositoryPayload Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+    UpdateRepositoryPayload Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 
 encodeUpdateRepository : UpdateRepositoryPayload -> Encode.Value
@@ -474,6 +479,7 @@ encodeUpdateRepository repo =
         , ( "allow_push", encodeOptional Encode.bool repo.allow_push )
         , ( "allow_deploy", encodeOptional Encode.bool repo.allow_deploy )
         , ( "allow_tag", encodeOptional Encode.bool repo.allow_tag )
+        , ( "allow_comment", encodeOptional Encode.bool repo.allow_comment )
         , ( "visibility", encodeOptional Encode.string repo.visibility )
         , ( "timeout", encodeOptional Encode.int repo.timeout )
         ]
@@ -522,6 +528,9 @@ buildUpdateRepoBoolPayload field value =
 
         "allow_tag" ->
             { defaultUpdateRepositoryPayload | allow_tag = Just value }
+
+        "allow_comment" ->
+            { defaultUpdateRepositoryPayload | allow_comment = Just value }            
 
         _ ->
             defaultUpdateRepositoryPayload

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -530,7 +530,7 @@ buildUpdateRepoBoolPayload field value =
             { defaultUpdateRepositoryPayload | allow_tag = Just value }
 
         "allow_comment" ->
-            { defaultUpdateRepositoryPayload | allow_comment = Just value }            
+            { defaultUpdateRepositoryPayload | allow_comment = Just value }
 
         _ ->
             defaultUpdateRepositoryPayload


### PR DESCRIPTION
Added the new ruleset `comment` functionality into the repo settings page.

This will allow a user to enable comment events on the repository so they can write `steps:` that utilize the new ruleset functionality.

<img width="468" alt="Screen Shot 2020-04-09 at 3 01 07 PM" src="https://user-images.githubusercontent.com/12552518/78937827-bfc04580-7a76-11ea-8863-8e2cadb6e5af.png">
