### PR TITLE
chore: tweak renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["local>go-vela/renovate-config"],
   "packageRules": [
     {
-      "excludePackageNames": ["nightly\\.\\d$"]
+      "excludePackageNames": ["nightly\\.\\d+$"]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>go-vela/renovate-config"]
+  "extends": ["local>go-vela/renovate-config"],
+  "packageRules": [
+    {
+      "excludePackageNames": ["nightly\\.\\d$"]
+    }
+  ]
 }


### PR DESCRIPTION
Tweaking renovate config to avoid getting PRs for "nightly" releases. We did it once to get away from Parcel 1 and have since switched to the beta branch. Will try to stay there until next beta and/or full release of Parcel 2.