### PR TITLE
Fix typo in Builds.elm

### DIFF
--- a/src/elm/Pages/Builds.elm
+++ b/src/elm/Pages/Builds.elm
@@ -43,7 +43,7 @@ view buildsModel now org repo maybeEvent =
             case maybeEvent of
                 Nothing ->
                     div []
-                        [ h1 [] [ text "Your respository has been added!" ]
+                        [ h1 [] [ text "Your repository has been added!" ]
                         , p [] [ text "Builds will show up here once you have:" ]
                         , ol [ class "list" ]
                             [ li []


### PR DESCRIPTION
## Description

I noticed this typo after I added a new repository today.

My guess is the word `repository` was intended instead of `respository`.

