### PR TITLE
fix(nav): use page input for repo tabs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,11 @@ services:
   # https://go-vela.github.io/docs/concepts/infrastructure/server/
   server:
     container_name: server
-    image: target/vela-server:latest
+    # image: target/vela-server:latest
+    build:
+      context: ../server/
+      dockerfile: Dockerfile
+    image: server:local
     networks:
       - vela
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,7 @@ services:
   # https://go-vela.github.io/docs/concepts/infrastructure/server/
   server:
     container_name: server
-    # image: target/vela-server:latest
-    build:
-      context: ../server/
-      dockerfile: Dockerfile
-    image: server:local
+    image: target/vela-server:latest
     networks:
       - vela
     environment:

--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -175,16 +175,16 @@ viewUtil model =
     div [ class "util" ]
         [ case model.page of
             Pages.RepositoryBuilds org repo _ _ _ ->
-                viewRepoTabs rm model.page
+                viewRepoTabs rm org repo model.page
 
             Pages.RepoSecrets engine org repo _ _ ->
-                viewRepoTabs rm model.page
+                viewRepoTabs rm org repo model.page
 
             Pages.Hooks org repo _ _ ->
-                viewRepoTabs rm model.page
+                viewRepoTabs rm org repo model.page
 
             Pages.RepoSettings org repo ->
-                viewRepoTabs rm model.page
+                viewRepoTabs rm org repo model.page
 
             Pages.Build _ _ _ _ ->
                 Pages.Build.History.view model.time model.zone model.page 10 model.repo
@@ -252,15 +252,9 @@ viewingTab p1 p2 =
 
 {-| viewRepoTabs : takes RepoModel and current page and renders navigation tabs
 -}
-viewRepoTabs : RepoModel -> Page -> Html msg
-viewRepoTabs rm currentPage =
+viewRepoTabs : RepoModel -> Org -> Repo -> Page -> Html msg
+viewRepoTabs rm org repo currentPage =
     let
-        org =
-            rm.org
-
-        repo =
-            rm.name
-
         tabs =
             [ Tab "Builds" currentPage <| Pages.RepositoryBuilds org repo rm.builds.maybePage rm.builds.maybePerPage rm.builds.maybeEvent
             , Tab "Secrets" currentPage <| Pages.RepoSecrets "native" org repo Nothing Nothing


### PR DESCRIPTION
this fixes a scenario where an invalid org/repo is provided.
using org/name in the repoModel depends on a successful build, so this is a bug

for example, if I visit a repo that has a valid org but bad repo, we should still see org secrets at 
vela.com/-/secrets/native/repo/DavidVader/dd

this fixes that