### PR TITLE
chore(deps): updating vulnerable dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6078,7 +6078,7 @@
         "json5": "^1.0.1",
         "micromatch": "^3.0.4",
         "mkdirp": "^0.5.1",
-        "node-forge": "^0.7.1",
+        "node-forge": "0.10.0",
         "node-libs-browser": "^2.0.0",
         "opn": "^5.1.0",
         "postcss": "^7.0.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6078,7 +6078,7 @@
         "json5": "^1.0.1",
         "micromatch": "^3.0.4",
         "mkdirp": "^0.5.1",
-        "node-forge": "0.10.0",
+        "node-forge": "^0.10.0",
         "node-libs-browser": "^2.0.0",
         "opn": "^5.1.0",
         "postcss": "^7.0.11",


### PR DESCRIPTION
bumping `node-forge` to `^0.10.0`

solves Prototype Pollution vulnerability 
https://github.com/advisories/GHSA-92xj-mqp7-vmcj