### PR TITLE
fix(tests): update cypress test to fix type(shift) by attaching it to an input

### DIFF
--- a/cypress/integration/steps.spec.js
+++ b/cypress/integration/steps.spec.js
@@ -172,12 +172,12 @@ context('Steps', () => {
           cy.wait('@getLogs-2');
           cy.get('[data-test=log-line-2-2]').as('line2:2');
           cy.get('[data-test=log-line-2-5]').as('line2:5');
+          cy.get('[data-test=log-line-num-2-2]').as('lineNumber2:2');
           cy.get('[data-test=log-line-num-2-5]').as('lineNumber2:5');
-          cy.get('[data-test=log-line-num-2-2]').click({ force: true });
-          cy.get('@lineNumber2:5')
+          cy.get('@lineNumber2:2')
             .type('{shift}', { release: false })
-            .get('@lineNumber2:5')
-            .click();
+            .get('@lineNumber2:2')
+            .click({ force: true });
           cy.get('@lineNumber2:5').type('{shift}', { release: true });
         });
         it('range start line should be highlighted', () => {

--- a/cypress/integration/steps.spec.js
+++ b/cypress/integration/steps.spec.js
@@ -174,7 +174,7 @@ context('Steps', () => {
           cy.get('[data-test=log-line-2-5]').as('line2:5');
           cy.get('[data-test=log-line-num-2-5]').as('lineNumber2:5');
           cy.get('[data-test=log-line-num-2-2]').click({ force: true });
-          cy.get('body')
+          cy.get('@lineNumber2:5')
             .type('{shift}', { release: false })
             .get('@lineNumber2:5')
             .click();


### PR DESCRIPTION
fixing > https://github.com/go-vela/ui/runs/1151230679#step:8:883

```
     CypressError: `cy.type()` failed because it requires a valid typeable element.
```