### PR TITLE
changed crumb structure for secrets, removed org links and changed re…

### DIFF
--- a/src/elm/Crumbs.elm
+++ b/src/elm/Crumbs.elm
@@ -122,13 +122,8 @@ toPath page =
                     in
                     [ overviewPage, organizationPage, repoBuilds, repoSettings ]
 
-                Pages.OrgSecrets engine org maybePage _ ->
+                Pages.OrgSecrets _ org maybePage _ ->
                     let
-                        engineCrumb =
-                            ( engine, Nothing )
-
-                        typeCrumb =
-                            ( "org", Nothing )
 
                         pageNumber =
                             pageToString maybePage
@@ -136,37 +131,27 @@ toPath page =
                         orgSecrets =
                             ( org ++ pageNumber, Nothing )
                     in
-                    [ overviewPage, secrets, engineCrumb, typeCrumb, orgSecrets ]
+                    [ overviewPage, orgSecrets, ("Org Secrets", Nothing) ]
 
-                Pages.RepoSecrets engine org repo maybePage _ ->
+                Pages.RepoSecrets _ org repo maybePage _ ->
                     let
-                        engineCrumb =
-                            ( engine, Nothing )
-
-                        typeCrumb =
-                            ( "repo", Nothing )
 
                         orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                            ( org, Nothing)
 
                         pageNumber =
                             pageToString maybePage
 
-                        repoSecrets =
-                            ( repo ++ pageNumber, Nothing )
+                        repoBuilds =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
                     in
-                    [ overviewPage, secrets, engineCrumb, typeCrumb, orgSecrets, repoSecrets ]
+                    [ overviewPage, orgSecrets, repoBuilds, ("Repo Secrets", Nothing) ]
 
-                Pages.SharedSecrets engine org team maybePage _ ->
+                Pages.SharedSecrets _ org team maybePage _ ->
                     let
-                        engineCrumb =
-                            ( engine, Nothing )
-
-                        typeCrumb =
-                            ( "shared", Nothing )
-
                         orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                            ( org,  Nothing )
 
                         pageNumber =
                             pageToString maybePage
@@ -174,115 +159,85 @@ toPath page =
                         teamSecrets =
                             ( team ++ pageNumber, Nothing )
                     in
-                    [ overviewPage, secrets, engineCrumb, typeCrumb, orgSecrets, teamSecrets ]
+                    [ overviewPage, orgSecrets, teamSecrets, ( "Shared Secrets", Nothing) ]
 
-                Pages.AddOrgSecret engine org ->
+                Pages.AddOrgSecret _ org ->
                     let
-                        engineCrumb =
-                            ( engine, Nothing )
-
-                        typeCrumb =
-                            ( "org", Nothing )
 
                         orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                            ( org, Nothing )
 
                         add =
-                            ( "Add", Nothing )
+                            ( "Add Org Secret", Nothing )
                     in
-                    [ overviewPage, secrets, engineCrumb, typeCrumb, orgSecrets, add ]
+                    [ overviewPage, orgSecrets, add ]
 
-                Pages.AddRepoSecret engine org repo ->
+                Pages.AddRepoSecret _ org repo ->
                     let
-                        engineCrumb =
-                            ( engine, Nothing )
-
-                        typeCrumb =
-                            ( "repo", Nothing )
 
                         orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                            ( org, Nothing )
 
-                        repoSecrets =
-                            ( repo, Just <| Pages.RepoSecrets engine org repo Nothing Nothing )
+                        repoBuilds =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
 
                         add =
-                            ( "Add", Nothing )
+                            ( "Add Repo Secret", Nothing )
                     in
-                    [ overviewPage, secrets, engineCrumb, typeCrumb, orgSecrets, repoSecrets, add ]
+                    [ overviewPage, orgSecrets, repoBuilds, add ]
 
-                Pages.AddSharedSecret engine org team ->
+                Pages.AddSharedSecret _ org team ->
                     let
-                        engineCrumb =
-                            ( engine, Nothing )
-
-                        typeCrumb =
-                            ( "shared", Nothing )
-
                         orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                            ( org, Nothing )
 
                         sharedSecrets =
-                            ( team, Just <| Pages.SharedSecrets engine org team Nothing Nothing )
+                            ( team, Nothing )
 
                         add =
-                            ( "Add", Nothing )
+                            ( "Add Shared Secret", Nothing )
                     in
-                    [ overviewPage, secrets, engineCrumb, typeCrumb, orgSecrets, sharedSecrets, add ]
+                    [ overviewPage, orgSecrets, sharedSecrets, add ]
 
-                Pages.OrgSecret engine org name ->
+                Pages.OrgSecret _ org name ->
                     let
-                        engineCrumb =
-                            ( engine, Nothing )
-
-                        typeCrumb =
-                            ( "org", Nothing )
-
                         orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                            ( org, Nothing )
 
                         nameCrumb =
                             ( Maybe.withDefault name <| percentDecode name, Nothing )
                     in
-                    [ overviewPage, secrets, engineCrumb, typeCrumb, orgSecrets, nameCrumb ]
+                    [ overviewPage, orgSecrets, ("View Org Secret", Nothing), nameCrumb ]
 
-                Pages.RepoSecret engine org repo name ->
+                Pages.RepoSecret _ org repo name ->
                     let
-                        engineCrumb =
-                            ( engine, Nothing )
-
-                        typeCrumb =
-                            ( "repo", Nothing )
 
                         orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                            ( org, Nothing )
 
-                        repoSecrets =
-                            ( repo, Just <| Pages.RepoSecrets engine org repo Nothing Nothing )
+                        repoBuilds =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
+
 
                         nameCrumb =
                             ( Maybe.withDefault name <| percentDecode name, Nothing )
                     in
-                    [ overviewPage, secrets, engineCrumb, typeCrumb, orgSecrets, repoSecrets, nameCrumb ]
+                    [ overviewPage, orgSecrets, repoBuilds, ("View Repo Secret", Nothing), nameCrumb ]
 
-                Pages.SharedSecret engine org team name ->
+                Pages.SharedSecret _ org team name ->
                     let
-                        engineCrumb =
-                            ( engine, Nothing )
-
-                        typeCrumb =
-                            ( "shared", Nothing )
-
                         orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                            ( org, Nothing )
 
                         sharedSecrets =
-                            ( Maybe.withDefault team <| percentDecode team, Just <| Pages.SharedSecrets engine org team Nothing Nothing )
+                            ( Maybe.withDefault team <| percentDecode team, Nothing )
 
                         nameCrumb =
                             ( Maybe.withDefault name <| percentDecode name, Nothing )
                     in
-                    [ overviewPage, secrets, engineCrumb, typeCrumb, orgSecrets, sharedSecrets, nameCrumb ]
+                    [ overviewPage, orgSecrets, sharedSecrets, nameCrumb ]
 
                 Pages.RepositoryBuilds org repo maybePage maybePerPage maybeEvent ->
                     let


### PR DESCRIPTION
# Secrets Crumb Refactor proposal

Vela UI needs a better way of handling Secrets navigation, and part of the problem is confusing breadcrumbs. 

## Problems

1. Navigating from Repo Builds -> Repo Secrets is one-way, the repo crumb updates to Repo Secrets rather than staying the same link which is misleading.
2. Navigating from Repo Secrets -> Org Secrets is one-way.
3. Too many URL values are reflected in the crumb. With the new plugin support for secret engines the UI should focus on internal, native secrets. 
4. Navigating to secrets pages creates closed loop, or a dead-end from Overview -> View repo secret

## Potential Designs

_Below are the ideas for how secrets crumbs could look and behave._

### Current

For reference, here is the current crumbs architecture, as well as repo builds and hooks for additional comparison.

##### Repo Builds

*vela.net/go-vela/ui*

```Overview / go-vela / ui```

##### Repo Hooks

*vela.net/go-vela/ui/hooks*

```Overview / go-vela / ui / Hooks```

##### View Repo Secrets

*vela.net/-/secrets/native/repo/go-vela/ui*

```Overview / Secrets / native / repo / go-vela / ui```

##### Edit Repo Secret

*vela.net/-/secrets/native/repo/go-vela/ui/docker_password*

```Overview / Secrets / native / repo / go-vela / ui / docker_password```

##### Add Repo Secret

```Overview / Secrets / native / repo / go-vela / ui / Add```
New
View Repo Secrets
Overview / go-vela / ui / Repo Secrets 
Edit Repo Secret
Overview / go-vela / ui / Repo Secrets 
Add Repo Secret
Overview / Secrets / native / repo / go-vela / ui / Add
