### PR TITLE
feat(nav): move code, prep work

### DIFF
--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -4,7 +4,7 @@ Use of this source code is governed by the LICENSE file in this repository.
 --}
 
 
-module Nav exposing (Msgs, viewNav, viewUtil)
+module Nav exposing (Msgs, viewBuildHistory, viewNav, viewUtil)
 
 import Browser.Events exposing (Visibility(..))
 import Crumbs
@@ -16,9 +16,13 @@ import Html
         , a
         , button
         , div
+        , em
+        , li
         , nav
+        , p
         , span
         , text
+        , ul
         )
 import Html.Attributes
     exposing
@@ -31,11 +35,11 @@ import Html.Attributes
 import Html.Events exposing (onClick)
 import Http exposing (Error(..))
 import Pages exposing (Page(..))
-import Pages.Build.View exposing (viewBuildHistory)
 import Pages.Builds exposing (view)
 import RemoteData exposing (RemoteData(..), WebData)
 import Routes exposing (Route(..))
 import Svg.Attributes
+import SvgBuilder exposing (recentBuildStatusToIcon)
 import Time exposing (Posix, Zone)
 import Util
 import Vela
@@ -174,7 +178,7 @@ viewUtil model =
     div [ class "util" ]
         [ case model.page of
             Pages.Build _ _ _ _ ->
-                viewBuildHistory model.time model.zone model.page model.repo.org model.repo.name model.repo.builds.builds 10
+                viewBuildHistory model.time model.zone model.page 10 rm
 
             Pages.RepositoryBuilds org repo _ _ _ ->
                 viewRepoTabs rm model.page
@@ -278,3 +282,132 @@ viewBuildTabs rm currentPage =
             []
     in
     viewTabs tabs "build"
+
+
+
+-- RECENT BUILDS
+
+
+{-| viewBuildHistory : takes the 10 most recent builds and renders icons/links back to them as a widget at the top of the Build page
+-}
+viewBuildHistory : Posix -> Zone -> Page -> Int -> RepoModel -> Html msg
+viewBuildHistory now timezone page limit rm =
+    let
+        org =
+            rm.org
+
+        repo =
+            rm.name
+
+        builds =
+            rm.builds.builds
+
+        buildNumber =
+            case page of
+                Pages.Build _ _ b _ ->
+                    Maybe.withDefault -1 <| String.toInt b
+
+                _ ->
+                    -1
+    in
+    case builds of
+        RemoteData.Success blds ->
+            if List.length blds > 0 then
+                div [ class "build-history" ]
+                    [ p [ class "build-history-title" ] [ text "Recent Builds" ]
+                    , ul [ Util.testAttribute "build-history", class "previews" ] <|
+                        List.indexedMap (viewRecentBuild now timezone page org repo buildNumber) <|
+                            List.take limit blds
+                    ]
+
+            else
+                text ""
+
+        RemoteData.Loading ->
+            div [ class "build-history" ] [ Util.smallLoader ]
+
+        RemoteData.NotAsked ->
+            div [ class "build-history" ] [ Util.smallLoader ]
+
+        _ ->
+            text ""
+
+
+{-| viewRecentBuild : takes recent build and renders status and link to build as a small icon widget
+
+    focusing or hovering the recent build icon will display a build info tooltip
+
+-}
+viewRecentBuild : Posix -> Zone -> Page -> Org -> Repo -> Int -> Int -> Build -> Html msg
+viewRecentBuild now timezone page org repo buildNumber idx build =
+    li [ class "recent-build" ]
+        [ recentBuildLink page org repo buildNumber build idx
+        , recentBuildTooltip now timezone build
+        ]
+
+
+{-| recentBuildLink : takes time info and build and renders line for redirecting to recent build
+
+    focusing and hovering this element will display the tooltip
+
+-}
+recentBuildLink : Page -> Org -> Repo -> Int -> Build -> Int -> Html msg
+recentBuildLink page org repo buildNumber build idx =
+    let
+        icon =
+            recentBuildStatusToIcon build.status idx
+
+        currentBuildClass =
+            if buildNumber == build.number then
+                class "-current"
+
+            else if buildNumber > build.number then
+                class "-older"
+
+            else
+                class ""
+    in
+    a
+        [ class "recent-build-link"
+        , Util.testAttribute <| "recent-build-link-" ++ String.fromInt buildNumber
+        , currentBuildClass
+        , case page of
+            Pages.Build _ _ _ _ ->
+                Routes.href <| Routes.Build org repo (String.fromInt build.number) Nothing
+
+            _ ->
+                Routes.href <| Routes.Build org repo (String.fromInt build.number) Nothing
+        , attribute "aria-label" <| "go to previous build number " ++ String.fromInt build.number
+        ]
+        [ icon
+        ]
+
+
+{-| recentBuildTooltip : takes time info and build and renders tooltip for viewing recent build info
+
+    tooltip is visible when the recent build link is focused or hovered
+
+-}
+recentBuildTooltip : Posix -> Zone -> Build -> Html msg
+recentBuildTooltip now timezone build =
+    div [ class "recent-build-tooltip", Util.testAttribute "build-history-tooltip" ]
+        [ ul [ class "info" ]
+            [ li [ class "line" ]
+                [ span [ class "number" ] [ text <| String.fromInt build.number ]
+                , em [] [ text build.event ]
+                ]
+            , viewTooltipField "started:" <| Util.dateToHumanReadable timezone build.started
+            , viewTooltipField "finished:" <| Util.dateToHumanReadable timezone build.finished
+            , viewTooltipField "duration:" <| Util.formatRunTime now build.started build.finished
+            , viewTooltipField "worker:" build.host
+            , viewTooltipField "commit:" <| Util.trimCommitHash build.commit
+            , viewTooltipField "branch:" build.branch
+            ]
+        ]
+
+
+{-| viewTooltipField : takes build field key and value, renders field in the tooltip
+-}
+viewTooltipField : String -> String -> Html msg
+viewTooltipField key value =
+    li [ class "line" ] [ span [] [ text key ], text value ]

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -8,7 +8,6 @@ module Pages.Build.View exposing
     ( statusToClass
     , statusToString
     , viewBuild
-    , viewBuildHistory
     , viewLine
     , viewPreview
     )
@@ -177,12 +176,12 @@ viewPreview now zone org repo build =
         commit =
             [ text <| String.replace "_" " " build.event
             , text " ("
-            , a [ href build.source ] [ text <| trimCommitHash build.commit ]
+            , a [ href build.source ] [ text <| Util.trimCommitHash build.commit ]
             , text <| ")"
             ]
 
         branch =
-            [ a [ href <| buildBranchUrl build.clone build.branch ] [ text build.branch ] ]
+            [ a [ href <| Util.buildBranchUrl build.clone build.branch ] [ text build.branch ] ]
 
         sender =
             [ text build.sender ]
@@ -755,121 +754,6 @@ viewError build =
             div [] []
 
 
-{-| viewBuildHistory : takes the 10 most recent builds and renders icons/links back to them as a widget at the top of the Build page
--}
-viewBuildHistory : Posix -> Zone -> Page -> Org -> Repo -> WebData Builds -> Int -> Html msg
-viewBuildHistory now timezone page org repo builds limit =
-    let
-        ( show, buildNumber ) =
-            case page of
-                Pages.Build _ _ b _ ->
-                    ( True, Maybe.withDefault -1 <| String.toInt b )
-
-                _ ->
-                    ( False, -1 )
-    in
-    if show then
-        case builds of
-            RemoteData.Success blds ->
-                if List.length blds > 0 then
-                    div [ class "build-history" ]
-                        [ p [ class "build-history-title" ] [ text "Recent Builds" ]
-                        , ul [ Util.testAttribute "build-history", class "previews" ] <|
-                            List.indexedMap (viewRecentBuild now timezone org repo buildNumber) <|
-                                List.take limit blds
-                        ]
-
-                else
-                    text ""
-
-            RemoteData.Loading ->
-                div [ class "build-history" ] [ Util.smallLoader ]
-
-            RemoteData.NotAsked ->
-                div [ class "build-history" ] [ Util.smallLoader ]
-
-            _ ->
-                text ""
-
-    else
-        text ""
-
-
-{-| viewRecentBuild : takes recent build and renders status and link to build as a small icon widget
-
-    focusing or hovering the recent build icon will display a build info tooltip
-
--}
-viewRecentBuild : Posix -> Zone -> Org -> Repo -> Int -> Int -> Build -> Html msg
-viewRecentBuild now timezone org repo buildNumber idx build =
-    li [ class "recent-build" ]
-        [ recentBuildLink org repo buildNumber build idx
-        , recentBuildTooltip now timezone build
-        ]
-
-
-{-| recentBuildLink : takes time info and build and renders line for redirecting to recent build
-
-    focusing and hovering this element will display the tooltip
-
--}
-recentBuildLink : Org -> Repo -> Int -> Build -> Int -> Html msg
-recentBuildLink org repo buildNumber build idx =
-    let
-        icon =
-            recentBuildStatusToIcon build.status idx
-
-        currentBuildClass =
-            if buildNumber == build.number then
-                class "-current"
-
-            else if buildNumber > build.number then
-                class "-older"
-
-            else
-                class ""
-    in
-    a
-        [ class "recent-build-link"
-        , Util.testAttribute <| "recent-build-link-" ++ String.fromInt buildNumber
-        , currentBuildClass
-        , Routes.href <| Routes.Build org repo (String.fromInt build.number) Nothing
-        , attribute "aria-label" <| "go to previous build number " ++ String.fromInt build.number
-        ]
-        [ icon
-        ]
-
-
-{-| recentBuildTooltip : takes time info and build and renders tooltip for viewing recent build info
-
-    tooltip is visible when the recent build link is focused or hovered
-
--}
-recentBuildTooltip : Posix -> Zone -> Build -> Html msg
-recentBuildTooltip now timezone build =
-    div [ class "recent-build-tooltip", Util.testAttribute "build-history-tooltip" ]
-        [ ul [ class "info" ]
-            [ li [ class "line" ]
-                [ span [ class "number" ] [ text <| String.fromInt build.number ]
-                , em [] [ text build.event ]
-                ]
-            , viewTooltipField "started:" <| Util.dateToHumanReadable timezone build.started
-            , viewTooltipField "finished:" <| Util.dateToHumanReadable timezone build.finished
-            , viewTooltipField "duration:" <| Util.formatRunTime now build.started build.finished
-            , viewTooltipField "worker:" build.host
-            , viewTooltipField "commit:" <| trimCommitHash build.commit
-            , viewTooltipField "branch:" build.branch
-            ]
-        ]
-
-
-{-| viewTooltipField : takes build field key and value, renders field in the tooltip
--}
-viewTooltipField : String -> String -> Html msg
-viewTooltipField key value =
-    li [ class "line" ] [ span [] [ text key ], text value ]
-
-
 
 -- HELPERS
 
@@ -1021,17 +905,3 @@ bottomBuildNumberDashes buildNumber =
 
         _ ->
             "-animation-dashes-2"
-
-
-{-| buildBranchUrl : drops '.git' off the clone url and concatenates tree + branch ref
--}
-buildBranchUrl : String -> String -> String
-buildBranchUrl clone branch =
-    String.dropRight 4 clone ++ "/tree/" ++ branch
-
-
-{-| trimCommitHash : takes the first 7 characters of the full commit hash
--}
-trimCommitHash : String -> String
-trimCommitHash commit =
-    String.left 7 commit

--- a/src/elm/Util.elm
+++ b/src/elm/Util.elm
@@ -10,6 +10,7 @@ module Util exposing
     , ariaHidden
     , base64Decode
     , boolToYesNo
+    , buildBranchUrl
     , dateToHumanReadable
     , dispatch
     , extractFocusIdFromRange
@@ -43,6 +44,7 @@ module Util exposing
     , successful
     , testAttribute
     , toTwoDigits
+    , trimCommitHash
     , yesNoToBool
     )
 
@@ -517,3 +519,17 @@ refToString maybeRef =
 
             else
                 "(default branch)"
+
+
+{-| buildBranchUrl : drops '.git' off the clone url and concatenates tree + branch ref
+-}
+buildBranchUrl : String -> String -> String
+buildBranchUrl clone branch =
+    String.dropRight 4 clone ++ "/tree/" ++ branch
+
+
+{-| trimCommitHash : takes the first 7 characters of the full commit hash
+-}
+trimCommitHash : String -> String
+trimCommitHash commit =
+    String.left 7 commit


### PR DESCRIPTION
prep work for https://github.com/go-vela/community/issues/166

no functional changes, but fixes an inevitable cyclical import issue
moving buildhistory and some util functions so they may be used across multiple pages