### PR TITLE
fix(nginx): correct pathing for location

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -20,7 +20,7 @@ server {
     }
 
     # proxy to backend server to allow using CLI w/ UI url
-    location ~ ^/(login|authenticate|api/v[0-9]+)/ {
+    location ~ ^/(login|authenticate|api/v[0-9]+/) {
         proxy_pass $VELA_API;
 
         recursive_error_pages on;

--- a/nginx/local.conf
+++ b/nginx/local.conf
@@ -18,7 +18,7 @@ server {
     }
 
     # proxy to backend server to allow using CLI w/ UI url
-    location ~ ^/(login|authenticate|api/v[0-9]+)/ {
+    location ~ ^/(login|authenticate|api/v[0-9]+/) {
         proxy_pass http://server:8080;
 
         recursive_error_pages on;


### PR DESCRIPTION
this fixes issue with CLI not able to login due to trailing `/` in location, for example