### PR TITLE
fix(css): remove partial flowline from last build step

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -733,7 +733,7 @@ nav {
   );
 }
 
-.step.-line.-last {
+.step.flowline-left.-last {
   background-repeat: no-repeat;
   background-size: 100% 2em;
 }


### PR DESCRIPTION
![Screen Shot 2020-09-02 at 5 36 47 PM](https://user-images.githubusercontent.com/48764154/92044015-ebeca380-ed42-11ea-8ae5-e193bd9858a1.png)
recent change updated this class, forgot to propagate the change to remove it from the last step