### PR TITLE
fix(message): move msg next to build number

### DIFF
--- a/cypress/integration/build.spec.js
+++ b/cypress/integration/build.spec.js
@@ -173,11 +173,11 @@ context('Build', () => {
       });
 
       it('build should display commit message', () => {
-        cy.get('@build').find('.message').should('be.visible');
+        cy.get('@build').find('.commit-msg').should('be.visible');
       });
       it('longer build commit message should be truncated with ellipsis', () => {
         cy.get('@build')
-          .find('.message')
+          .find('.commit-msg')
           .should('have.css', 'text-overflow', 'ellipsis');
       });
     });

--- a/cypress/integration/builds.spec.js
+++ b/cypress/integration/builds.spec.js
@@ -49,12 +49,12 @@ context('Builds', () => {
     });
 
     it('builds should display commit message', () => {
-      cy.get('@builds').find('.message').should('be.visible');
+      cy.get('@builds').find('.commit-msg').should('be.visible');
     });
 
     it('longer build commit message should be truncated with ellipsis', () => {
       cy.get('@builds')
-        .find('.message')
+        .find('.commit-msg')
         .should('have.css', 'text-overflow', 'ellipsis');
     });
 
@@ -85,11 +85,11 @@ context('Builds', () => {
     });
 
     it('builds should display commit message', () => {
-      cy.get('@builds').find('.message').should('be.visible');
+      cy.get('@builds').find('.commit-msg').should('be.visible');
     });
     it('longer build commit message should be truncated with ellipsis', () => {
       cy.get('@builds')
-        .find('.message')
+        .find('.commit-msg')
         .should('have.css', 'text-overflow', 'ellipsis');
     });
 
@@ -131,16 +131,16 @@ context('Builds', () => {
     });
 
     it('build should display commit message', () => {
-      cy.get('@firstBuild').find('.message').should('be.visible');
-      cy.get('@lastBuild').find('.message').should('be.visible');
+      cy.get('@firstBuild').find('.commit-msg').should('be.visible');
+      cy.get('@lastBuild').find('.commit-msg').should('be.visible');
     });
 
     it('longer build commit message should be truncated with ellipsis', () => {
       cy.get('@firstBuild')
-        .find('.message')
+        .find('.commit-msg')
         .should('have.css', 'text-overflow', 'ellipsis');
       cy.get('@lastBuild')
-        .find('.message')
+        .find('.commit-msg')
         .should('have.css', 'text-overflow', 'ellipsis');
     });
 

--- a/src/elm/Pages/Build.elm
+++ b/src/elm/Pages/Build.elm
@@ -168,7 +168,7 @@ viewPreview now org repo build =
             [ text build.sender ]
 
         message =
-            [ text build.message ]
+            [ text <| "- " ++ build.message ]
 
         id =
             [ a
@@ -190,8 +190,9 @@ viewPreview now org repo build =
         markdown =
             [ div [ class "status", Util.testAttribute "build-status", statusClass ] status
             , div [ class "info" ]
-                [ div [ class "row" ]
+                [ div [ class "row -left" ]
                     [ div [ class "id" ] id
+                    , div [ class "commit-msg" ] [ strong [] message ]
                     ]
                 , div [ class "row" ]
                     [ div [ class "git-info" ]
@@ -206,11 +207,6 @@ viewPreview now org repo build =
                         , span [ class "delimiter" ] [ text "/" ]
                         , div [ class "duration" ] duration
                         ]
-                    ]
-                , div [ class "row" ]
-                    [ strong
-                        [ class "message" ]
-                        message
                     ]
                 , viewError build
                 ]

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -403,6 +403,8 @@ nav {
   flex-direction: column;
   justify-content: center;
 
+  min-width: 0;
+
   padding: 12px 0;
 
   background: var(--color-bg-dark);
@@ -413,6 +415,10 @@ nav {
   flex-direction: row;
   justify-content: space-between;
   padding: 0 24px;
+
+  &.-left {
+    justify-content: flex-start;
+  }
 }
 
 .build .error {
@@ -442,12 +448,12 @@ nav {
   margin: 0 8px 0 8px;
 }
 
-.row .message {
-  font-size: 1rem;
-  width: 60%;
-  white-space: nowrap;
-  overflow: hidden;
+.commit-msg {
+  flex-basis: 80%;
   text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  margin-left: 6px;
 }
 
 .time-info {


### PR DESCRIPTION
Moving commit message next to build number due to element stretching with error message. This keeps the element compact and consistent. Old version also had an issue with time info disappearing for long commit messages. Evidence below taking from Cypress tests for the element in an error state.

![comparison](https://user-images.githubusercontent.com/1301201/90104040-2bf2d480-dd09-11ea-8ddd-35fca7028b57.png)
