### PR TITLE
chore: bump nginx to 1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fholzer/nginx-brotli
+FROM fholzer/nginx-brotli:v1.19.1
 
 RUN apk update && \
     apk add --no-cache ca-certificates && \


### PR DESCRIPTION
Pinning to specific version of the nginx image and with that updating from Nginx `1.18.0` to `1.19.1` to be on latest.

This should mitigate: https://vuldb.com/?id.155282#:~:text=NGINX%20through%201.18.,since%2004%2F28%2F2020