### PR TITLE
fix(cancel): add cancel button to all build resources

### DIFF
--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -149,10 +149,16 @@ navButtons model { fetchSourceRepos, toggleFavorite, restartBuild, cancelBuild }
                 ]
 
         Pages.BuildServices org repo _ _ ->
-            restartBuildButton org repo model.repo.build.build restartBuild
+            div [ class "buttons" ]
+                [ cancelBuildButton org repo model.repo.build.build cancelBuild
+                , restartBuildButton org repo model.repo.build.build restartBuild
+                ]
 
         Pages.BuildPipeline org repo _ _ _ _ ->
-            restartBuildButton org repo model.repo.build.build restartBuild
+            div [ class "buttons" ]
+                [ cancelBuildButton org repo model.repo.build.build cancelBuild
+                , restartBuildButton org repo model.repo.build.build restartBuild
+                ]
 
         Pages.Hooks org repo _ _ ->
             starToggle org repo toggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo


### PR DESCRIPTION
the cancel button only renders on the build steps tab.

this fix adds the button to the pipeline and services tabs.