### PR TITLE
fix: repo updated response overwriting repo model

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1313,7 +1313,7 @@ update msg model =
                         |> Alerting.addToast Alerts.successConfig AlertsUpdate (Alerts.Success "Success" (Pages.RepoSettings.alert field updatedRepo) Nothing)
 
                 Err error ->
-                    ( { model | repo = updateRepo (toFailure error) rm }, addError error )
+                    ( model, addError error )
 
         RepoChownedResponse repo response ->
             case response of


### PR DESCRIPTION
fixes a ux headache where a non-admin that makes a repo update gets a page error, when they should just receive a notification tray error.