### PR TITLE
fix(repo): fixes error for non admin repo visitors

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2665,7 +2665,7 @@ loadRepoSubPage model org repo toPage =
                             fetchSecrets o r
 
                         _ ->
-                            fetchSecrets org repo
+                            Cmd.none
                     ]
                 )
 


### PR DESCRIPTION
do not pre-load secrets unless visiting the tab explicitly

fixes: https://github.com/go-vela/community/issues/206