### PR TITLE
perf(logs): optimization, only base64 decode when logs change

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,44 +1,42 @@
 {
-    "type": "application",
-    "source-directories": [
-        "src/elm"
-    ],
-    "elm-version": "0.19.1",
-    "dependencies": {
-        "direct": {
-            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
-            "danfishgold/base64-bytes": "1.0.3",
-            "elm/browser": "1.0.2",
-            "elm/bytes": "1.0.8",
-            "elm/core": "1.0.5",
-            "elm/file": "1.0.5",
-            "elm/html": "1.0.0",
-            "elm/http": "2.0.0",
-            "elm/json": "1.1.3",
-            "elm/svg": "1.0.1",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm-community/list-extra": "8.2.4",
-            "elm-community/string-extra": "4.0.1",
-            "feathericons/elm-feather": "1.5.0",
-            "jackfranklin/elm-parse-link-header": "2.0.2",
-            "jzxhuang/http-extras": "2.1.0",
-            "krisajenkins/remotedata": "6.0.1",
-            "pablen/toasty": "1.2.0",
-            "ryannhg/date-format": "2.3.0",
-            "vito/elm-ansi": "9.0.1"
-        },
-        "indirect": {
-            "elm/parser": "1.1.0",
-            "elm/random": "1.0.0",
-            "elm/regex": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
-        }
+  "type": "application",
+  "source-directories": ["src/elm"],
+  "elm-version": "0.19.1",
+  "dependencies": {
+    "direct": {
+      "NoRedInk/elm-json-decode-pipeline": "1.0.0",
+      "danfishgold/base64-bytes": "1.0.3",
+      "elm/browser": "1.0.2",
+      "elm/bytes": "1.0.8",
+      "elm/core": "1.0.5",
+      "elm/file": "1.0.5",
+      "elm/html": "1.0.0",
+      "elm/http": "2.0.0",
+      "elm/json": "1.1.3",
+      "elm/svg": "1.0.1",
+      "elm/time": "1.0.0",
+      "elm/url": "1.0.0",
+      "elm-community/list-extra": "8.2.4",
+      "elm-community/string-extra": "4.0.1",
+      "feathericons/elm-feather": "1.5.0",
+      "jackfranklin/elm-parse-link-header": "2.0.2",
+      "jzxhuang/http-extras": "2.1.0",
+      "krisajenkins/remotedata": "6.0.1",
+      "pablen/toasty": "1.2.0",
+      "ryannhg/date-format": "2.3.0",
+      "vito/elm-ansi": "9.0.1"
     },
-    "test-dependencies": {
-        "direct": {
-            "elm-explorations/test": "1.2.2"
-        },
-        "indirect": {}
+    "indirect": {
+      "elm/parser": "1.1.0",
+      "elm/random": "1.0.0",
+      "elm/regex": "1.0.0",
+      "elm/virtual-dom": "1.0.2"
     }
+  },
+  "test-dependencies": {
+    "direct": {
+      "elm-explorations/test": "1.2.2"
+    },
+    "indirect": {}
+  }
 }

--- a/elm.json
+++ b/elm.json
@@ -1,42 +1,44 @@
 {
-  "type": "application",
-  "source-directories": ["src/elm"],
-  "elm-version": "0.19.1",
-  "dependencies": {
-    "direct": {
-      "NoRedInk/elm-json-decode-pipeline": "1.0.0",
-      "elm/browser": "1.0.2",
-      "elm/core": "1.0.5",
-      "elm/file": "1.0.5",
-      "elm/html": "1.0.0",
-      "elm/http": "2.0.0",
-      "elm/json": "1.1.3",
-      "elm/svg": "1.0.1",
-      "elm/time": "1.0.0",
-      "elm/url": "1.0.0",
-      "elm-community/list-extra": "8.2.4",
-      "elm-community/string-extra": "4.0.1",
-      "feathericons/elm-feather": "1.5.0",
-      "jackfranklin/elm-parse-link-header": "2.0.2",
-      "jzxhuang/http-extras": "2.1.0",
-      "krisajenkins/remotedata": "6.0.1",
-      "pablen/toasty": "1.2.0",
-      "ryannhg/date-format": "2.3.0",
-      "truqu/elm-base64": "2.0.4",
-      "vito/elm-ansi": "9.0.1"
+    "type": "application",
+    "source-directories": [
+        "src/elm"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
+            "danfishgold/base64-bytes": "1.0.3",
+            "elm/browser": "1.0.2",
+            "elm/bytes": "1.0.8",
+            "elm/core": "1.0.5",
+            "elm/file": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.3",
+            "elm/svg": "1.0.1",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm-community/list-extra": "8.2.4",
+            "elm-community/string-extra": "4.0.1",
+            "feathericons/elm-feather": "1.5.0",
+            "jackfranklin/elm-parse-link-header": "2.0.2",
+            "jzxhuang/http-extras": "2.1.0",
+            "krisajenkins/remotedata": "6.0.1",
+            "pablen/toasty": "1.2.0",
+            "ryannhg/date-format": "2.3.0",
+            "vito/elm-ansi": "9.0.1"
+        },
+        "indirect": {
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
     },
-    "indirect": {
-      "elm/bytes": "1.0.8",
-      "elm/parser": "1.1.0",
-      "elm/random": "1.0.0",
-      "elm/regex": "1.0.0",
-      "elm/virtual-dom": "1.0.2"
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
+        "indirect": {}
     }
-  },
-  "test-dependencies": {
-    "direct": {
-      "elm-explorations/test": "1.2.2"
-    },
-    "indirect": {}
-  }
 }

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -59,7 +59,7 @@ import Http.Detailed
 import Interop
 import Json.Decode as Decode exposing (string)
 import Json.Encode as Encode
-import List.Extra exposing (setIf, updateIf)
+import List.Extra exposing (updateIf)
 import Maybe
 import Nav
 import Pager
@@ -763,11 +763,8 @@ update msg model =
 
                             else
                                 Cmd.none
-
-                        decodedLog =
-                            { incomingLog | data = Util.base64Decode incomingLog.data }
                     in
-                    ( updateLogs { model | steps = steps } decodedLog
+                    ( updateLogs { model | steps = steps } incomingLog
                     , cmd
                     )
 
@@ -2532,16 +2529,16 @@ updateLogs model incomingLog =
 -}
 updateLog : Log -> Logs -> Logs
 updateLog incomingLog logs =
-    setIf
+    updateIf
         (\log ->
             case log of
                 Success log_ ->
-                    incomingLog.id == log_.id && incomingLog.data /= log_.data
+                    incomingLog.id == log_.id && incomingLog.rawData /= log_.rawData
 
                 _ ->
                     True
         )
-        (RemoteData.succeed incomingLog)
+        (\log -> RemoteData.succeed { incomingLog | decodedLogs = Util.base64Decode incomingLog.rawData })
         logs
 
 
@@ -2549,7 +2546,7 @@ updateLog incomingLog logs =
 -}
 addLog : Log -> Logs -> Logs
 addLog incomingLog logs =
-    RemoteData.succeed incomingLog :: logs
+    RemoteData.succeed { incomingLog | decodedLogs = Util.base64Decode incomingLog.rawData } :: logs
 
 
 {-| homeMsgs : prepares the input record required for the Home page to route Msgs back to Main.elm

--- a/src/elm/Pages/Build/Logs.elm
+++ b/src/elm/Pages/Build/Logs.elm
@@ -27,7 +27,6 @@ module Pages.Build.Logs exposing
 
 import Ansi.Log
 import Array
-import Base64 exposing (decode)
 import List.Extra exposing (updateIf)
 import Pages exposing (Page)
 import Pages.Build.Model exposing (Msg(..))
@@ -335,7 +334,7 @@ toString log =
         Just log_ ->
             case log_ of
                 RemoteData.Success l ->
-                    l.data
+                    l.decodedLogs
 
                 _ ->
                     ""

--- a/src/elm/Util.elm
+++ b/src/elm/Util.elm
@@ -43,9 +43,9 @@ module Util exposing
     , yesNoToBool
     )
 
-import Bytes.Decode
 import Base64
 import Bytes
+import Bytes.Decode
 import DateFormat exposing (monthNameFull)
 import DateFormat.Relative exposing (defaultRelativeOptions, relativeTimeWithOptions)
 import Html exposing (Attribute, Html, div, text)
@@ -447,7 +447,6 @@ extractFocusIdFromRange focusId =
 
     else
         focusId
-
 
 
 {-| base64Decode : takes string and decodes it from base64

--- a/src/elm/Util.elm
+++ b/src/elm/Util.elm
@@ -43,7 +43,9 @@ module Util exposing
     , yesNoToBool
     )
 
-import Base64 exposing (decode)
+import Bytes.Decode
+import Base64
+import Bytes
 import DateFormat exposing (monthNameFull)
 import DateFormat.Relative exposing (defaultRelativeOptions, relativeTimeWithOptions)
 import Html exposing (Attribute, Html, div, text)
@@ -447,13 +449,16 @@ extractFocusIdFromRange focusId =
         focusId
 
 
+
 {-| base64Decode : takes string and decodes it from base64
 -}
 base64Decode : String -> String
 base64Decode inStr =
-    case decode inStr of
-        Ok str ->
-            str
-
-        Err _ ->
-            ""
+    Base64.toBytes inStr
+        |> Maybe.andThen
+            (\bytes ->
+                Bytes.Decode.decode
+                    (Bytes.Decode.string (Bytes.width bytes))
+                    bytes
+            )
+        |> Maybe.withDefault ""

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -867,7 +867,8 @@ type alias Log =
     , step_id : Int
     , build_id : Int
     , repository_id : Int
-    , data : String
+    , rawData : String
+    , decodedLogs : String
     }
 
 
@@ -881,6 +882,8 @@ decodeLog =
         |> optional "build_id" int -1
         |> optional "repository_id" int -1
         |> optional "data" string ""
+        -- "decodedLogs"
+        |> hardcoded ""
 
 
 type alias Logs =


### PR DESCRIPTION
optimizing base64 decode process a bit with some small tweaks:
- update to use more performant base64 library (javascript solution still WIP)
- use updateIf rather than setIf when overwriting logs
- only base64 decode when we actually update the logs in the model

saw several performance improvements
large-logs performance bottleneck has been more-or-less transferred to table/row renderanimationframe bloating