### PR TITLE
fix(form): fix overlap in non-stack scenario

### DIFF
--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -76,10 +76,14 @@
 
   &.-stack {
     flex-flow: row wrap;
+
+    .form-label {
+      flex: 1 0 100%;
+    }
   }
 
-  .form-label {
-    flex: 1 0 100%;
+  &.-no-overflow {
+    overflow: hidden;
   }
 }
 

--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -81,10 +81,6 @@
       flex: 1 0 100%;
     }
   }
-
-  &.-no-overflow {
-    overflow: hidden;
-  }
 }
 
 // radio & checkbox


### PR DESCRIPTION
fixes an issue with form label overflowing onto buttons making the buttons less accessible, kinda like..

```
+----form-control------+ +----<button>----+
| +-----------+ +------|-|----------------|---+
| |  <input>  | |        <label>          |   |
| +-----------+ +------|-|----------------|---+
+----------------------+ +----------------+
```
(not scaled to size)

it only allowed interactivity at the top and bottom of the button. 

the issue was observed in Firefox v89 on the Repo Settings page, specifically the Build Timeout setting.