### PR TITLE
feat: improve build summary

### DIFF
--- a/src/elm/Pages/Build/History.elm
+++ b/src/elm/Pages/Build/History.elm
@@ -7,7 +7,7 @@ import RemoteData
 import Routes
 import SvgBuilder exposing (recentBuildStatusToIcon)
 import Time exposing (Posix, Zone)
-import Util exposing (getNameFromRef)
+import Util
 import Vela exposing (Build, Org, Repo, RepoModel)
 
 
@@ -151,10 +151,10 @@ buildInfo : Build -> Html msg
 buildInfo build =
     case build.event of
         "pull_request" ->
-            viewTooltipField "PR" ("#" ++ getNameFromRef build.ref ++ " " ++ build.message)
+            viewTooltipField "PR" ("#" ++ Util.getNameFromRef build.ref ++ " " ++ build.message)
 
         "tag" ->
-            viewTooltipField "Tag" (getNameFromRef build.ref)
+            viewTooltipField "Tag" (Util.getNameFromRef build.ref)
 
         _ ->
             viewTooltipField "" ""

--- a/src/elm/Pages/Build/History.elm
+++ b/src/elm/Pages/Build/History.elm
@@ -7,7 +7,7 @@ import RemoteData
 import Routes
 import SvgBuilder exposing (recentBuildStatusToIcon)
 import Time exposing (Posix, Zone)
-import Util
+import Util exposing (getNameFromRef)
 import Vela exposing (Build, Org, Repo, RepoModel)
 
 
@@ -135,14 +135,29 @@ recentBuildTooltip now timezone build =
                 [ span [ class "number" ] [ text <| String.fromInt build.number ]
                 , em [] [ text build.event ]
                 ]
+            , buildInfo build
             , viewTooltipField "started:" <| Util.humanReadableWithDefault timezone build.started
             , viewTooltipField "finished:" <| Util.humanReadableWithDefault timezone build.finished
             , viewTooltipField "duration:" <| Util.formatRunTime now build.started build.finished
             , viewTooltipField "worker:" build.host
+            , viewTooltipField "author:" build.author
             , viewTooltipField "commit:" <| Util.trimCommitHash build.commit
             , viewTooltipField "branch:" build.branch
             ]
         ]
+
+
+buildInfo : Build -> Html msg
+buildInfo build =
+    case build.event of
+        "pull_request" ->
+            viewTooltipField "PR" ("#" ++ getNameFromRef build.ref ++ " " ++ build.message)
+
+        "tag" ->
+            viewTooltipField "Tag" (getNameFromRef build.ref)
+
+        _ ->
+            viewTooltipField "" ""
 
 
 {-| viewTooltipField : takes build field key and value, renders field in the tooltip


### PR DESCRIPTION
Related Issue: https://github.com/go-vela/community/issues/310

Add PR # + Description, and Tag # along with author to history hover card.
This is more inline with the details available on the list of builds screen.

<img width="362" alt="Screen Shot 2021-10-01 at 8 51 29 AM" src="https://user-images.githubusercontent.com/1265665/135632463-ced7180c-4c0f-4395-8656-afe36b770c63.png">
<img width="339" alt="Screen Shot 2021-10-01 at 8 51 16 AM" src="https://user-images.githubusercontent.com/1265665/135632465-86f5a7f8-b09b-44d5-a207-97ef240e8991.png">
