### PR TITLE
revert: purgecss upgrade from #293

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1126,11 +1126,11 @@
       }
     },
     "@fullhuman/postcss-purgecss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-4.0.0.tgz",
-      "integrity": "sha512-1DNYIDxFsvGOeKdc2BFtIQriMWwzX6dY+9q0Z0n9TNZhFZ9T6nHRZHPC22aYLlPDd0ucCgIr1deTgDTrjq21KQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.1.3.tgz",
+      "integrity": "sha512-kwOXw8fZ0Lt1QmeOOrd+o4Ibvp4UTEBFQbzvWldjlKv5n+G9sXfIPn1hh63IQIL8K8vbvv1oYMJiIUbuy9bGaA==",
       "requires": {
-        "purgecss": "^4.0.0"
+        "purgecss": "^3.1.3"
       }
     },
     "@hapi/hoek": {
@@ -7445,9 +7445,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "purgecss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-4.0.0.tgz",
-      "integrity": "sha512-j/y6OtNpEiggw/ipCJUOMNLgLpeAv9L8q+SqzEdDzyVEZOfdWjg8yvgOxhBflNyYgJ8SZ+tTwPxrHT9vQUpEPw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-3.1.3.tgz",
+      "integrity": "sha512-hRSLN9mguJ2lzlIQtW4qmPS2kh6oMnA9RxdIYK8sz18QYqd6ePp4GNDl18oWHA1f2v2NEQIh51CO8s/E3YGckQ==",
       "requires": {
         "commander": "^6.0.0",
         "glob": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=12.14.1"
   },
   "dependencies": {
-    "@fullhuman/postcss-purgecss": "4.0.0",
+    "@fullhuman/postcss-purgecss": "3.1.3",
     "@types/clipboard": "2.0.1",
     "@types/parcel-env": "0.0.0",
     "autoprefixer": "9.8.6",


### PR DESCRIPTION
purgecss v4 causes issues atm similar to the autoprefixer upgrade.  will need to address separately.