### PR TITLE
fix: update github spelling

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2328,7 +2328,7 @@ viewLogin =
                 |> FeatherIcons.toHtml [ attribute "aria-hidden" "true" ]
             , text "GitHub"
             ]
-        , p [] [ text "You will be taken to Github to authenticate." ]
+        , p [] [ text "You will be taken to GitHub to authenticate." ]
         ]
 
 

--- a/src/elm/Pages/SourceRepos.elm
+++ b/src/elm/Pages/SourceRepos.elm
@@ -103,7 +103,7 @@ view model actions =
                     ]
                 , p []
                     [ text <|
-                        "Hang tight while we grab the list of repositories that you have access to from Github. If you have access to a lot of organizations and repositories this might take a little while."
+                        "Hang tight while we grab the list of repositories that you have access to from GitHub. If you have access to a lot of organizations and repositories this might take a little while."
                     ]
                 ]
     in


### PR DESCRIPTION
PR Includes the following changes:

* Update spelling from `Github` to `GitHub` on auth page
* Update spelling from `Github` to `GitHub` on source repos page

_Note: updating for consistency and to correct GitHub proper capitalization_