### PR TITLE
fix(css): adding break-word to logs

### DIFF
--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -482,7 +482,7 @@ viewLine id lineNumber line stepNumber logFocus shiftDown =
                     ]
                     [ td []
                         [ lineFocusButton stepNumber logFocus lineNumber shiftDown ]
-                    , td [ class "log-line-word-break", class "overflow-auto" ]
+                    , td [ class "break-text", class "overflow-auto" ]
                         [ code [ Util.testAttribute <| String.join "-" [ "log", "data", stepNumber, String.fromInt lineNumber ] ]
                             [ Ansi.Log.viewLine l
                             ]

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -482,7 +482,7 @@ viewLine id lineNumber line stepNumber logFocus shiftDown =
                     ]
                     [ td []
                         [ lineFocusButton stepNumber logFocus lineNumber shiftDown ]
-                    , td [ class "break-all", class "break-word", class "overflow-auto" ]
+                    , td [ class "log-line-word-break", class "overflow-auto" ]
                         [ code [ Util.testAttribute <| String.join "-" [ "log", "data", stepNumber, String.fromInt lineNumber ] ]
                             [ Ansi.Log.viewLine l
                             ]

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -482,7 +482,7 @@ viewLine id lineNumber line stepNumber logFocus shiftDown =
                     ]
                     [ td []
                         [ lineFocusButton stepNumber logFocus lineNumber shiftDown ]
-                    , td [ class "break-all", class "overflow-auto" ]
+                    , td [ class "break-all", class "break-word", class "overflow-auto" ]
                         [ code [ Util.testAttribute <| String.join "-" [ "log", "data", stepNumber, String.fromInt lineNumber ] ]
                             [ Ansi.Log.viewLine l
                             ]

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -1418,7 +1418,7 @@ nav {
   @include visually-hidden();
 }
 
-.log-line-word-break {
+.break-text {
   word-break: break-all;
   word-wrap: break-word;
 }

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -1419,7 +1419,7 @@ nav {
 }
 
 .break-all {
-  word-break: break-word;
+  word-break: break-all;
 }
 
 .break-word {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -1424,7 +1424,7 @@ nav {
 }
 
 .break-word {
-  word-break: break-word;
+  word-wrap: break-word;
 }
 
 .no-wrap {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -1423,6 +1423,7 @@ nav {
 }
 
 .break-word {
+  word-break: break-word;
   word-wrap: break-word;
 }
 

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -1419,7 +1419,7 @@ nav {
 }
 
 .break-all {
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .break-word {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -1418,13 +1418,13 @@ nav {
   @include visually-hidden();
 }
 
-.break-all {
+.log-line-word-break {
   word-break: break-all;
+  word-wrap: break-word;
 }
 
 .break-word {
   word-break: break-word;
-  word-wrap: break-word;
 }
 
 .no-wrap {


### PR DESCRIPTION
Adding 
```css
word-break: break-word;
```

to fix a bug with single-word logs that extend past the screens viewport.

### Before (extends past screen width):
![Screen Shot 2020-10-12 at 3 33 38 PM](https://user-images.githubusercontent.com/48764154/95788105-79a3a300-0ca0-11eb-9c45-9b3d30faf2d1.png)

### After:
![Screen Shot 2020-10-12 at 3 33 59 PM](https://user-images.githubusercontent.com/48764154/95788137-8aecaf80-0ca0-11eb-87fb-7c127efd1211.png)
