### PR TITLE
fix: prevent actions overlap

### DIFF
--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -325,9 +325,7 @@ details.build-toggle {
   position: absolute;
   top: 1em;
   right: 1em;
-  z-index: 9999;
 
-  -webkit-flex: 0;
   flex: 0;
 }
 
@@ -337,8 +335,8 @@ details.build-toggle {
 
 .build-menu {
   position: absolute;
-  top: 0.5em;
-  right: 0;
+  top: 0.75rem;
+  right: 0.25rem;
 
   width: max-content;
   min-width: 100%;


### PR DESCRIPTION
fixes an issue with the actions menu overlapping on top of the notifications toast messages.

Before:
![image](https://user-images.githubusercontent.com/1301201/136852791-381f9ba0-cad0-499e-93d4-2e4fe67c5893.png)

After:
![image](https://user-images.githubusercontent.com/1301201/136853009-a7a6b255-d8cb-429d-8f2d-1faf706c5ed5.png)

close https://github.com/go-vela/community/issues/404
