### PR TITLE
fix(css): fix small recent builds css regression

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -597,8 +597,7 @@ nav {
 
 .build-history-title {
   font-size: 0.8em;
-  margin: 0 0.4rem;
-  padding: 0.4rem 0 0;
+  padding: 0.4rem 0 0.4rem 0.4rem;
   display: inline;
 }
 

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -599,6 +599,7 @@ nav {
   font-size: 0.8em;
   margin: 0 0.4rem;
   padding: 0.4rem 0 0;
+  display: inline;
 }
 
 .recent-build {


### PR DESCRIPTION
set display inline to the Recent Builds title <p>
didnt notice this when merging that one in

### without
![Screen Shot 2020-12-07 at 11 01 33 AM](https://user-images.githubusercontent.com/48764154/101381521-77169180-387c-11eb-8f87-d63e416d599f.png)

### with inline
![Screen Shot 2020-12-07 at 11 01 44 AM](https://user-images.githubusercontent.com/48764154/101381537-7978eb80-387c-11eb-84d0-0a4be74e4c3a.png)
