### PR TITLE
feat: add allow_command radio buttons to Secrets UI

### DIFF
--- a/src/elm/Pages/Secrets/Form.elm
+++ b/src/elm/Pages/Secrets/Form.elm
@@ -244,18 +244,18 @@ radio value field title msg =
 -}
 viewAllowCommandCheckbox : SecretForm -> Html Msg
 viewAllowCommandCheckbox secretUpdate =
-    section [ class "type", Util.testAttribute "" ]
-        [ h4 [ class "field-header" ]
-            [ text "Allow Commands"
+    section [ Util.testAttribute "" ]
+        [ div [ class "form-control" ]
+            [ strong [] [ text "Allow Commands"
             , span [ class "field-description" ]
                 [ text "( "
                 , em [] [ text "\"No\" will disable this secret in " ]
                 , code [] [ text "commands" ]
                 , text " )"
                 ]
-            ]
+            ]]
         , div
-            [ class "form-controls", class "-row" ]
+            [ class "form-controls", class "-stack" ]
             [ radio (Util.boolToYesNo secretUpdate.allowCommand) "yes" "Yes" <| OnChangeAllowCommand "yes"
             , radio (Util.boolToYesNo secretUpdate.allowCommand) "no" "No" <| OnChangeAllowCommand "no"
             ]

--- a/src/elm/Pages/Secrets/Form.elm
+++ b/src/elm/Pages/Secrets/Form.elm
@@ -5,7 +5,8 @@ Use of this source code is governed by the LICENSE file in this repository.
 
 
 module Pages.Secrets.Form exposing
-    ( viewEventsSelect
+    ( viewAllowCommandCheckbox
+    , viewEventsSelect
     , viewHelp
     , viewImagesInput
     , viewNameInput
@@ -21,6 +22,7 @@ import Html
         , code
         , div
         , em
+        , h4
         , input
         , label
         , section
@@ -31,13 +33,15 @@ import Html
         )
 import Html.Attributes
     exposing
-        ( class
+        ( checked
+        , class
         , disabled
         , for
         , href
         , id
         , placeholder
         , rows
+        , type_
         , value
         , wrap
         )
@@ -45,6 +49,7 @@ import Html.Events exposing (onClick, onInput)
 import Pages.RepoSettings exposing (checkbox)
 import Pages.Secrets.Model exposing (DeleteSecretState(..), Model, Msg(..), SecretForm)
 import Util
+import Vela exposing (Field)
 
 
 {-| viewAddedImages : renders added images
@@ -216,6 +221,44 @@ viewImagesInput secret imageInput =
                 ]
             ]
         , div [ class "images" ] <| viewAddedImages secret.images
+        ]
+
+
+{-| radio : takes current value, field id, title for label, and click action and renders an input radio.
+-}
+radio : String -> String -> Field -> msg -> Html msg
+radio value field title msg =
+    div [ class "form-control", Util.testAttribute <| "secret-radio-" ++ field ]
+        [ input
+            [ type_ "radio"
+            , id <| "radio-" ++ field
+            , checked (value == field)
+            , onClick msg
+            ]
+            []
+        , label [ class "form-label", for <| "radio-" ++ field ] [ strong [] [ text title ] ]
+        ]
+
+
+{-| allowCommandCheckbox : renders checkbox inputs for selecting allowcommand
+-}
+viewAllowCommandCheckbox : SecretForm -> Html Msg
+viewAllowCommandCheckbox secretUpdate =
+    section [ class "type", Util.testAttribute "" ]
+        [ h4 [ class "field-header" ]
+            [ text "Allow Commands"
+            , span [ class "field-description" ]
+                [ text "( "
+                , em [] [ text "\"No\" will disable this secret in " ]
+                , code [] [ text "commands" ]
+                , text " )"
+                ]
+            ]
+        , div
+            [ class "form-controls", class "-row" ]
+            [ radio (Util.boolToYesNo secretUpdate.allowCommand) "yes" "Yes" <| OnChangeAllowCommand "yes"
+            , radio (Util.boolToYesNo secretUpdate.allowCommand) "no" "No" <| OnChangeAllowCommand "no"
+            ]
         ]
 
 

--- a/src/elm/Pages/Secrets/Form.elm
+++ b/src/elm/Pages/Secrets/Form.elm
@@ -246,14 +246,16 @@ viewAllowCommandCheckbox : SecretForm -> Html Msg
 viewAllowCommandCheckbox secretUpdate =
     section [ Util.testAttribute "" ]
         [ div [ class "form-control" ]
-            [ strong [] [ text "Allow Commands"
-            , span [ class "field-description" ]
-                [ text "( "
-                , em [] [ text "\"No\" will disable this secret in " ]
-                , code [] [ text "commands" ]
-                , text " )"
+            [ strong []
+                [ text "Allow Commands"
+                , span [ class "field-description" ]
+                    [ text "( "
+                    , em [] [ text "\"No\" will disable this secret in " ]
+                    , code [] [ text "commands" ]
+                    , text " )"
+                    ]
                 ]
-            ]]
+            ]
         , div
             [ class "form-controls", class "-stack" ]
             [ radio (Util.boolToYesNo secretUpdate.allowCommand) "yes" "Yes" <| OnChangeAllowCommand "yes"

--- a/src/elm/Pages/Secrets/Update.elm
+++ b/src/elm/Pages/Secrets/Update.elm
@@ -275,7 +275,7 @@ toAddSecretPayload secretsModel secret =
         (stringToMaybe secret.value)
         (Just secret.events)
         (Just secret.images)
-        Nothing
+        (Just secret.allowCommand)
 
 
 {-| toUpdateSecretPayload : builds payload for updating secret

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -29,7 +29,8 @@ import Html.Attributes
 import Html.Events exposing (onClick)
 import Pages.Secrets.Form
     exposing
-        ( viewEventsSelect
+        ( viewAllowCommandCheckbox
+        , viewEventsSelect
         , viewHelp
         , viewImagesInput
         , viewNameInput
@@ -385,6 +386,7 @@ addForm secretsModel =
         , viewValueInput secretUpdate.value "Secret Value"
         , viewEventsSelect secretUpdate
         , viewImagesInput secretUpdate secretUpdate.imageInput
+        , viewAllowCommandCheckbox secretUpdate
         , viewHelp
         , div [ class "form-action" ]
             [ button [ class "button", class "-outline", onClick <| Pages.Secrets.Model.AddSecret secretsModel.engine ] [ text "Add" ]
@@ -444,8 +446,7 @@ editForm secretsModel =
         , viewValueInput secretUpdate.value "Secret Value (leave blank to make no change)"
         , viewEventsSelect secretUpdate
         , viewImagesInput secretUpdate secretUpdate.imageInput
-
-        -- , allowCommandCheckbox secretUpdate
+        , viewAllowCommandCheckbox secretUpdate
         , viewHelp
         , viewSubmitButtons secretsModel
         ]


### PR DESCRIPTION
Related Issue: https://github.com/go-vela/community/issues/87

Added radio to select if secret should be allowed in commands.

Interestingly I found most of this code in another commit: https://github.com/go-vela/ui/commit/ea4e8056f40ee537c152add529d45d4ead22a931#diff-ebc97117a8ca6bd59c6e215aef88e99ca9daef03682fbab29858ece410e754c3R237-R256

The code from the commit above only worked for update, not for adding a secret. I was able to tweak it to work in both scenarios.

