### PR TITLE
chore(renovate): tweak config .. one more time

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "extends": ["local>go-vela/renovate-config"],
   "packageRules": [
     {
-      "excludePackagePatterns": ["nightly\\.\\d+$"]
+      "matchPackagePatterns": "^@?parcel",
+      "allowedVersions": "!/nightly\\.\\d+$/"
     }
   ]
 }


### PR DESCRIPTION
ok, different approach to ignore `nightly` package PRs. see the following for references:
- https://docs.renovatebot.com/configuration-options/#matchpackagepatterns
- https://docs.renovatebot.com/configuration-options/#allowedversions