### PR TITLE
refactor(steps): adding StepsModel and moving code from Update.elm, prep work

### DIFF
--- a/src/elm/Pages/Build/Logs.elm
+++ b/src/elm/Pages/Build/Logs.elm
@@ -6,14 +6,21 @@ Use of this source code is governed by the LICENSE file in this repository.
 
 module Pages.Build.Logs exposing
     ( bottomTrackerFocusId
+    , clickResource
     , decodeAnsi
     , downloadFileName
+    , expandActive
     , focus
     , focusAndClear
     , getCurrentResource
+    , getInfo
     , getLog
+    , isViewing
     , logEmpty
+    , merge
+    , setAllViews
     , toString
+    , toggleView
     , topTrackerFocusId
     )
 
@@ -23,6 +30,7 @@ import Focus exposing (FocusTarget, parseFocusFragment, resourceFocusFragment)
 import List.Extra exposing (updateIf)
 import Pages exposing (Page)
 import RemoteData exposing (WebData)
+import Util exposing (overwriteById)
 import Vela
     exposing
         ( BuildNumber
@@ -39,6 +47,103 @@ import Vela
 
 
 -- HELPERS
+
+
+{-| clickResource : takes resources and resource number, toggles resource view state, and returns whether or not to fetch logs
+-}
+clickResource : WebData (Resources a) -> String -> ( WebData (Resources a), Bool )
+clickResource resources stepNumber =
+    resources
+        |> RemoteData.unwrap ( resources, False )
+            (\resources_ ->
+                ( toggleView stepNumber resources_ |> RemoteData.succeed
+                , True
+                )
+            )
+
+
+{-| merge : takes takes current resources and incoming resource information and merges them, updating old logs and retaining previous state.
+-}
+merge : Maybe String -> Bool -> WebData (Resources a) -> Resources a -> Resources a
+merge logFocus refresh current incoming =
+    let
+        merged =
+            current
+                |> RemoteData.unwrap incoming
+                    (\resources ->
+                        incoming
+                            |> List.map
+                                (\r ->
+                                    let
+                                        ( viewing, f ) =
+                                            getInfo resources r.number
+
+                                        s =
+                                            { r
+                                                | viewing = viewing
+                                                , logFocus = f
+                                            }
+                                    in
+                                    Just <| Maybe.withDefault s <| overwriteById s resources
+                                )
+                            |> List.filterMap identity
+                    )
+    in
+    -- when not an automatic refresh, respect the url focus
+    if not refresh then
+        focus logFocus merged
+
+    else
+        merged
+
+
+{-| isViewing : takes resources and resource number and returns the resource viewing state
+-}
+isViewing : WebData (Resources a) -> String -> Bool
+isViewing resources number =
+    resources
+        |> RemoteData.withDefault []
+        |> List.filter (\resource -> String.fromInt resource.number == number)
+        |> List.map .viewing
+        |> List.head
+        |> Maybe.withDefault False
+
+
+{-| toggleView : takes resources and resource number and toggles that resource viewing state
+-}
+toggleView : String -> Resources a -> Resources a
+toggleView number =
+    List.Extra.updateIf
+        (\resource -> String.fromInt resource.number == number)
+        (\resource -> { resource | viewing = not resource.viewing })
+
+
+{-| setAllViews : takes resources and value and sets all resources viewing state
+-}
+setAllViews : Bool -> Resources a -> Resources a
+setAllViews value =
+    List.map (\resource -> { resource | viewing = value })
+
+
+{-| expandActive : takes resources and sets resource viewing state if the resource is active
+-}
+expandActive : String -> Resources a -> Resources a
+expandActive number resources =
+    List.Extra.updateIf
+        (\resource -> (String.fromInt resource.number == number) && (resource.status /= Vela.Pending))
+        (\resource -> { resource | viewing = True })
+        resources
+
+
+{-| getInfo : takes resources and resource number and returns the resource update information
+-}
+getInfo : Resources a -> Int -> ( Bool, LogFocus )
+getInfo resources number =
+    resources
+        |> List.filter (\resource -> resource.number == number)
+        |> List.map (\resource -> ( resource.viewing, resource.logFocus ))
+        |> List.head
+        |> Maybe.withDefault ( False, ( Nothing, Nothing ) )
 
 
 {-| getCurrentResource : takes resources and returns the newest running or pending resource

--- a/src/elm/Pages/Build/Model.elm
+++ b/src/elm/Pages/Build/Model.elm
@@ -46,7 +46,7 @@ type alias PartialModel a =
 type Msg
     = ExpandStep Org Repo BuildNumber StepNumber
     | FocusLogs String
-    | DownloadLogs String String
+    | DownloadFile String String String
     | FollowStep Int
     | ExpandAllSteps Org Repo BuildNumber
     | CollapseAllSteps

--- a/src/elm/Pages/Build/Update.elm
+++ b/src/elm/Pages/Build/Update.elm
@@ -4,15 +4,15 @@ Use of this source code is governed by the LICENSE file in this repository.
 --}
 
 
-module Pages.Build.Update exposing (expandActiveStep, mergeSteps, update)
+module Pages.Build.Update exposing (update)
 
 import Api
 import Browser.Dom as Dom
 import Browser.Navigation as Navigation
 import File.Download as Download
-import Focus exposing (resourceFocusFragment)
+import Focus exposing (Resource, ResourceID, resourceFocusFragment)
 import List.Extra
-import Pages.Build.Logs exposing (focus)
+import Pages.Build.Logs exposing (..)
 import Pages.Build.Model
     exposing
         ( GetLogs
@@ -25,13 +25,15 @@ import Util exposing (overwriteById)
 import Vela
     exposing
         ( BuildNumber
+        , LogFocus
         , Org
         , Repo
+        , Resources
         , StepNumber
         , Steps
         , updateBuild
-        , updateBuildStepFollowing
         , updateBuildSteps
+        , updateBuildStepsFollowing
         )
 
 
@@ -52,7 +54,7 @@ update model msg ( getBuildStepLogs, getBuildStepsLogs ) focusResult =
         ExpandStep org repo buildNumber stepNumber ->
             let
                 ( steps, fetchStepLogs ) =
-                    clickStep build.steps stepNumber
+                    clickResource build.steps.steps stepNumber
 
                 action =
                     if fetchStepLogs then
@@ -62,11 +64,11 @@ update model msg ( getBuildStepLogs, getBuildStepsLogs ) focusResult =
                         Cmd.none
 
                 stepOpened =
-                    isViewingStep steps stepNumber
+                    isViewing steps stepNumber
 
                 -- step clicked is step being followed
                 onFollowedStep =
-                    build.followingStep == (Maybe.withDefault -1 <| String.toInt stepNumber)
+                    build.steps.followingStep == (Maybe.withDefault -1 <| String.toInt stepNumber)
 
                 follow =
                     if onFollowedStep && not stepOpened then
@@ -74,14 +76,9 @@ update model msg ( getBuildStepLogs, getBuildStepsLogs ) focusResult =
                         0
 
                     else
-                        build.followingStep
+                        build.steps.followingStep
             in
-            ( { model
-                | repo =
-                    rm
-                        |> updateBuildSteps steps
-                        |> updateBuildStepFollowing follow
-              }
+            ( { model | repo = rm |> updateBuildSteps steps |> updateBuildStepsFollowing follow }
             , Cmd.batch <|
                 [ action
                 , if stepOpened then
@@ -97,38 +94,33 @@ update model msg ( getBuildStepLogs, getBuildStepsLogs ) focusResult =
             , Navigation.pushUrl model.navigationKey url
             )
 
-        DownloadLogs filename logs ->
+        DownloadFile ext filename content ->
             ( model
-            , Download.string filename "text" logs
+            , Download.string filename ext content
             )
 
-        FollowStep step ->
-            ( { model | repo = updateBuildStepFollowing step rm }
+        FollowStep follow ->
+            ( { model | repo = updateBuildStepsFollowing follow rm }
             , Cmd.none
             )
 
         CollapseAllSteps ->
             let
                 steps =
-                    build.steps
-                        |> RemoteData.unwrap build.steps
-                            (\steps_ -> steps_ |> setAllStepViews False |> RemoteData.succeed)
+                    build.steps.steps
+                        |> RemoteData.unwrap build.steps.steps
+                            (\steps_ -> steps_ |> setAllViews False |> RemoteData.succeed)
             in
-            ( { model
-                | repo =
-                    rm
-                        |> updateBuildSteps steps
-                        |> updateBuildStepFollowing 0
-              }
+            ( { model | repo = rm |> updateBuildSteps steps |> updateBuildStepsFollowing 0 }
             , Cmd.none
             )
 
         ExpandAllSteps org repo buildNumber ->
             let
                 steps =
-                    RemoteData.unwrap build.steps
-                        (\steps_ -> steps_ |> setAllStepViews True |> RemoteData.succeed)
-                        build.steps
+                    RemoteData.unwrap build.steps.steps
+                        (\steps_ -> steps_ |> setAllViews True |> RemoteData.succeed)
+                        build.steps.steps
 
                 -- refresh logs for expanded steps
                 action =
@@ -140,105 +132,3 @@ update model msg ( getBuildStepLogs, getBuildStepsLogs ) focusResult =
 
         FocusOn id ->
             ( model, Dom.focus id |> Task.attempt focusResult )
-
-
-{-| clickStep : takes steps and step number, toggles step view state, and returns whether or not to fetch logs
--}
-clickStep : WebData Steps -> StepNumber -> ( WebData Steps, Bool )
-clickStep steps stepNumber =
-    let
-        ( stepsOut, action ) =
-            RemoteData.unwrap ( steps, False )
-                (\steps_ ->
-                    ( toggleStepView stepNumber steps_ |> RemoteData.succeed
-                    , True
-                    )
-                )
-                steps
-    in
-    ( stepsOut
-    , action
-    )
-
-
-{-| mergeSteps : takes takes current steps and incoming step information and merges them, updating old logs and retaining previous state.
--}
-mergeSteps : Maybe String -> Bool -> WebData Steps -> Steps -> Steps
-mergeSteps logFocus refresh currentSteps incomingSteps =
-    let
-        updatedSteps =
-            currentSteps
-                |> RemoteData.unwrap incomingSteps
-                    (\steps ->
-                        incomingSteps
-                            |> List.map
-                                (\incomingStep ->
-                                    let
-                                        ( viewing, focus ) =
-                                            getStepInfo steps incomingStep.number
-                                    in
-                                    overwriteById
-                                        { incomingStep
-                                            | viewing = viewing
-                                            , logFocus = focus
-                                        }
-                                        steps
-                                )
-                            |> List.filterMap identity
-                    )
-    in
-    -- when not an automatic refresh, respect the url focus
-    if not refresh then
-        focus logFocus updatedSteps
-
-    else
-        updatedSteps
-
-
-{-| isViewingStep : takes steps and step number and returns the step viewing state
--}
-isViewingStep : WebData Steps -> StepNumber -> Bool
-isViewingStep steps stepNumber =
-    steps
-        |> RemoteData.withDefault []
-        |> List.filter (\step -> String.fromInt step.number == stepNumber)
-        |> List.map .viewing
-        |> List.head
-        |> Maybe.withDefault False
-
-
-{-| toggleStepView : takes steps and step number and toggles that steps viewing state
--}
-toggleStepView : String -> Steps -> Steps
-toggleStepView stepNumber =
-    List.Extra.updateIf
-        (\step -> String.fromInt step.number == stepNumber)
-        (\step -> { step | viewing = not step.viewing })
-
-
-{-| setAllStepViews : takes steps and value and sets all steps viewing state
--}
-setAllStepViews : Bool -> Steps -> Steps
-setAllStepViews value =
-    List.map (\step -> { step | viewing = value })
-
-
-{-| expandActiveStep : takes steps and sets step viewing state if the step is active
--}
-expandActiveStep : StepNumber -> Steps -> Steps
-expandActiveStep stepNumber steps =
-    List.Extra.updateIf
-        (\step -> (String.fromInt step.number == stepNumber) && (step.status /= Vela.Pending))
-        (\step -> { step | viewing = True })
-        steps
-
-
-{-| getStepInfo : takes steps and step number and returns the step update information
--}
-getStepInfo : Steps -> Int -> ( Bool, ( Maybe Int, Maybe Int ) )
-getStepInfo steps stepNumber =
-    steps
-        |> List.filter (\step -> step.number == stepNumber)
-        |> List.map (\step -> ( step.viewing, step.logFocus ))
-        |> List.head
-        |> Maybe.withDefault ( False, ( Nothing, Nothing ) )

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -123,7 +123,7 @@ viewBuild model org repo =
                     ( text "", "" )
 
         logActions =
-            build.steps
+            build.steps.steps
                 |> RemoteData.unwrap (text "")
                     (\_ ->
                         div
@@ -138,7 +138,7 @@ viewBuild model org repo =
                     )
 
         buildSteps =
-            case build.steps of
+            case build.steps.steps of
                 RemoteData.Success steps_ ->
                     viewBuildSteps model rm steps_
 
@@ -380,7 +380,7 @@ viewLogs model rm step =
             stepSkipped step
 
         _ ->
-            viewLogLines rm.org rm.name rm.build.buildNumber (String.fromInt step.number) step.logFocus (getLog step .step_id rm.build.logs) rm.build.followingStep model.shift
+            viewLogLines rm.org rm.name rm.build.buildNumber (String.fromInt step.number) step.logFocus (getLog step .step_id rm.build.steps.logs) rm.build.steps.followingStep model.shift
 
 
 {-| viewLogLines : takes stepnumber linefocus log and clickAction shiftDown and renders logs for a build step
@@ -639,7 +639,7 @@ downloadStepLogsButton stepNumber fileName logs =
         [ class "button"
         , class "-link"
         , Util.testAttribute <| "download-logs-" ++ stepNumber
-        , onClick <| DownloadLogs fileName logs
+        , onClick <| DownloadFile "text" fileName logs
         , attribute "aria-label" <| "download logs for step " ++ stepNumber
         ]
         [ text "download step logs" ]


### PR DESCRIPTION
prep work for go-vela/community#166

some changes here can be found in the open PRs: #252 #253

*No functional changes* 
#### Changes
- adds a StepsModel for tracking steps information which will be more obvious when introducing services
- changes steps to resources so the code may be used for services
- moves the updated code out of Update.elm so that file may be deleted in the following PR