### PR TITLE
fix(api): update cancel response to build

### DIFF
--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -325,14 +325,14 @@ put api endpoint body decoder =
 
 {-| delete : creates a DELETE request configuration
 -}
-delete : String -> Endpoint -> Request String
-delete api endpoint =
+delete : String -> Endpoint -> Decoder b -> Request b
+delete api endpoint decoder =
     request
         { method = "DELETE"
         , headers = []
         , url = Endpoint.toUrl api endpoint
         , body = Http.emptyBody
-        , decoder = Json.Decode.string
+        , decoder = decoder
         }
 
 
@@ -465,7 +465,7 @@ getSourceRepositories model =
 -}
 deleteRepo : PartialModel a -> Repository -> Request String
 deleteRepo model repository =
-    delete model.velaAPI (Endpoint.Repository repository.org repository.name)
+    delete model.velaAPI (Endpoint.Repository repository.org repository.name) Json.Decode.string
         |> withAuth model.session
 
 
@@ -535,9 +535,9 @@ restartBuild model org repository buildNumber =
 
 {-| cancelBuild : cancels a build
 -}
-cancelBuild : PartialModel a -> Org -> Repo -> BuildNumber -> Request String
+cancelBuild : PartialModel a -> Org -> Repo -> BuildNumber -> Request Build
 cancelBuild model org repository buildNumber =
-    delete model.velaAPI (Endpoint.CancelBuild org repository buildNumber)
+    delete model.velaAPI (Endpoint.CancelBuild org repository buildNumber) decodeBuild
         |> withAuth model.session
 
 
@@ -645,5 +645,5 @@ addSecret model engine type_ org key body =
 -}
 deleteSecret : PartialModel a -> Engine -> Type -> Org -> Key -> Name -> Request String
 deleteSecret model engine type_ org key name =
-    delete model.velaAPI (Endpoint.Secret engine type_ org key name)
+    delete model.velaAPI (Endpoint.Secret engine type_ org key name) Json.Decode.string
         |> withAuth model.session


### PR DESCRIPTION
updating to match
https://github.com/go-vela/worker/pull/152

non-breaking but fixes ugly alert and uses canceled build to update the build if the user is actively viewing it

#### before
![Screen Shot 2021-02-11 at 2 31 21 PM](https://user-images.githubusercontent.com/48764154/107695193-dc6c7180-6c75-11eb-8e72-f02ee40b5c2e.png)

#### after
![Screen Shot 2021-02-11 at 2 30 06 PM](https://user-images.githubusercontent.com/48764154/107695207-e2625280-6c75-11eb-891b-674498b4ba28.png)
