### PR TITLE
fix(css): adding margin to search bars

### DIFF
--- a/src/elm/Pages/Home.elm
+++ b/src/elm/Pages/Home.elm
@@ -72,7 +72,7 @@ view user filter { toggleFavorite, search } =
                 , a [ class "button", Routes.href Routes.SourceRepositories ] [ text "Source Repositories" ]
                 ]
     in
-    div [ Util.testAttribute "overview" ] <|
+    div [ class "overview", Util.testAttribute "overview" ] <|
         case user of
             Success u ->
                 if List.length u.favorites > 0 then

--- a/src/elm/Pages/Home.elm
+++ b/src/elm/Pages/Home.elm
@@ -72,7 +72,7 @@ view user filter { toggleFavorite, search } =
                 , a [ class "button", Routes.href Routes.SourceRepositories ] [ text "Source Repositories" ]
                 ]
     in
-    div [ class "overview", Util.testAttribute "overview" ] <|
+    div [ Util.testAttribute "overview" ] <|
         case user of
             Success u ->
                 if List.length u.favorites > 0 then

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -156,6 +156,7 @@ header {
 
 .content-wrap {
   margin: 0 var(--horizontal-pad) var(--horizontal-pad);
+  padding: 1rem 0;
 }
 
 nav {
@@ -279,11 +280,6 @@ nav {
 .util {
   display: flex;
   padding-bottom: 0.3rem;
-}
-
-.overview .form-control:first-child,
-.source-repos .form-control:first-child {
-  margin-top: 1rem;
 }
 
 .filtered-repos {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -281,6 +281,10 @@ nav {
   padding-bottom: 0.3rem;
 }
 
+.overview .form-control:first-child {
+  margin-top: 1rem;
+}
+
 .filtered-repos {
   margin-top: 2em;
 }

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -281,7 +281,8 @@ nav {
   padding-bottom: 0.3rem;
 }
 
-.overview .form-control:first-child {
+.overview .form-control:first-child,
+.source-repos .form-control:first-child {
   margin-top: 1rem;
 }
 

--- a/src/scss/_nav.scss
+++ b/src/scss/_nav.scss
@@ -18,7 +18,6 @@
 .jump-bar {
   display: flex;
   width: 100%;
-  padding: 1rem 0;
 }
 
 .jump-bar .jump-button {

--- a/src/scss/_nav.scss
+++ b/src/scss/_nav.scss
@@ -18,6 +18,7 @@
 .jump-bar {
   display: flex;
   width: 100%;
+  padding-bottom: 1rem;
 }
 
 .jump-bar .jump-button {


### PR DESCRIPTION
giving source repos and home page filter bar some breathing room

#### from
![Screen Shot 2021-01-14 at 3 37 04 PM](https://user-images.githubusercontent.com/48764154/104652234-6d9ff680-567e-11eb-9ac5-d034821adc20.png)

#### to
![Screen Shot 2021-01-14 at 3 37 15 PM](https://user-images.githubusercontent.com/48764154/104652241-70025080-567e-11eb-8ef5-5098dca8842a.png)
