### PR TITLE
ci(Makefile): remove pull target from up target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ restart: down up ## Restart the local docker-compose stack
 #
 # Usage: `make up`
 .PHONY: up
-up: pull build compose-up ## Create the local docker-compose stack
+up: build compose-up ## Create the local docker-compose stack
 
 # The `up-prod` target is intended to create
 # the local Docker compose stack with the UI compiled


### PR DESCRIPTION
This modifies the `make up` target to no longer run the `make pull` target.

> NOTE: The `make pull` target still exists, but it will no longer be executed when invoking `make up`.

Last year, Docker introduced rate limiting when pulling images as an unauthenticated user:

https://www.docker.com/increase-rate-limits

The impact is that you can actually hit the rate limit from Docker if you are doing a fair amount of local development where you are running `make restart` and/or `make up`, which starts the Vela stack via `docker-compose`, in those efforts.

I personally, have only experienced this a handful of times, but I still feel it warrants reducing the potential to run into this.

The end idea being that the user who is running the Vela stack locally will be responsible for pulling the images themselves.

It's worth mentioning that compose will already pull the Docker images on your behalf if they aren't cached locally.