### PR TITLE
enhance(tabs): show bottom line on hover

### DIFF
--- a/src/scss/_nav.scss
+++ b/src/scss/_nav.scss
@@ -19,6 +19,16 @@
   display: flex;
   width: 100%;
   padding-bottom: 1rem;
+
+  a {
+    /* stylelint-disable-next-line plugin/no-low-performance-animation-properties */
+    transition: border-color 0.4s;
+
+    &:hover,
+    &:focus {
+      border-color: var(--color-primary);
+    }
+  }
 }
 
 .jump-bar .jump-button {


### PR DESCRIPTION
gives another visual cue on hovering tabs. will also show when in focus.

not excited about targeting `a` tag directly. i think with a different implementation we can avoid the the "costly" animation as the linter points out as well.

### old
![hover_old](https://user-images.githubusercontent.com/1301201/105544707-e4fa0980-5cc0-11eb-943a-90b6536a65ee.gif)

### proposed
![hover](https://user-images.githubusercontent.com/1301201/105544722-e88d9080-5cc0-11eb-9c3b-bd3b439033ee.gif)
