### PR TITLE
fix: changes org page title to org name - Vela

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2278,7 +2278,7 @@ viewContent model =
             )
 
         Pages.OrgRepositories org ->
-            ( "Org Repositories"
+            ( org
             , lazy2 Pages.Organization.viewOrgRepos org model.repo.orgRepos
             )
 


### PR DESCRIPTION
closes [#358](https://github.com/go-vela/community/issues/358)


Example: (`MatthewFevold` is my org)

<img width="400" alt="Screen Shot 2021-08-10 at 2 00 12 PM" src="https://user-images.githubusercontent.com/15000375/128919524-7a4392e6-c92c-484b-af5d-f4b89a45685d.png">
