### PR TITLE
fix: revert caddy, add host/scheme prefix to redirect proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - vela
     environment:
       VELA_ADDR: 'http://localhost:8080'
-      VELA_WEBUI_ADDR: 'http://ui:80'
+      VELA_WEBUI_ADDR: 'http://localhost:8888'
       VELA_DATABASE_DRIVER: postgres
       VELA_DATABASE_CONFIG: 'postgres://vela:zB7mrKDTZqNeNTD8z47yG4DHywspAh@postgres:5432/vela?sslmode=disable'
       VELA_LOG_LEVEL: trace

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -40,7 +40,7 @@ server {
     }
 
     location @handle_redirects {
-        set $saved_redirect_location '$upstream_http_location';
+        set $saved_redirect_location '$VELA_API$upstream_http_location';
         proxy_pass $saved_redirect_location;
     }
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -40,7 +40,9 @@ server {
     }
 
     location @handle_redirects {
-        set $saved_redirect_location '$scheme://$upstream_addr$upstream_http_location';
+        # add upstream redirect path to $VELA_API 
+        set $saved_redirect_location '$VELA_API$upstream_http_location';
+        
         proxy_pass $saved_redirect_location;
     }
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -40,7 +40,7 @@ server {
     }
 
     location @handle_redirects {
-        # set proxy_pass to VELA_API + upstream location
+        # set proxy_pass to VELA_API + upstream_http_location
         set $saved_redirect_location '$VELA_API$upstream_http_location';
         proxy_pass $saved_redirect_location;
     }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -40,7 +40,7 @@ server {
     }
 
     location @handle_redirects {
-        set $saved_redirect_location '$VELA_API$upstream_http_location';
+        set $saved_redirect_location '$scheme://$upstream_addr$upstream_http_location';
         proxy_pass $saved_redirect_location;
     }
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -42,7 +42,6 @@ server {
     location @handle_redirects {
         # add upstream redirect path to $VELA_API 
         set $saved_redirect_location '$VELA_API$upstream_http_location';
-        
         proxy_pass $saved_redirect_location;
     }
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -40,7 +40,7 @@ server {
     }
 
     location @handle_redirects {
-        # add upstream redirect path to $VELA_API 
+        # set proxy_pass to VELA_API + upstream location
         set $saved_redirect_location '$VELA_API$upstream_http_location';
         proxy_pass $saved_redirect_location;
     }

--- a/nginx/local.conf
+++ b/nginx/local.conf
@@ -19,7 +19,8 @@ server {
 
     # proxy to backend server to allow using CLI w/ UI url
     location ~ ^/(login|authenticate|api/v[0-9]+/) {
-        proxy_pass http://server:8080;
+
+        proxy_pass 'http://server:8080';
 
         recursive_error_pages on;
         proxy_intercept_errors on;
@@ -38,7 +39,9 @@ server {
     }
 
     location @handle_redirects {
-        set $saved_redirect_location '$upstream_http_location';
+
+        set $saved_redirect_location 'http://server:8080$upstream_http_location';
+
         proxy_pass $saved_redirect_location;
     }
 

--- a/nginx/local.conf
+++ b/nginx/local.conf
@@ -38,7 +38,7 @@ server {
     }
 
     location @handle_redirects {
-        # set proxy_pass to the upstream address 
+        # set proxy_pass to http:// + upstream_addr + upstream_http_location
         set $saved_redirect_location 'http://$upstream_addr$upstream_http_location';
         proxy_pass $saved_redirect_location;
     }

--- a/nginx/local.conf
+++ b/nginx/local.conf
@@ -19,8 +19,7 @@ server {
 
     # proxy to backend server to allow using CLI w/ UI url
     location ~ ^/(login|authenticate|api/v[0-9]+/) {
-
-        proxy_pass 'http://server:8080';
+        proxy_pass http://server:8080;
 
         recursive_error_pages on;
         proxy_intercept_errors on;
@@ -39,9 +38,7 @@ server {
     }
 
     location @handle_redirects {
-
         set $saved_redirect_location 'http://server:8080$upstream_http_location';
-
         proxy_pass $saved_redirect_location;
     }
 

--- a/nginx/local.conf
+++ b/nginx/local.conf
@@ -38,7 +38,7 @@ server {
     }
 
     location @handle_redirects {
-        set $saved_redirect_location 'http://server:8080$upstream_http_location';
+        set $saved_redirect_location '$scheme://$upstream_addr$upstream_http_location';
         proxy_pass $saved_redirect_location;
     }
 

--- a/nginx/local.conf
+++ b/nginx/local.conf
@@ -35,12 +35,16 @@ server {
         proxy_set_header X-Forwarded-Proto  $scheme;
         proxy_set_header X-Forwarded-Host   $host;
         proxy_set_header X-Forwarded-Port   $server_port;
+
     }
 
     location @handle_redirects {
-        set $saved_redirect_location '$scheme://$upstream_addr$upstream_http_location';
+        # add upstream redirect path to http://server:8080 
+        set $saved_redirect_location 'http://server:8080$upstream_http_location';
+        
         proxy_pass $saved_redirect_location;
     }
+
 
     # deny acccess to . files
     location ~ /\.(?!well-known) {

--- a/nginx/local.conf
+++ b/nginx/local.conf
@@ -35,16 +35,13 @@ server {
         proxy_set_header X-Forwarded-Proto  $scheme;
         proxy_set_header X-Forwarded-Host   $host;
         proxy_set_header X-Forwarded-Port   $server_port;
-
     }
 
     location @handle_redirects {
         # add upstream redirect path to http://server:8080 
         set $saved_redirect_location 'http://server:8080$upstream_http_location';
-        
         proxy_pass $saved_redirect_location;
     }
-
 
     # deny acccess to . files
     location ~ /\.(?!well-known) {

--- a/nginx/local.conf
+++ b/nginx/local.conf
@@ -38,8 +38,8 @@ server {
     }
 
     location @handle_redirects {
-        # add upstream redirect path to http://server:8080 
-        set $saved_redirect_location 'http://server:8080$upstream_http_location';
+        # set proxy_pass to the upstream address 
+        set $saved_redirect_location 'http://$upstream_addr$upstream_http_location';
         proxy_pass $saved_redirect_location;
     }
 


### PR DESCRIPTION
this proposes a potential fix for `invalid URL prefix error` and the Caddy v2 infinite redirect loop issue
```
2021/02/09 18:40:28 [error] 11#11: *7 invalid URL prefix in "/authenticate?redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fauthenticate%2Fcli%2F53958" while sending to client, client: 172.30.0.1, server: vela, request: "GET /login?port=53958&type=cli HTTP/1.1", host: "localhost:8888"
```

requires revert of https://github.com/go-vela/ui/pull/316 from caddy back to nginx