### PR TITLE
fix(deployment): use correct update function

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1486,7 +1486,7 @@ update msg model =
                     )
 
                 Err error ->
-                    ( { model | repo = updateDeployments (toFailure error) rm }, addError error )
+                    ( model, addError error )
 
         StepsResponse org repo buildNumber logFocus refresh response ->
             case response of


### PR DESCRIPTION
fixes an issue where a failure to load deployments would update the error state of builds instead of deployments causing a error message on the builds tab before the automatic refresh loads in the builds correctly.

also limits loading to when you are on the deployments tab.