### PR TITLE
fix: adding default for 0 timestamps in tooltip

### DIFF
--- a/src/elm/Pages/Build/History.elm
+++ b/src/elm/Pages/Build/History.elm
@@ -135,23 +135,14 @@ recentBuildTooltip now timezone build =
                 [ span [ class "number" ] [ text <| String.fromInt build.number ]
                 , em [] [ text build.event ]
                 ]
-            , viewTooltipField "started:" <| humanReadableWithDefault timezone build.started
-            , viewTooltipField "finished:" <| humanReadableWithDefault timezone build.finished
+            , viewTooltipField "started:" <| Util.humanReadableWithDefault timezone build.started
+            , viewTooltipField "finished:" <| Util.humanReadableWithDefault timezone build.finished
             , viewTooltipField "duration:" <| Util.formatRunTime now build.started build.finished
             , viewTooltipField "worker:" build.host
             , viewTooltipField "commit:" <| Util.trimCommitHash build.commit
             , viewTooltipField "branch:" build.branch
             ]
         ]
-
-
-humanReadableWithDefault : Zone -> Int -> String
-humanReadableWithDefault timezone t =
-    if t == 0 then
-        "-"
-
-    else
-        Util.dateToHumanReadable timezone t
 
 
 {-| viewTooltipField : takes build field key and value, renders field in the tooltip

--- a/src/elm/Pages/Build/History.elm
+++ b/src/elm/Pages/Build/History.elm
@@ -135,14 +135,23 @@ recentBuildTooltip now timezone build =
                 [ span [ class "number" ] [ text <| String.fromInt build.number ]
                 , em [] [ text build.event ]
                 ]
-            , viewTooltipField "started:" <| Util.dateToHumanReadable timezone build.started
-            , viewTooltipField "finished:" <| Util.dateToHumanReadable timezone build.finished
+            , viewTooltipField "started:" <| humanReadableWithDefault timezone build.started
+            , viewTooltipField "finished:" <| humanReadableWithDefault timezone build.finished
             , viewTooltipField "duration:" <| Util.formatRunTime now build.started build.finished
             , viewTooltipField "worker:" build.host
             , viewTooltipField "commit:" <| Util.trimCommitHash build.commit
             , viewTooltipField "branch:" build.branch
             ]
         ]
+
+
+humanReadableWithDefault : Zone -> Int -> String
+humanReadableWithDefault timezone t =
+    if t == 0 then
+        "-"
+
+    else
+        Util.dateToHumanReadable timezone t
 
 
 {-| viewTooltipField : takes build field key and value, renders field in the tooltip

--- a/src/elm/Util.elm
+++ b/src/elm/Util.elm
@@ -19,6 +19,7 @@ module Util exposing
     , formatRunTime
     , formatTestTag
     , humanReadableDateTimeFormatter
+    , humanReadableWithDefault
     , isLoading
     , isSuccess
     , largeLoader
@@ -82,6 +83,17 @@ millisToSeconds millis =
 dateToHumanReadable : Zone -> Int -> String
 dateToHumanReadable timezone time =
     humanReadableDateFormatter timezone <| Time.millisToPosix <| secondsToMillis time
+
+
+{-| humanReadableWithDefault : takes timezone and posix timestamp and returns human readable date string with a default value for 0
+-}
+humanReadableWithDefault : Zone -> Int -> String
+humanReadableWithDefault timezone t =
+    if t == 0 then
+        "-"
+
+    else
+        dateToHumanReadable timezone t
 
 
 {-| humanReadableDateFormatter : formats a zone and date into human readable chunks


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/244

### running build

![Screen Shot 2021-04-28 at 1 55 14 PM](https://user-images.githubusercontent.com/48764154/116457924-9d3bce80-a829-11eb-82c6-b4b453e1ae9c.png)

### pending build

![Screen Shot 2021-04-28 at 1 55 24 PM](https://user-images.githubusercontent.com/48764154/116457925-9dd46500-a829-11eb-962c-96df505923e3.png)
