### PR TITLE
fix(help): --step in help window should be --step-number

### DIFF
--- a/src/elm/Help/Commands.elm
+++ b/src/elm/Help/Commands.elm
@@ -243,7 +243,7 @@ listSteps org repo buildNumber =
 {-| viewStep : returns cli command for viewing a step
 
     eg.
-    vela view step --org octocat --repo hello-world --build 14 --step 1
+    vela view step --org octocat --repo hello-world --build 14 --step-number 1
 
 -}
 viewStep : Org -> Repo -> BuildNumber -> Command
@@ -253,7 +253,7 @@ viewStep org repo buildNumber =
             "View Step"
 
         content =
-            Just <| "vela view step " ++ buildArgs org repo buildNumber ++ " --step 1"
+            Just <| "vela view step " ++ buildArgs org repo buildNumber ++ " --step-number 1"
 
         docs =
             Just "steps/get"


### PR DESCRIPTION
Ran into an issue copying and pasting the command `vela view step --org foo --repo bar --build x --step x`

Changed to be step-number. Let me know if I missed something :D 