### PR TITLE
fix: local setup with server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@
 # These are used by the ui service
 # defined in the docker compose stack
 
-# customize the location where you want users to provide feedack
+# customize the location where you want users to provide feedback
 #
 # default: https://github.com/go-vela/ui/issues/new
 # VELA_FEEDBACK_URL=
@@ -22,15 +22,10 @@
 # default: https://go-vela.github.io/docs
 # VELA_DOCS_URL=
 
-# Vela api server address, typically runs on port :8080 locally.
-# Should match the "VELA_ADDR" value in docker-compose.yml
-# when running locally.
+# customize the location for the Vela server address
+#
+# Should match the "VELA_ADDR" value in docker-compose.yml when running locally.
 VELA_API=http://localhost:8080
-
-# Vela log filesize limit in bytes.
-# This value configures the upper limit on log size that the UI will attempt to render.
-# The default is 200000 (2mb).
-# VELA_LOG_BYTES_LIMIT=2000000
 
 ############################################################
 #  _______  _______  ______    __   __  _______  ______    #
@@ -49,10 +44,10 @@ VELA_API=http://localhost:8080
 # github web url (only required if using GitHub Enterprise)
 #
 # default: https://github.com
-# VELA_SOURCE_ADDR=
+# VELA_SCM_ADDR=
 
 # github client id from oauth application
-VELA_SOURCE_CLIENT=
+VELA_SCM_CLIENT=
 
 # github client secret from oauth application
-VELA_SOURCE_SECRET=
+VELA_SCM_SECRET=

--- a/DOCS.md
+++ b/DOCS.md
@@ -39,7 +39,7 @@ cd $HOME/go-vela/ui
 
 ```bash
 # add Github Enterprise Web URL to local secrets file for `docker-compose`
-echo "VELA_SOURCE_ADDR=<GitHub Enterprise Web URL>" >> .env
+echo "VELA_SCM_ADDR=<GitHub Enterprise Web URL>" >> .env
 ```
 
 * Create an [OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) and obtain secrets for local development:
@@ -51,10 +51,10 @@ echo "VELA_SOURCE_ADDR=<GitHub Enterprise Web URL>" >> .env
 
 ```bash
 # add Github Client ID to local secrets file for `docker-compose`
-echo "VELA_SOURCE_CLIENT=<Github OAuth Client ID>" >> .env
+echo "VELA_SCM_CLIENT=<Github OAuth Client ID>" >> .env
 
 # add Github Client Secret to local secrets file for `docker-compose`
-echo "VELA_SOURCE_SECRET=<Github OAuth Client Secret>" >> .env
+echo "VELA_SCM_SECRET=<Github OAuth Client Secret>" >> .env
 ```
 
 * Switch to the correct version of NodeJS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,8 @@ services:
       QUEUE_DRIVER: redis
       QUEUE_ADDR: 'redis://redis:6379'
       QUEUE_ROUTES: 'docker,local,docker:local'
-      SOURCE_DRIVER: github
-      SOURCE_CONTEXT: 'continuous-integration/vela'
+      SCM_DRIVER: github
+      SCM_CONTEXT: 'continuous-integration/vela'
       SECRET_VAULT: 'true'
       SECRET_VAULT_ADDR: 'http://vault:8200'
       SECRET_VAULT_TOKEN: vela


### PR DESCRIPTION
Related to https://github.com/go-vela/server/pull/536

This updates any references of `SOURCE_*` -> `SCM_*` based off the above change.