### PR TITLE
chore: update copyright year to 2021

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -30,7 +30,7 @@ Please see our [support](SUPPORT.md) documentation for further instructions.
 ## Copyright and License
 
 ```
-Copyright (c) 2020 Target Brands, Inc.
+Copyright (c) 2021 Target Brands, Inc.
 ```
 
 [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 

--- a/.postcssrc.js
+++ b/.postcssrc.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2020 Target Brands, Inc.
+   Copyright (c) 2021 Target Brands, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 
@@ -222,4 +222,3 @@ bump-deps: clean bump-deps-npm bump-deps-elm ## Bump NPM and Elm dependencies
 # Usage: `make bump-deps-test`
 .PHONY: bump-deps-test
 bump-deps-test: bump-deps test-cypress ## Bump dependencies and run Cypress tests
-

--- a/cypress/integration/a11y.lighttheme.spec.js
+++ b/cypress/integration/a11y.lighttheme.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/a11y.spec.js
+++ b/cypress/integration/a11y.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/add_repositories.spec.js
+++ b/cypress/integration/add_repositories.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/auth.spec.js
+++ b/cypress/integration/auth.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/build.spec.js
+++ b/cypress/integration/build.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/builds.spec.js
+++ b/cypress/integration/builds.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/contextual_help.spec.js
+++ b/cypress/integration/contextual_help.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/crumbs.spec.js
+++ b/cypress/integration/crumbs.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/errors.spec.js
+++ b/cypress/integration/errors.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/favorites.spec.js
+++ b/cypress/integration/favorites.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/hooks.spec.js
+++ b/cypress/integration/hooks.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/logs.spec.js
+++ b/cypress/integration/logs.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 context(

--- a/cypress/integration/overview.spec.js
+++ b/cypress/integration/overview.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/pipeline.spec.js
+++ b/cypress/integration/pipeline.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/repo.spec.js
+++ b/cypress/integration/repo.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/repo_settings.spec.js
+++ b/cypress/integration/repo_settings.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/searching.spec.js
+++ b/cypress/integration/searching.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/secrets.spec.js
+++ b/cypress/integration/secrets.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/settings.spec.js
+++ b/cypress/integration/settings.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/cypress/integration/steps.spec.js
+++ b/cypress/integration/steps.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/src/elm/Alerts.elm
+++ b/src/elm/Alerts.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Api/Endpoint.elm
+++ b/src/elm/Api/Endpoint.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Api/Header.elm
+++ b/src/elm/Api/Header.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Api/Pagination.elm
+++ b/src/elm/Api/Pagination.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Auth/Jwt.elm
+++ b/src/elm/Auth/Jwt.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Auth/Session.elm
+++ b/src/elm/Auth/Session.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Crumbs.elm
+++ b/src/elm/Crumbs.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Errors.elm
+++ b/src/elm/Errors.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Favorites.elm
+++ b/src/elm/Favorites.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Help/Commands.elm
+++ b/src/elm/Help/Commands.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Help/View.elm
+++ b/src/elm/Help/View.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Interop.elm
+++ b/src/elm/Interop.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Main/index.d.ts
+++ b/src/elm/Main/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+ * Copyright (c) 2021 Target Brands, Inc. All rights reserved.
  * Use of this source code is governed by the LICENSE file in this repository.
  */
 

--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pager.elm
+++ b/src/elm/Pager.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages.elm
+++ b/src/elm/Pages.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Build/Logs.elm
+++ b/src/elm/Pages/Build/Logs.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Build/Model.elm
+++ b/src/elm/Pages/Build/Model.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Builds.elm
+++ b/src/elm/Pages/Builds.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Home.elm
+++ b/src/elm/Pages/Home.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Hooks.elm
+++ b/src/elm/Pages/Hooks.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Pipeline/View.elm
+++ b/src/elm/Pages/Pipeline/View.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/RepoSettings.elm
+++ b/src/elm/Pages/RepoSettings.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Secrets/Form.elm
+++ b/src/elm/Pages/Secrets/Form.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Secrets/Model.elm
+++ b/src/elm/Pages/Secrets/Model.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Secrets/Update.elm
+++ b/src/elm/Pages/Secrets/Update.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/Settings.elm
+++ b/src/elm/Pages/Settings.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Pages/SourceRepos.elm
+++ b/src/elm/Pages/SourceRepos.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Routes.elm
+++ b/src/elm/Routes.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Search.elm
+++ b/src/elm/Search.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/SvgBuilder.elm
+++ b/src/elm/SvgBuilder.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Table.elm
+++ b/src/elm/Table.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Util.elm
+++ b/src/elm/Util.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -1,5 +1,5 @@
 {--
-Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 Use of this source code is governed by the LICENSE file in this repository.
 --}
 

--- a/src/scss/_animations.scss
+++ b/src/scss/_animations.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_ansi.scss
+++ b/src/scss/_ansi.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_buttons.scss
+++ b/src/scss/_buttons.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_details.scss
+++ b/src/scss/_details.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_nav.scss
+++ b/src/scss/_nav.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_pipelines.scss
+++ b/src/scss/_pipelines.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_reset.scss
+++ b/src/scss/_reset.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_tooltips.scss
+++ b/src/scss/_tooltips.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,6 +1,6 @@
 @charset 'utf-8';
 
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 


### PR DESCRIPTION
This is a general housekeeping task.

I used VS code's search and replace:

* Search: `Copyright (c) 2020`
* Replace: `Copyright (c) 2021`

At the top of every file, the new copyright statement now looks like:

```
// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
```