### PR TITLE
enhancement(secrets): add comment event

### DIFF
--- a/src/elm/Pages/Secrets/Form.elm
+++ b/src/elm/Pages/Secrets/Form.elm
@@ -180,12 +180,12 @@ viewEventsSelect secretUpdate =
                 "comment"
                 (eventEnabled "comment" secretUpdate.events)
               <|
-                OnChangeEvent "comment"                
+                OnChangeEvent "comment"
             , checkbox "Deploy"
                 "deployment"
                 (eventEnabled "deployment" secretUpdate.events)
               <|
-                OnChangeEvent "deployment"                
+                OnChangeEvent "deployment"
             ]
         ]
 

--- a/src/elm/Pages/Secrets/Form.elm
+++ b/src/elm/Pages/Secrets/Form.elm
@@ -171,16 +171,21 @@ viewEventsSelect secretUpdate =
                 (eventEnabled "pull_request" secretUpdate.events)
               <|
                 OnChangeEvent "pull_request"
-            , checkbox "Deploy"
-                "deployment"
-                (eventEnabled "deployment" secretUpdate.events)
-              <|
-                OnChangeEvent "deployment"
             , checkbox "Tag"
                 "tag"
                 (eventEnabled "tag" secretUpdate.events)
               <|
                 OnChangeEvent "tag"
+            , checkbox "Comment"
+                "comment"
+                (eventEnabled "comment" secretUpdate.events)
+              <|
+                OnChangeEvent "comment"                
+            , checkbox "Deploy"
+                "deployment"
+                (eventEnabled "deployment" secretUpdate.events)
+              <|
+                OnChangeEvent "deployment"                
             ]
         ]
 

--- a/src/elm/Pages/Secrets/Form.elm
+++ b/src/elm/Pages/Secrets/Form.elm
@@ -181,7 +181,7 @@ viewEventsSelect secretUpdate =
                 (eventEnabled "comment" secretUpdate.events)
               <|
                 OnChangeEvent "comment"
-            , checkbox "Deploy"
+            , checkbox "Deployment"
                 "deployment"
                 (eventEnabled "deployment" secretUpdate.events)
               <|


### PR DESCRIPTION
Adding the comment event so people can scope their secrets to the comments functionality added in `v0.4.0`
https://go-vela.github.io/docs/usage/pipeline/steps/ruleset/#comment