### PR TITLE
fix(css): step-error and step-killed padding

### DIFF
--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -651,14 +651,12 @@ viewError build =
         Vela.Error ->
             div [ class "error", Util.testAttribute "build-error" ]
                 [ span [] [ text "error:" ]
-                , span [ class "message" ]
-                    [ text <|
-                        if String.isEmpty build.error then
-                            "no error msg"
+                , text <|
+                    if String.isEmpty build.error then
+                        "no error msg"
 
-                        else
-                            build.error
-                    ]
+                    else
+                        build.error
                 ]
 
         _ ->

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -592,7 +592,7 @@ stepFollowButton stepNumber following =
 stepError : Step -> Html msg
 stepError step =
     div [ class "step-error", Util.testAttribute "step-error" ]
-        [ span [ class "label" ] [ text "error:" ]
+        [ span [] [ text "error:" ]
         , span [ class "message" ]
             [ text <|
                 if String.isEmpty step.error then
@@ -612,7 +612,7 @@ stepError step =
 stepKilled : Step -> Html msg
 stepKilled _ =
     div [ class "step-error", Util.testAttribute "step-error" ]
-        [ span [ class "label" ] [ text "step was killed" ] ]
+        [ span [ class "message" ] [ text "step was killed" ] ]
 
 
 {-| stepSkipped : renders message for a skipped step
@@ -620,7 +620,7 @@ stepKilled _ =
 stepSkipped : Step -> Html msg
 stepSkipped _ =
     div [ class "step-skipped", Util.testAttribute "step-skipped" ]
-        [ span [ class "label" ] [ text "step was skipped" ] ]
+        [ span [ class "message" ] [ text "step was skipped" ] ]
 
 
 {-| viewStepIcon : renders a build step status icon

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -612,7 +612,7 @@ stepError step =
 stepKilled : Step -> Html msg
 stepKilled _ =
     div [ class "step-error", Util.testAttribute "step-error" ]
-        [ span [ class "message" ] [ text "step was killed" ] ]
+        [ text "step was killed" ]
 
 
 {-| stepSkipped : renders message for a skipped step
@@ -620,7 +620,7 @@ stepKilled _ =
 stepSkipped : Step -> Html msg
 stepSkipped _ =
     div [ class "step-skipped", Util.testAttribute "step-skipped" ]
-        [ span [ class "message" ] [ text "step was skipped" ] ]
+        [ text "step was skipped" ]
 
 
 {-| viewStepIcon : renders a build step status icon
@@ -637,7 +637,7 @@ viewError build =
     case build.status of
         Vela.Error ->
             div [ class "error", Util.testAttribute "build-error" ]
-                [ span [ class "label" ] [ text "error:" ]
+                [ span [] [ text "error:" ]
                 , span [ class "message" ]
                     [ text <|
                         if String.isEmpty build.error then

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -887,7 +887,7 @@ nav {
 
 .step-error .message,
 .step-skipped .message {
-  margin-left: 0.2em;
+  padding: 1rem 0.2em;
 }
 
 .animated {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -879,7 +879,7 @@ nav {
 
 .step-error,
 .step-skipped {
-  padding: 0.5rem 1em;
+  padding: 0.5rem 1rem;
 
   color: var(--color-red-light);
   font-size: 14px;

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -879,15 +879,10 @@ nav {
 
 .step-error,
 .step-skipped {
-  margin-left: 1.5em;
+  padding: 0.5rem 1em;
 
   color: var(--color-red-light);
   font-size: 14px;
-}
-
-.step-error .message,
-.step-skipped .message {
-  padding: 1rem 0.2em;
 }
 
 .animated {


### PR DESCRIPTION
removing unused classes
```css
.step-error .message,
.step-skipped .message
```
and moving padding to step-killed
(in preparation for #197 )