### PR TITLE
enhance(logs): refactor and clean up logs controller and style

### DIFF
--- a/cypress/integration/logs.spec.js
+++ b/cypress/integration/logs.spec.js
@@ -205,11 +205,7 @@ context('visit Build with ansi encoded logs using url line fragment', () => {
     });
 
     it('logs header actions should not exist', () => {
-      cy.get('[data-test=logs-header-actions-1]').within(() => {
-        cy.get('[data-test=jump-to-bottom-1]').should('not.exist');
-        cy.get('[data-test=follow-logs-1]').should('not.exist');
-        cy.get('[data-test=download-logs-1]').should('not.exist');
-      });
+      cy.get('[data-test=logs-header-actions-1]').should('not.exist');
     });
 
     it('logs sidebar actions should not exist', () => {

--- a/cypress/integration/logs.spec.js
+++ b/cypress/integration/logs.spec.js
@@ -204,11 +204,11 @@ context('visit Build with ansi encoded logs using url line fragment', () => {
       cy.get('[data-test=step-header-1]').click({ force: true });
     });
 
-    it('logs header actions should only contain download', () => {
+    it('logs header actions should not exist', () => {
       cy.get('[data-test=logs-header-actions-1]').within(() => {
         cy.get('[data-test=jump-to-bottom-1]').should('not.exist');
         cy.get('[data-test=follow-logs-1]').should('not.exist');
-        cy.get('[data-test=download-logs-1]').should('exist');
+        cy.get('[data-test=download-logs-1]').should('not.exist');
       });
     });
 

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -319,6 +319,7 @@ viewLogLines org repo buildNumber stepNumber logFocus maybeLog following shiftDo
             RemoteData.Success _ ->
                 if logEmpty decodedLog then
                     [ emptyLogs ]
+
                 else
                     let
                         ( logs, numLines ) =
@@ -328,8 +329,10 @@ viewLogLines org repo buildNumber stepNumber logFocus maybeLog following shiftDo
                     , logsSidebar stepNumber following numLines
                     , logs
                     ]
+
             RemoteData.Failure err ->
                 [ code [ Util.testAttribute "logs-error" ] [ text "error fetching logs" ] ]
+
             _ ->
                 [ loadingLogs ]
 

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -612,7 +612,7 @@ stepError step =
         ]
 
 
-{-| loadingLogs : renders message for empty logs
+{-| loadingLogs : renders message for loading logs
 -}
 loadingLogs : Html msg
 loadingLogs =

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -628,7 +628,7 @@ loadingLogs =
 emptyLogs : Html msg
 emptyLogs =
     div [ class "message" ]
-        [ text "The build has not written logs to this step yet." ]
+        [ text "the build has not written logs to this step yet" ]
 
 
 {-| stepKilled : renders message for a killed step

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -780,22 +780,26 @@ nav {
   font-family: var(--font-code);
 }
 
-.loading-logs {
-  margin-top: 0.3em;
-  margin-left: 0.3em;
-  padding: 0.5em 0;
-}
 
 .logs-container {
   margin-right: -1rem;
   margin-left: -1rem;
   background-color: var(--color-bg-dark);
   position: relative;
-}
-
-.logs {
   font-weight: 300;
   font-size: 14px;
+
+  .message {
+    padding: 0.5rem 1rem;
+
+    span {
+     margin-right: 0.6rem;
+    }
+  }
+  
+  .error span {
+    color: var(--color-red-light);
+  }
 }
 
 .logs .line {
@@ -948,14 +952,6 @@ nav {
     margin-bottom: 0.4rem;
     color: var(--color-offwhite);
   }
-}
-
-.step-error,
-.step-skipped {
-  padding: 0.5rem 1rem;
-
-  color: var(--color-red-light);
-  font-size: 14px;
 }
 
 .animated {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -780,7 +780,6 @@ nav {
   font-family: var(--font-code);
 }
 
-
 .logs-container {
   margin-right: -1rem;
   margin-left: -1rem;
@@ -793,10 +792,10 @@ nav {
     padding: 0.5rem 1rem;
 
     span {
-     margin-right: 0.6rem;
+      margin-right: 0.6rem;
     }
   }
-  
+
   .error span {
     color: var(--color-red-light);
   }


### PR DESCRIPTION
3 changes
- refactor existing logs style, cleaner structure, removed redundant css
- made step skipped/errors more readable, moved red font to error label only
- added a message for empty logs and empty error (null)

![Screen Shot 2020-10-06 at 3 41 44 PM](https://user-images.githubusercontent.com/48764154/95258389-4b7b1a80-07eb-11eb-9180-fad656df35b9.png)
