### PR TITLE
feat(nav): adding pipeline types and download yml button, prep work

### DIFF
--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -64,7 +64,6 @@ import Vela
         , Log
         , Name
         , Org
-        , Pipeline
         , PipelineConfig
         , Repo
         , Repositories

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -130,8 +130,8 @@ import Vela
         , Logs
         , Name
         , Org
-        , Pipeline
         , PipelineConfig
+        , PipelineModel
         , PipelineTemplates
         , Ref
         , RepairRepo
@@ -239,7 +239,7 @@ type alias Model =
     , showIdentity : Bool
     , favicon : Favicon
     , secretsModel : Pages.Secrets.Model.Model Msg
-    , pipeline : Pipeline
+    , pipeline : PipelineModel
     , templates : PipelineTemplates
     }
 

--- a/src/elm/Pages/Pipeline/Api.elm
+++ b/src/elm/Pages/Pipeline/Api.elm
@@ -8,7 +8,7 @@ module Pages.Pipeline.Api exposing (expandPipelineConfig, getPipelineConfig, get
 
 import Api
 import Pages.Pipeline.Model exposing (Msg(..), PartialModel)
-import Vela exposing (Org, Ref, Repo)
+import Vela exposing (FocusFragment, Org, Ref, Repo)
 
 
 {-| getPipelineConfig : takes model, org, repo and ref and fetches a pipeline configuration from the API.
@@ -27,6 +27,6 @@ expandPipelineConfig model org repo ref =
 
 {-| getPipelineTemplates : takes model, org, repo and ref and fetches templates used in a pipeline configuration from the API.
 -}
-getPipelineTemplates : PartialModel a -> Org -> Repo -> Maybe Ref -> Cmd Msg
-getPipelineTemplates model org repo ref =
-    Api.try (PipelineTemplatesResponse org repo) <| Api.getPipelineTemplates model org repo ref
+getPipelineTemplates : PartialModel a -> Org -> Repo -> Maybe Ref -> FocusFragment -> Cmd Msg
+getPipelineTemplates model org repo ref lineFocus =
+    Api.try (GetPipelineTemplatesResponse org repo lineFocus) <| Api.getPipelineTemplates model org repo ref

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -7,6 +7,7 @@ Use of this source code is governed by the LICENSE file in this repository.
 module Pages.Pipeline.Model exposing (Msg(..), PartialModel)
 
 import Alerts exposing (Alert)
+import Browser.Dom as Dom
 import Browser.Navigation as Navigation
 import Errors exposing (Error)
 import Http
@@ -18,8 +19,10 @@ import Toasty as Alerting exposing (Stack)
 import Vela
     exposing
         ( Build
+        , FocusFragment
         , Org
-        , Pipeline
+        , PipelineModel
+        , PipelineTemplates
         , Repo
         , RepoModel
         , Session
@@ -42,8 +45,8 @@ type alias PartialModel a =
         , time : Posix
         , repo : RepoModel
         , shift : Bool
-        , templates : ( WebData Templates, Error )
-        , pipeline : Pipeline
+        , templates : PipelineTemplates
+        , pipeline : PipelineModel
         , page : Page
         , toasties : Stack Alert
     }
@@ -58,7 +61,10 @@ type Msg
     | ExpandPipelineConfig Org Repo (Maybe String) Bool
     | GetPipelineConfigResponse Org Repo (Maybe String) (Result (Http.Detailed.Error String) ( Http.Metadata, String ))
     | ExpandPipelineConfigResponse Org Repo (Maybe String) (Result (Http.Detailed.Error String) ( Http.Metadata, String ))
-    | PipelineTemplatesResponse Org Repo (Result (Http.Detailed.Error String) ( Http.Metadata, Templates ))
+    | GetPipelineTemplatesResponse Org Repo FocusFragment (Result (Http.Detailed.Error String) ( Http.Metadata, Templates ))
     | FocusLine Int
     | Error Error
     | AlertsUpdate (Alerting.Msg Alert)
+    | DownloadLogs String String
+    | FocusOn String
+    | FocusResult (Result Dom.Error ())

--- a/src/elm/Pages/Pipeline/Update.elm
+++ b/src/elm/Pages/Pipeline/Update.elm
@@ -100,6 +100,8 @@ resourceChanged ( orgA, repoA, idA ) ( orgB, repoB, idB ) =
     not <| orgA == orgB && repoA == repoB && idA == idB
 
 
+{-| isSamePipelineRef : takes two pipeline resource identifiers and returns if the pipeline ref has changed
+-}
 isSamePipelineRef : RepoResourceIdentifier -> Page -> Bool
 isSamePipelineRef id currentPage =
     case currentPage of

--- a/src/elm/Pages/Pipeline/Update.elm
+++ b/src/elm/Pages/Pipeline/Update.elm
@@ -93,24 +93,6 @@ load model org repo ref expand lineFocus =
     )
 
 
-{-| resourceChanged : takes two repo resource identifiers and returns if the build has changed
--}
-resourceChanged : RepoResourceIdentifier -> RepoResourceIdentifier -> Bool
-resourceChanged ( orgA, repoA, idA ) ( orgB, repoB, idB ) =
-    not <| orgA == orgB && repoA == repoB && idA == idB
-
-
-{-| isSamePipelineRef : takes two pipeline resource identifiers and returns if the pipeline ref has changed
--}
-isSamePipelineRef : RepoResourceIdentifier -> Page -> Bool
-isSamePipelineRef id currentPage =
-    case currentPage of
-        Pages.Pipeline o r rf _ _ ->
-            not <| resourceChanged id ( o, r, Maybe.withDefault "" rf )
-
-        _ ->
-            False
-
 
 
 -- UPDATE
@@ -252,3 +234,22 @@ update model msg =
                 Ok ok ->
                     -- successfully focus the dom
                     ( model, Cmd.none )
+
+
+{-| resourceChanged : takes two repo resource identifiers and returns if the build has changed
+-}
+resourceChanged : RepoResourceIdentifier -> RepoResourceIdentifier -> Bool
+resourceChanged ( orgA, repoA, idA ) ( orgB, repoB, idB ) =
+    not <| orgA == orgB && repoA == repoB && idA == idB
+
+
+{-| isSamePipelineRef : takes two pipeline resource identifiers and returns if the pipeline ref has changed
+-}
+isSamePipelineRef : RepoResourceIdentifier -> Page -> Bool
+isSamePipelineRef id currentPage =
+    case currentPage of
+        Pages.Pipeline o r rf _ _ ->
+            not <| resourceChanged id ( o, r, Maybe.withDefault "" rf )
+
+        _ ->
+            False

--- a/src/elm/Pages/Pipeline/Update.elm
+++ b/src/elm/Pages/Pipeline/Update.elm
@@ -8,19 +8,23 @@ module Pages.Pipeline.Update exposing (load, update)
 
 import Alerts exposing (Alert)
 import Api
+import Browser.Dom as Dom
 import Browser.Navigation as Navigation
 import Errors exposing (addError, detailedErrorToString, toFailure)
+import File.Download as Download
 import Focus exposing (..)
 import Http
 import Http.Detailed
-import Pages
+import Pages exposing (Page)
 import Pages.Pipeline.Api exposing (expandPipelineConfig, getPipelineConfig, getPipelineTemplates)
 import Pages.Pipeline.Model exposing (Msg(..), PartialModel)
 import RemoteData exposing (RemoteData(..))
 import Routes
 import Svg exposing (line)
+import Task
 import Toasty as Alerting exposing (Stack)
-import Vela exposing (LogFocus, Org, Repo, Templates)
+import Util
+import Vela exposing (LogFocus, Org, Repo, RepoResourceIdentifier, Templates)
 
 
 
@@ -46,11 +50,19 @@ load model org repo ref expand lineFocus =
 
         parsed =
             parseFocusFragment lineFocus
+
+        sameRef =
+            isSamePipelineRef ( org, repo, Maybe.withDefault "" ref ) model.page
     in
     ( { model
         | page = Pages.Pipeline org repo ref expand lineFocus
         , pipeline =
-            { config = ( Loading, "" )
+            { config =
+                if sameRef then
+                    model.pipeline.config
+
+                else
+                    ( Loading, "" )
             , expanded = False
             , expanding = True
             , org = org
@@ -58,14 +70,44 @@ load model org repo ref expand lineFocus =
             , ref = ref
             , expand = expand
             , lineFocus = ( parsed.lineA, parsed.lineB )
+            , focusFragment =
+                case lineFocus of
+                    Just l ->
+                        Just <| "#" ++ l
+
+                    Nothing ->
+                        Nothing
+            , buildNumber = Nothing
             }
-        , templates = ( Loading, "" )
+        , templates =
+            if sameRef then
+                model.templates
+
+            else
+                { data = Loading, error = "", show = True }
       }
     , Cmd.batch
         [ getPipelineConfigAction
-        , getPipelineTemplates model org repo ref
+        , getPipelineTemplates model org repo ref lineFocus
         ]
     )
+
+
+{-| resourceChanged : takes two repo resource identifiers and returns if the build has changed
+-}
+resourceChanged : RepoResourceIdentifier -> RepoResourceIdentifier -> Bool
+resourceChanged ( orgA, repoA, idA ) ( orgB, repoB, idB ) =
+    not <| orgA == orgB && repoA == repoB && idA == idB
+
+
+isSamePipelineRef : RepoResourceIdentifier -> Page -> Bool
+isSamePipelineRef id currentPage =
+    case currentPage of
+        Pages.Pipeline o r rf _ _ ->
+            not <| resourceChanged id ( o, r, Maybe.withDefault "" rf )
+
+        _ ->
+            False
 
 
 
@@ -157,17 +199,17 @@ update model msg =
                     , addError error Error
                     )
 
-        PipelineTemplatesResponse org repo response ->
+        GetPipelineTemplatesResponse org repo lineFocus response ->
             case response of
                 Ok ( meta, templates ) ->
                     ( { model
-                        | templates = ( RemoteData.succeed templates, "" )
+                        | templates = { data = RemoteData.succeed templates, error = "", show = model.templates.show }
                       }
-                    , Cmd.none
+                    , Util.dispatch <| FocusOn <| Util.extractFocusIdFromRange <| focusFragmentToFocusId "config" lineFocus
                     )
 
                 Err error ->
-                    ( { model | templates = ( toFailure error, detailedErrorToString error ) }, addError error Error )
+                    ( { model | templates = { data = toFailure error, error = detailedErrorToString error, show = model.templates.show } }, addError error Error )
 
         FocusLine line ->
             let
@@ -189,3 +231,22 @@ update model msg =
 
         AlertsUpdate subMsg ->
             Alerting.update Alerts.successConfig AlertsUpdate subMsg model
+
+        DownloadLogs filename logs ->
+            ( model
+            , Download.string filename "text" logs
+            )
+
+        FocusOn id ->
+            ( model, Dom.focus id |> Task.attempt FocusResult )
+
+        FocusResult result ->
+            -- handle success or failure here
+            case result of
+                Err (Dom.NotFound id) ->
+                    -- unable to find dom 'id'
+                    ( model, Cmd.none )
+
+                Ok ok ->
+                    -- successfully focus the dom
+                    ( model, Cmd.none )

--- a/src/elm/Pages/Pipeline/Update.elm
+++ b/src/elm/Pages/Pipeline/Update.elm
@@ -94,7 +94,6 @@ load model org repo ref expand lineFocus =
 
 
 
-
 -- UPDATE
 
 

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -36,8 +36,8 @@ module Vela exposing
     , Logs
     , Name
     , Org
-    , Pipeline
     , PipelineConfig
+    , PipelineModel
     , PipelineTemplates
     , Ref
     , RepairRepo
@@ -867,21 +867,23 @@ buildUpdateRepoIntPayload field value =
 -- PIPELINE
 
 
-type alias Pipeline =
+type alias PipelineModel =
     { config : ( WebData PipelineConfig, Error )
     , expanded : Bool
     , expanding : Bool
     , org : Org
-    , repo : Org
+    , repo : Repo
+    , buildNumber : Maybe BuildNumber
     , ref : Maybe Ref
     , expand : Maybe String
     , lineFocus : LogFocus
+    , focusFragment : FocusFragment
     }
 
 
-defaultPipeline : Pipeline
+defaultPipeline : PipelineModel
 defaultPipeline =
-    Pipeline ( NotAsked, "" ) False False "" "" Nothing Nothing ( Nothing, Nothing )
+    PipelineModel ( NotAsked, "" ) False False "" "" Nothing Nothing Nothing ( Nothing, Nothing ) Nothing
 
 
 type alias PipelineConfig =
@@ -890,7 +892,10 @@ type alias PipelineConfig =
 
 
 type alias PipelineTemplates =
-    ( WebData Templates, Error )
+    { data : WebData Templates
+    , error : Error
+    , show : Bool
+    }
 
 
 type alias Template =
@@ -907,7 +912,7 @@ type alias Templates =
 
 defaultPipelineTemplates : PipelineTemplates
 defaultPipelineTemplates =
-    ( NotAsked, "" )
+    PipelineTemplates NotAsked "" True
 
 
 decodePipelineConfig : Decode.Decoder String

--- a/src/scss/_pipelines.scss
+++ b/src/scss/_pipelines.scss
@@ -84,9 +84,17 @@
 .expand-templates {
   display: flex;
   flex-direction: row;
-  align-items: center;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  justify-content: flex-start;
+}
+
+.pipeline .action:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+.pipeline .actions {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
 
   border-bottom: 1px solid var(--color-bg-light);
 
@@ -112,14 +120,9 @@
   }
 
   small {
-    margin-left: 1rem;
     padding: 0.2rem 0.4rem;
 
     background-color: var(--color-bg-light);
-  }
-
-  .tip {
-    margin-right: 0.6rem;
   }
 }
 
@@ -139,13 +142,19 @@
   .header {
     display: flex;
     flex-direction: row;
+    align-items: center;
     justify-content: space-between;
+
     padding: 0.6rem 0.8rem;
 
     font-weight: normal;
     font-size: 18px;
 
     border-bottom: 1px solid var(--color-secondary);
+
+    .link {
+      margin-left: 1rem;
+    }
   }
 
   .logs-table {


### PR DESCRIPTION
prep work for go-vela/community#166

some changes here can be found in the open PRs: #252 #253

#### Changes
- adds a PipelineTemplates type for more easily tracking pipeline templates in the Model.
- adds a "Download vela.yml" button to Pipelines
![Screen Shot 2021-01-05 at 1 37 41 PM](https://user-images.githubusercontent.com/48764154/103691336-a0017380-4f5b-11eb-84be-01df5cc82412.png)
  