### PR TITLE
fix(css): ignore ansi stylesheet during purgecss

### DIFF
--- a/.postcssrc.js
+++ b/.postcssrc.js
@@ -15,7 +15,7 @@ const production = {
   plugins: [
     purgecss({
       content: ['./src/**/*.elm', './src/static/index.js'],
-      whitelist: ['html', 'body', 'svg', 'ansi-*'],
+      whitelist: ['html', 'body', 'svg', 'ansi'],
     }),
     autoprefixer,
   ],

--- a/.postcssrc.js
+++ b/.postcssrc.js
@@ -15,7 +15,7 @@ const production = {
   plugins: [
     purgecss({
       content: ['./src/**/*.elm', './src/static/index.js'],
-      whitelist: ['html', 'body', 'svg', 'ansi'],
+      whitelist: ['html', 'body', 'svg'],
     }),
     autoprefixer,
   ],

--- a/.postcssrc.js
+++ b/.postcssrc.js
@@ -15,7 +15,7 @@ const production = {
   plugins: [
     purgecss({
       content: ['./src/**/*.elm', './src/static/index.js'],
-      whitelist: ['html', 'body', 'svg'],
+      whitelist: ['html', 'body', 'svg', 'ansi-*'],
     }),
     autoprefixer,
   ],

--- a/src/scss/_ansi.scss
+++ b/src/scss/_ansi.scss
@@ -2,7 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
-/* ansi text */
+/* purgecss start ignore */
 .ansi-bold {
   font-weight: bold;
 }
@@ -188,3 +188,4 @@
     color: inherit;
   }
 }
+/* purgecss end ignore */

--- a/src/scss/_ansi.scss
+++ b/src/scss/_ansi.scss
@@ -2,7 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
-/* purgecss start ignore */
+/*! purgecss start ignore */
 .ansi-bold {
   font-weight: bold;
 }
@@ -188,4 +188,4 @@
     color: inherit;
   }
 }
-/* purgecss end ignore */
+/*! purgecss end ignore */


### PR DESCRIPTION
ansi styles are applied during runtime, therefore purgecss is considering the ansi stylesheet as "unused" and is consequently scrubbing it from the production parcel build.
this commit adds ignore flags to _ansi.scss