### PR TITLE
feat: Add link to the org page from home page

### DIFF
--- a/src/elm/Pages/Home.elm
+++ b/src/elm/Pages/Home.elm
@@ -163,7 +163,7 @@ viewOrg : String -> ToggleFavorite msg -> Favorites -> Html msg
 viewOrg org toggleFavorite favorites =
     details [ class "details", class "-with-border", attribute "open" "open", Util.testAttribute "repo-org" ]
         (summary [ class "summary" ]
-            [ text org
+            [ a [ Routes.href <| Routes.OrgRepositories org Nothing Nothing ] [ text org ]
             , FeatherIcons.chevronDown |> FeatherIcons.withSize 20 |> FeatherIcons.withClass "details-icon-expand" |> FeatherIcons.toHtml []
             ]
             :: List.map (viewFavorite favorites toggleFavorite False) favorites


### PR DESCRIPTION
Related Issue: closes https://github.com/go-vela/community/issues/409

<img width="1060" alt="Screen Shot 2021-10-22 at 11 08 25 AM" src="https://user-images.githubusercontent.com/1265665/138488177-6a23e0ab-5378-44b9-847f-2b2ca27b5f39.png">

Clicking the name of the Org will take the user to the org page, clicking the Chevron or anywhere else on the header will collapse / expand as it always has.