### PR TITLE
fix(css): adding padding to make room for logs sidebar

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -870,6 +870,7 @@ nav {
   max-height: 75rem;
   padding-bottom: 2rem;
   padding-top: 1rem;
+  padding-right: 3rem;
   resize: vertical;
 
   scrollbar-color: var(--color-coal-light) var(--color-bg-dark);


### PR DESCRIPTION
before: (sidebar covers top log line)
![Screen Shot 2020-10-12 at 3 46 21 PM](https://user-images.githubusercontent.com/48764154/95788973-3813f780-0ca2-11eb-90e1-75db7f0b0ffc.png)

after: (padding)
![Screen Shot 2020-10-12 at 3 45 40 PM](https://user-images.githubusercontent.com/48764154/95788968-35b19d80-0ca2-11eb-9e4d-82a3838f22b6.png)
