### PR TITLE
perf(logs): moving base64 decode to log receiver

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -735,7 +735,7 @@ update msg model =
 
         StepLogResponse stepNumber logFocus refresh response ->
             case response of
-                Ok ( _, log ) ->
+                Ok ( _, incomingLog ) ->
                     let
                         following =
                             model.followingStep /= 0
@@ -763,8 +763,11 @@ update msg model =
 
                             else
                                 Cmd.none
+
+                        decodedLog =
+                            { incomingLog | data = Util.base64Decode incomingLog.data }
                     in
-                    ( updateLogs { model | steps = steps } log
+                    ( updateLogs { model | steps = steps } decodedLog
                     , cmd
                     )
 

--- a/src/elm/Pages/Build/Logs.elm
+++ b/src/elm/Pages/Build/Logs.elm
@@ -6,7 +6,6 @@ Use of this source code is governed by the LICENSE file in this repository.
 
 module Pages.Build.Logs exposing
     ( SetLogFocus
-    , base64Decode
     , decodeAnsi
     , focusFragmentToFocusId
     , focusLogs
@@ -319,18 +318,6 @@ logFocusExists steps =
                     RemoteData.withDefault [] steps
     )
         /= ( Nothing, Nothing )
-
-
-{-| base64Decode : returns a string from a Maybe Log and decodes it from base64
--}
-base64Decode : String -> String
-base64Decode log =
-    case decode log of
-        Ok str ->
-            str
-
-        Err _ ->
-            ""
 
 
 {-| logEmpty : takes log string and returns True if content does not exist

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -49,8 +49,7 @@ import Http exposing (Error(..))
 import Pages exposing (Page(..))
 import Pages.Build.Logs
     exposing
-        ( base64Decode
-        , decodeAnsi
+        ( decodeAnsi
         , getDownloadLogsFileName
         , getStepLog
         , logEmpty
@@ -305,14 +304,11 @@ viewLogs org repo buildNumber step logs follow shiftDown =
 viewLogLines : Org -> Repo -> BuildNumber -> StepNumber -> LogFocus -> Maybe (WebData Log) -> Int -> Bool -> Html Msg
 viewLogLines org repo buildNumber stepNumber logFocus maybeLog following shiftDown =
     let
-        log =
+        decodedLog =
             toString maybeLog
 
         fileName =
             getDownloadLogsFileName org repo buildNumber "step" stepNumber
-
-        decodedLog =
-            base64Decode log
     in
     div
         [ class "logs"
@@ -324,7 +320,7 @@ viewLogLines org repo buildNumber stepNumber logFocus maybeLog following shiftDo
                 [ code [ Util.testAttribute "logs-error" ] [ text "error" ] ]
 
             _ ->
-                if logEmpty log then
+                if logEmpty decodedLog then
                     [ logsHeader stepNumber fileName decodedLog
                     , div [ class "loading-logs" ] [ Util.smallLoaderWithText "loading logs..." ]
                     ]

--- a/src/elm/Util.elm
+++ b/src/elm/Util.elm
@@ -8,6 +8,7 @@ module Util exposing
     ( addIfUniqueId
     , anyBlank
     , ariaHidden
+    , base64Decode
     , boolToYesNo
     , dateToHumanReadable
     , dispatch
@@ -42,6 +43,7 @@ module Util exposing
     , yesNoToBool
     )
 
+import Base64 exposing (decode)
 import DateFormat exposing (monthNameFull)
 import DateFormat.Relative exposing (defaultRelativeOptions, relativeTimeWithOptions)
 import Html exposing (Attribute, Html, div, text)
@@ -443,3 +445,15 @@ extractFocusIdFromRange focusId =
 
     else
         focusId
+
+
+{-| base64Decode : takes string and decodes it from base64
+-}
+base64Decode : String -> String
+base64Decode inStr =
+    case decode inStr of
+        Ok str ->
+            str
+
+        Err _ ->
+            ""

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -868,6 +868,7 @@ type alias Log =
     , build_id : Int
     , repository_id : Int
     , data : String
+    , decoded : Bool
     }
 
 
@@ -881,6 +882,7 @@ decodeLog =
         |> optional "build_id" int -1
         |> optional "repository_id" int -1
         |> optional "data" string ""
+        |> hardcoded False
 
 
 type alias Logs =

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -868,7 +868,6 @@ type alias Log =
     , build_id : Int
     , repository_id : Int
     , data : String
-    , decoded : Bool
     }
 
 
@@ -882,7 +881,6 @@ decodeLog =
         |> optional "build_id" int -1
         |> optional "repository_id" int -1
         |> optional "data" string ""
-        |> hardcoded False
 
 
 type alias Logs =


### PR DESCRIPTION
preparing for future log updates, moving base64 decode to when log is received, rather than on view/render.
this should improve performance greatly and goes in hand with additional incoming enhancements