### PR TITLE
test: github actions

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -5,6 +5,8 @@
 
 vela ui
 
+foobar
+
 > Vela is in active development and is a pre-release product.
 >
 > Feel free to send us feedback at https://github.com/go-vela/community/issues/new.


### PR DESCRIPTION
@wass3r was able to figure out that Actions is fine

But it appears the label we're pinning to for Ubuntu hosts isn't working:

https://github.com/go-vela/ui/runs/3679654532?check_suite_focus=true

> Can't find any online and idle self-hosted runner in the current repository, account/organization and enterprise that matches the required labels: 'ubuntu-16.04'
Waiting for a self-hosted runner to pickup this job...