### PR TITLE
enhance(overview): make entire repos on Overview clickable

### DIFF
--- a/cypress/integration/favorites.spec.js
+++ b/cypress/integration/favorites.spec.js
@@ -186,7 +186,7 @@ context('Favorites', () => {
               cy.route('PUT', '*api/v1/user*', 'fixture:favorites.json');
               cy.get('[data-test=star-toggle-cat-purr]').as('togglePurr');
               cy.get('@togglePurr').click();
-              cy.get('[data-test=star-toggle-cat-purr]').should(
+              cy.get('a > [data-test=star-toggle-cat-purr]').should(
                 'not.be.visible',
               );
             });

--- a/cypress/integration/overview.spec.js
+++ b/cypress/integration/overview.spec.js
@@ -39,11 +39,11 @@ context('Overview/Repositories Page', () => {
     });
 
     it('View button should exist for all repos', () => {
-      cy.get('[data-test=repo-view]').should('have.length', 3);
+      cy.get('[data-test=repo-item]').should('have.length', 3);
     });
 
     it('it should take you to the repo build page when utilizing the View button', () => {
-      cy.get('[data-test=repo-view]').first().click();
+      cy.get('[data-test=repo-item]').first().click();
       cy.location('pathname').should('eq', '/github/octocat');
     });
     it('org should show', () => {

--- a/src/elm/Pages/AddRepos.elm
+++ b/src/elm/Pages/AddRepos.elm
@@ -201,7 +201,7 @@ viewSourceRepo user enableRepo toggleFavorite repo =
         favorited =
             isFavorited user <| repo.org ++ "/" ++ repo.name
     in
-    div [ class "item", Util.testAttribute <| "source-repo-" ++ repo.name ]
+    div [ class "item", class "padding-1", Util.testAttribute <| "source-repo-" ++ repo.name ]
         [ div [] [ text repo.name ]
         , enableRepoButton repo enableRepo toggleFavorite favorited
         ]
@@ -211,7 +211,7 @@ viewSourceRepo user enableRepo toggleFavorite repo =
 -}
 viewSearchedSourceRepo : EnableRepo msg -> ToggleFavorite msg -> Repository -> Bool -> Html msg
 viewSearchedSourceRepo enableRepo toggleFavorite repo favorited =
-    div [ class "item", Util.testAttribute <| "source-repo-" ++ repo.name ]
+    div [ class "item", class "padding-1", Util.testAttribute <| "source-repo-" ++ repo.name ]
         [ div []
             [ text <| repo.org ++ "/" ++ repo.name ]
         , enableRepoButton repo enableRepo toggleFavorite favorited
@@ -326,7 +326,7 @@ searchReposGlobal model repos enableRepo toggleFavorite =
 
         else
             -- No repos matched the search
-            [ div [ class "item" ] [ text "No results" ] ]
+            [ div [ class "item", class "padding-1" ] [ text "No results" ] ]
 
 
 {-| searchReposLocal : takes repo search filters, the org, and repos and renders a list of repos based on user-entered text
@@ -344,5 +344,5 @@ searchReposLocal user org filters repos enableRepo toggleFavorite =
         List.map (viewSourceRepo user enableRepo toggleFavorite) filteredRepos
 
       else
-        [ div [ class "item" ] [ text "No results" ] ]
+        [ div [ class "item", class "padding-1" ] [ text "No results" ] ]
     )

--- a/src/elm/Pages/Home.elm
+++ b/src/elm/Pages/Home.elm
@@ -187,12 +187,16 @@ viewFavorite favorites toggleFavorite filtered favorite =
             else
                 repo
     in
-    a
+    div
         [ class "item"
         , Util.testAttribute "repo-item"
-        , Routes.href <| Routes.RepositoryBuilds org repo Nothing Nothing Nothing
         ]
-        [ div [] [ text name ]
+        [ a
+            [ class "view-favorite"
+            , Routes.href <| Routes.RepositoryBuilds org repo Nothing Nothing Nothing
+            ]
+            [ text name
+            ]
         , div [ class "buttons" ]
             [ starToggle org repo toggleFavorite <| List.member favorite favorites
             , a

--- a/src/elm/Pages/Home.elm
+++ b/src/elm/Pages/Home.elm
@@ -190,7 +190,6 @@ viewFavorite favorites toggleFavorite filtered favorite =
     a
         [ class "item"
         , Util.testAttribute "repo-item"
-        , Util.testAttribute "repo-view"
         , Routes.href <| Routes.RepositoryBuilds org repo Nothing Nothing Nothing
         ]
         [ div [] [ text name ]

--- a/src/elm/Pages/Home.elm
+++ b/src/elm/Pages/Home.elm
@@ -193,31 +193,12 @@ viewFavorite favorites toggleFavorite filtered favorite =
         ]
         [ a
             [ class "view-favorite"
+            , class "padding-1"
             , Routes.href <| Routes.RepositoryBuilds org repo Nothing Nothing Nothing
             ]
             [ text name
             ]
-        , div [ class "buttons" ]
+        , div [ class "buttons", class "padding-1" ]
             [ starToggle org repo toggleFavorite <| List.member favorite favorites
-            , a
-                [ class "button"
-                , class "-outline"
-                , Routes.href <| Routes.RepoSettings org repo
-                ]
-                [ text "Settings" ]
-            , a
-                [ class "button"
-                , class "-outline"
-                , Util.testAttribute "repo-hooks"
-                , Routes.href <| Routes.Hooks org repo Nothing Nothing
-                ]
-                [ text "Hooks" ]
-            , a
-                [ class "button"
-                , class "-outline"
-                , Util.testAttribute "repo-secrets"
-                , Routes.href <| Routes.RepoSecrets "native" org repo Nothing Nothing
-                ]
-                [ text "Secrets" ]
             ]
         ]

--- a/src/elm/Pages/Home.elm
+++ b/src/elm/Pages/Home.elm
@@ -187,7 +187,12 @@ viewFavorite favorites toggleFavorite filtered favorite =
             else
                 repo
     in
-    div [ class "item", Util.testAttribute "repo-item" ]
+    a
+        [ class "item"
+        , Util.testAttribute "repo-item"
+        , Util.testAttribute "repo-view"
+        , Routes.href <| Routes.RepositoryBuilds org repo Nothing Nothing Nothing
+        ]
         [ div [] [ text name ]
         , div [ class "buttons" ]
             [ starToggle org repo toggleFavorite <| List.member favorite favorites
@@ -211,11 +216,5 @@ viewFavorite favorites toggleFavorite filtered favorite =
                 , Routes.href <| Routes.RepoSecrets "native" org repo Nothing Nothing
                 ]
                 [ text "Secrets" ]
-            , a
-                [ class "button"
-                , Util.testAttribute "repo-view"
-                , Routes.href <| Routes.RepositoryBuilds org repo Nothing Nothing Nothing
-                ]
-                [ text "View" ]
             ]
         ]

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -217,12 +217,9 @@ nav {
 }
 
 .view-favorite {
-  padding: 1rem;
   flex: 1;
-}
-
-.item .buttons {
-  padding: 1rem;
+  text-decoration: none;
+  color: var(--color-text);
 }
 
 .actions-divider {
@@ -1341,4 +1338,8 @@ nav {
 
 .overflow-auto {
   overflow: auto;
+}
+
+.padding-1 {
+  padding: 1rem;
 }

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -211,10 +211,18 @@ nav {
   align-items: center;
   justify-content: space-between;
   margin: 0.5rem 0 0 0;
-  padding: 1rem;
   text-decoration: none;
   color: var(--color-text);
   background-color: var(--color-bg-dark);
+}
+
+.view-favorite {
+  padding: 1rem;
+  flex: 1;
+}
+
+.item .buttons {
+  padding: 1rem;
 }
 
 .actions-divider {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -212,7 +212,8 @@ nav {
   justify-content: space-between;
   margin: 0.5rem 0 0 0;
   padding: 1rem;
-
+  text-decoration: none;
+  color: var(--color-text);
   background-color: var(--color-bg-dark);
 }
 


### PR DESCRIPTION
Move the "View" repo functionality on Overview from a button to the entire repo item/row