### PR TITLE
feat(repo settings): allow minimum build timeout of 1 minute

### DIFF
--- a/src/elm/Pages/RepoSettings.elm
+++ b/src/elm/Pages/RepoSettings.elm
@@ -383,7 +383,7 @@ timeoutWarning inTimeout =
     case inTimeout of
         Just _ ->
             p [ class "notice" ]
-                [ text "Disclaimer: if you are experiencing build timeouts, it is highly recommended to optimize your pipeline before altering this value. Timeouts must also lie between 1 and 90 minutes."
+                [ text "Disclaimer: if you are experiencing build timeouts, it is highly recommended to optimize your pipeline before increasing this value. Timeouts must also lie between 1 and 90 minutes."
                 ]
 
         Nothing ->

--- a/src/elm/Pages/RepoSettings.elm
+++ b/src/elm/Pages/RepoSettings.elm
@@ -347,7 +347,7 @@ timeoutInput repo inTimeout inputMsg =
             [ id <| "repo-timeout"
             , onInput inputMsg
             , type_ "number"
-            , Html.Attributes.min "30"
+            , Html.Attributes.min "1"
             , Html.Attributes.max "90"
             , value <| String.fromInt <| Maybe.withDefault repo.timeout inTimeout
             ]
@@ -383,7 +383,7 @@ timeoutWarning inTimeout =
     case inTimeout of
         Just _ ->
             p [ class "notice" ]
-                [ text "Disclaimer: if you are experiencing build timeouts, it is highly recommended to optimize your pipeline before altering this value. Timeouts must also lie between 30 and 90 minutes."
+                [ text "Disclaimer: if you are experiencing build timeouts, it is highly recommended to optimize your pipeline before altering this value. Timeouts must also lie between 1 and 90 minutes."
                 ]
 
         Nothing ->
@@ -543,7 +543,7 @@ validTimeout : Maybe Int -> Maybe Int -> Bool
 validTimeout inTimeout repoTimeout =
     case inTimeout of
         Just t ->
-            if t >= 30 && t <= 90 then
+            if t >= 1 && t <= 90 then
                 case repoTimeout of
                     Just ti ->
                         t /= ti


### PR DESCRIPTION
* Minimum build timeout has been lowered from 30 minutes to 1 minute; the default for newly enabled repos is still 30 minutes.

* Dependent on pr: https://github.com/go-vela/types/pull/119

![image](https://user-images.githubusercontent.com/31659837/101090374-2d782f00-357c-11eb-9fac-ae122c743a90.png)
