### PR TITLE
fix(css): adding gray color var to match current release flowline color

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -749,7 +749,7 @@ nav {
   background: linear-gradient(
     90deg,
     hsla(0, 0, 0, 0) calc(3.25em - 1px),
-    var(--color-bg-light) calc(3.25em),
+    var(--color-gray) calc(3.25em),
     hsla(0, 0, 0, 0) calc(3.25em + 1px)
   );
 }

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -749,7 +749,7 @@ nav {
   background: linear-gradient(
     90deg,
     hsla(0, 0, 0, 0) calc(3.25em - 1px),
-    var(--color-gray) calc(3.25em),
+    var(--color-flowline) calc(3.25em),
     hsla(0, 0, 0, 0) calc(3.25em + 1px)
   );
 }

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -23,6 +23,8 @@ body.theme-dark {
   --color-secondary-light: var(--color-lavender-light);
 
   --color-focus: var(--color-slate);
+
+  --color-flowline: var(--color-gray);
 }
 
 // light theme
@@ -43,6 +45,8 @@ body.theme-light {
   --color-secondary-light: var(--color-cyan-light);
 
   --color-focus: var(--color-bg-dark);
+
+  --color-flowline: var(--color-gray);
 }
 
 .theme-light {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -18,6 +18,7 @@
 
   --color-white: hsl(0, 0%, 100%);
   --color-offwhite: hsl(0, 0%, 98%); // main light bg
+  --color-gray: hsl(0, 0%, 70%);
   --color-gray-light: hsl(0, 0%, 85%);
 
   // status indications


### PR DESCRIPTION
Fixing the flowline color. In #216 the hardcoded color was removed but using `var(--color-bg-light)` is more difficult to see. This change adds a better gray for light/dark theme and uses it for the flowline.

See below.
*After* is almost identical to the hardcoded color in the current release (0.7.0)

### Before: (--color-bg-light)
![Screen Shot 2020-10-12 at 4 05 45 PM](https://user-images.githubusercontent.com/48764154/95790405-e9b42800-0ca4-11eb-9407-adbbf09cd0d3.png)
![Screen Shot 2020-10-12 at 4 05 53 PM](https://user-images.githubusercontent.com/48764154/95790407-ea4cbe80-0ca4-11eb-85bf-8a015f96ba65.png)

### After: (--color-gray)
![Screen Shot 2020-10-12 at 4 02 45 PM](https://user-images.githubusercontent.com/48764154/95790428-f5075380-0ca4-11eb-91cb-dd30caf04b2f.png)
![Screen Shot 2020-10-12 at 4 02 36 PM](https://user-images.githubusercontent.com/48764154/95790432-f6d11700-0ca4-11eb-96dc-df6babdff30d.png)
