### PR TITLE
feat: add visual alert for audit

### DIFF
--- a/src/scss/_nav.scss
+++ b/src/scss/_nav.scss
@@ -42,12 +42,31 @@
 
 .jump-bar .jump,
 .jump-bar .jump-button {
+  position: relative;
+
   padding: 1rem;
 
   color: var(--color-text);
   text-decoration: none;
 
   border-bottom: 3px solid var(--color-bg-light);
+
+  &.alerting::after {
+    position: absolute;
+
+    top: 0.8rem;
+    right: 0.2rem;
+
+    display: block;
+
+    width: 0.4rem;
+    height: 0.4rem;
+
+    background-color: var(--color-red);
+    border-radius: 50%;
+
+    content: '';
+  }
 
   &.current {
     font-weight: bold;


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/191

![image](https://user-images.githubusercontent.com/1301201/105860202-f1c57880-5fb2-11eb-8a7f-07025c7a02f1.png)

Likely not the final form of this feature. Enough for MVP, probably.

One note: audit doesn't refresh unless it's the active tab, so you only see it on page load. It does disappear when a new build successfully starts (when you are on the builds tab) because it invalidates the condition by which the "alert" is added.

I lied, two notes: No tests (yet; hence draft status)