### PR TITLE
safe fix for breaking long lines

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -1447,7 +1447,7 @@ nav {
 }
 
 .break-text {
-  word-break: break-all;
+  word-break: break-word;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
better fix for:
https://github.com/go-vela/ui/pull/218

did not formerly account for infinite "......" that do not break in display: table.

now breaks text properly.
![Screen Shot 2020-12-21 at 9 30 53 AM](https://user-images.githubusercontent.com/48764154/102793390-764b2880-436f-11eb-939a-b15e1be41b9c.png)
![Screen Shot 2020-12-21 at 9 32 45 AM](https://user-images.githubusercontent.com/48764154/102793442-8531db00-436f-11eb-8500-31a1d0e6d807.png)

