### PR TITLE
chore: update docker-compose to match updated server and worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,6 @@ services:
       VELA_QUEUE_DRIVER: redis
       VELA_QUEUE_CONFIG: 'redis://redis:6379'
       VELA_QUEUE_WORKER_ROUTES: 'docker,local,docker:local'
-      VELA_PORT: ':8080'
       VELA_SECRET: 'zB7mrKDTZqNeNTD8z47yG4DHywspAh'
       VELA_SOURCE_DRIVER: github
       VELA_SECRET_NATIVE_KEY: 'C639A572E14D5075C526FDDD43E4ECF6'
@@ -82,6 +81,7 @@ services:
       VELA_RUNTIME_DRIVER: docker
       VELA_SERVER_ADDR: 'http://server:8080'
       VELA_SERVER_SECRET: 'zB7mrKDTZqNeNTD8z47yG4DHywspAh'
+      WORKER_ADDR: http://worker:8080
     restart: always
     ports:
       - '8081:8080'


### PR DESCRIPTION
updates the docker-compose.yml to match the flags that were changed in  https://github.com/go-vela/server/pull/236 and https://github.com/go-vela/worker/pull/130