### PR TITLE
feat(settings): show time remaining on token

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2256,7 +2256,7 @@ viewContent model =
 
         Pages.Settings ->
             ( "Settings"
-            , Pages.Settings.view model.session (Pages.Settings.Msgs Copy)
+            , Pages.Settings.view model.session model.time (Pages.Settings.Msgs Copy)
             )
 
         Pages.Login ->

--- a/src/elm/Pages/Settings.elm
+++ b/src/elm/Pages/Settings.elm
@@ -7,10 +7,12 @@ Use of this source code is governed by the LICENSE file in this repository.
 module Pages.Settings exposing (Msgs, view)
 
 import Auth.Session exposing (Session(..))
+import DateFormat.Relative exposing (relativeTime)
 import FeatherIcons
 import Html exposing (Html, br, button, div, em, h2, label, p, section, text, textarea)
 import Html.Attributes exposing (attribute, class, for, id, readonly, rows, wrap)
 import Html.Events exposing (onClick)
+import Time
 import Util
 import Vela exposing (Copy)
 
@@ -21,15 +23,23 @@ type alias Msgs msg =
     { copy : Copy msg }
 
 
-view : Session -> Msgs msg -> Html msg
-view session actions =
-    div [ class "my-settings", Util.testAttribute "settings" ]
-        [ section [ class "settings", Util.testAttribute "user-token" ]
-            [ h2 [ class "settings-title" ] [ text "Auth Token" ]
-            , p [ class "settings-description" ] [ text "Your authentication token.", br [] [], em [] [ text "Updated every time you log in." ] ]
-            , case session of
-                Authenticated auth ->
-                    div [ class "form-controls", class "-no-x-pad" ]
+view : Session -> Time.Posix -> Msgs msg -> Html msg
+view session now actions =
+    div [ class "my-settings", Util.testAttribute "settings" ] <|
+        case session of
+            Authenticated auth ->
+                let
+                    timeRemaining =
+                        if Time.posixToMillis auth.expiresAt < Time.posixToMillis now then
+                            "Token has expired"
+
+                        else
+                            "Expires " ++ relativeTime now auth.expiresAt ++ "."
+                in
+                [ section [ class "settings", Util.testAttribute "user-token" ]
+                    [ h2 [ class "settings-title" ] [ text "Authentication Token" ]
+                    , p [ class "settings-description" ] [ text timeRemaining, br [] [], em [] [ text "Token will refresh before it expires." ] ]
+                    , div [ class "form-controls", class "-no-x-pad" ]
                         [ label [ class "form-label", class "visually-hidden", for "token" ] [ text "Auth Token" ]
                         , textarea
                             [ class "form-control"
@@ -56,8 +66,8 @@ view session actions =
                                 |> FeatherIcons.toHtml []
                             ]
                         ]
+                    ]
+                ]
 
-                Unauthenticated ->
-                    div [] [ text "unable to load token :(" ]
-            ]
-        ]
+            Unauthenticated ->
+                []


### PR DESCRIPTION
quick addition that will show time remaining on token:

<img width="457" alt="image" src="https://user-images.githubusercontent.com/1301201/104857554-e8674c80-58de-11eb-9113-87f6c90a6d4c.png">
