### PR TITLE
chore: use secrets.env

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -112,8 +112,6 @@ This method of running the application enables hot-reloading of the code.
   #   image: ui:local
   #   networks:
   #     - vela
-  #   environment:
-  #     VELA_API: 'http://localhost:8080'
   #   env_file:
   #     - secrets.env
   #   restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
     image: ui:local
     networks:
       - vela
-    environment:
-      VELA_API: 'http://localhost:8080'
     env_file:
       - secrets.env
     restart: always

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "predev": "npm run clean",
     "dev": "npm run start",
     "prestart": "npm run clean",
-    "start": "parcel src/static/index.html --port 8888",
+    "start": "DOTENV_CONFIG_PATH=secrets.env parcel src/static/index.html --port 8888",
     "build-img": "parcel build src/static/img/*",
     "prebuild": "npm run clean",
     "build": "parcel build src/static/index.html --no-minify",

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -22,6 +22,11 @@
 # default: https://go-vela.github.io/docs
 # VELA_DOCS_URL=
 
+# Vela api server address, typically runs on port :8080 locally.
+# Should match the "VELA_ADDR" value in docker-compose.yml
+# when running locally.
+VELA_API=http://localhost:8080
+
 ############################################################
 #  _______  _______  ______    __   __  _______  ______    #
 # |       ||       ||    _ |  |  | |  ||       ||    _ |   #


### PR DESCRIPTION
with the changes introduced in #226 we now have to pass in `VELA_API` manually if you want to run local dev via `npm run dev`. This PR will override the standard location that `parcel` uses (`.env`) to use the newly added `secrets.env` file. So, as long as you define `VELA_API` in `secrets.env` as we did previously with `.env`, you will not need to pass it manually.