### PR TITLE
fix: right align long tooltip fields

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       QUEUE_ADDR: 'redis://redis:6379'
       QUEUE_ROUTES: 'docker,local,docker:local'
       SOURCE_DRIVER: github
+      SOURCE_ADDR: https://git.target.com
       SOURCE_CONTEXT: 'continuous-integration/vela'
       SECRET_VAULT: 'true'
       SECRET_VAULT_ADDR: 'http://vault:8200'
@@ -51,8 +52,8 @@ services:
       VELA_DATABASE_ENCRYPTION_KEY: 'C639A572E14D5075C526FDDD43E4ECF6'
       VELA_LOG_LEVEL: trace
       VELA_SECRET: 'zB7mrKDTZqNeNTD8z47yG4DHywspAh'
-      VELA_REFRESH_TOKEN_DURATION: 5m
-      VELA_ACCESS_TOKEN_DURATION: 1m
+      VELA_REFRESH_TOKEN_DURATION: 9999m
+      VELA_ACCESS_TOKEN_DURATION: 999m
       VELA_DISABLE_WEBHOOK_VALIDATION: 'true'
       VELA_ENABLE_SECURE_COOKIE: 'false'
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       QUEUE_ADDR: 'redis://redis:6379'
       QUEUE_ROUTES: 'docker,local,docker:local'
       SOURCE_DRIVER: github
-      SOURCE_ADDR: https://git.target.com
       SOURCE_CONTEXT: 'continuous-integration/vela'
       SECRET_VAULT: 'true'
       SECRET_VAULT_ADDR: 'http://vault:8200'
@@ -52,8 +51,8 @@ services:
       VELA_DATABASE_ENCRYPTION_KEY: 'C639A572E14D5075C526FDDD43E4ECF6'
       VELA_LOG_LEVEL: trace
       VELA_SECRET: 'zB7mrKDTZqNeNTD8z47yG4DHywspAh'
-      VELA_REFRESH_TOKEN_DURATION: 9999m
-      VELA_ACCESS_TOKEN_DURATION: 999m
+      VELA_REFRESH_TOKEN_DURATION: 5m
+      VELA_ACCESS_TOKEN_DURATION: 1m
       VELA_DISABLE_WEBHOOK_VALIDATION: 'true'
       VELA_ENABLE_SECURE_COOKIE: 'false'
     env_file:

--- a/src/elm/Pages/Build/History.elm
+++ b/src/elm/Pages/Build/History.elm
@@ -149,4 +149,7 @@ recentBuildTooltip now timezone build =
 -}
 viewTooltipField : String -> String -> Html msg
 viewTooltipField key value =
-    li [ class "line" ] [ span [] [ text key ], text value ]
+    li [ class "line" ]
+        [ span [] [ text key ]
+        , span [] [ text value ]
+        ]

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -753,6 +753,10 @@ nav {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+
+  span:last-child {
+    text-align: right;
+  }
 }
 
 .recent-build-tooltip .number {


### PR DESCRIPTION
worker names are getting longer, right align tooltip fields

### before

![Screen Shot 2021-04-28 at 2 26 13 PM](https://user-images.githubusercontent.com/48764154/116461387-cf4f2f80-a82d-11eb-88ef-16f146544d12.png)

### after

![Screen Shot 2021-04-28 at 2 25 22 PM](https://user-images.githubusercontent.com/48764154/116461396-d1b18980-a82d-11eb-8b08-5b0b5631ba73.png)
