### PR TITLE
fix(crumbs): change last segment to not be a link

### DIFF
--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -353,7 +353,7 @@ patch api endpoint =
 -- ENTRYPOINT
 
 
-{-| try : default way to request information from and endpoint
+{-| try : default way to request information from an endpoint
 
     example usage:
         Api.try UserResponse <| Api.getUser model authParams
@@ -382,7 +382,7 @@ tryAll msg request_ =
 -- ENTRYPOINT
 
 
-{-| try : default way to request information from and endpoint
+{-| try : default way to request information from an endpoint
 example usage:
 Api.try UserResponse <| Api.getUser model authParams
 -}

--- a/src/elm/Crumbs.elm
+++ b/src/elm/Crumbs.elm
@@ -165,7 +165,7 @@ toPath page =
                         orgSecrets =
                             ( "Org Secrets", Just <| Pages.OrgSecrets engine org Nothing Nothing )
                     in
-                    [ overviewPage, orgPage, orgSecrets, ("Add", Nothing) ]
+                    [ overviewPage, orgPage, orgSecrets, ( "Add", Nothing ) ]
 
                 Pages.AddRepoSecret engine org repo ->
                     let
@@ -175,7 +175,7 @@ toPath page =
                         currentRepo =
                             ( repo, Just <| Pages.RepoSecrets engine org repo Nothing Nothing )
                     in
-                    [ overviewPage, orgPage, currentRepo, ("Add", Nothing) ]
+                    [ overviewPage, orgPage, currentRepo, ( "Add", Nothing ) ]
 
                 Pages.AddSharedSecret engine org team ->
                     let
@@ -188,7 +188,7 @@ toPath page =
                         sharedSecrets =
                             ( "Shared Secrets", Just <| Pages.SharedSecrets engine org team Nothing Nothing )
                     in
-                    [ overviewPage, orgPage, teamPage, sharedSecrets, ("Add", Nothing) ]
+                    [ overviewPage, orgPage, teamPage, sharedSecrets, ( "Add", Nothing ) ]
 
                 Pages.OrgSecret engine org name ->
                     let

--- a/src/elm/Crumbs.elm
+++ b/src/elm/Crumbs.elm
@@ -165,7 +165,7 @@ toPath page =
                         orgSecrets =
                             ( "Org Secrets", Just <| Pages.OrgSecrets engine org Nothing Nothing )
                     in
-                    [ overviewPage, orgPage, orgSecrets ]
+                    [ overviewPage, orgPage, orgSecrets, ("Add", Nothing) ]
 
                 Pages.AddRepoSecret engine org repo ->
                     let
@@ -175,7 +175,7 @@ toPath page =
                         currentRepo =
                             ( repo, Just <| Pages.RepoSecrets engine org repo Nothing Nothing )
                     in
-                    [ overviewPage, orgPage, currentRepo ]
+                    [ overviewPage, orgPage, currentRepo, ("Add", Nothing) ]
 
                 Pages.AddSharedSecret engine org team ->
                     let
@@ -188,7 +188,7 @@ toPath page =
                         sharedSecrets =
                             ( "Shared Secrets", Just <| Pages.SharedSecrets engine org team Nothing Nothing )
                     in
-                    [ overviewPage, orgPage, teamPage, sharedSecrets ]
+                    [ overviewPage, orgPage, teamPage, sharedSecrets, ("Add", Nothing) ]
 
                 Pages.OrgSecret engine org name ->
                     let


### PR DESCRIPTION
Fixes issue primarily present in secrets where the last crumb is a link. The updated crumb design doesn't really accommodate that use. There's probably a couple of ways this could be fixed - this is one suggestion, adding "Add" as the last crumb when you are on a page to add a secret.

![image](https://user-images.githubusercontent.com/1301201/106634860-d2e05c80-6545-11eb-87ad-5d64abb72d94.png)
![image](https://user-images.githubusercontent.com/1301201/106635720-c6103880-6546-11eb-86dd-135f67bcb6fe.png)

To consider.. changing "Add" to "Add Secret" or "Add Repo Secret"/"Add Org Secret".. that might eliminate the need for the heading on those pages, ie. "Add Repo Secret". Or, more invasively.. in the example's case, change "services" to "services Secrets" and keeping it as "Add", etc.

![image](https://user-images.githubusercontent.com/1301201/106636229-551d5080-6547-11eb-905c-37217830a1c3.png)
