### PR TITLE
fix: actions menu and build animation overflow bug

### DIFF
--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -1033,7 +1033,7 @@ buildStatusStyles markdown buildStatus buildNumber =
         animation =
             case buildStatus of
                 Vela.Running ->
-                    List.append (topParticles buildNumber) (bottomParticles buildNumber)
+                    [div [ class "build-animation"] <| List.append (topParticles buildNumber) (bottomParticles buildNumber)]
 
                 _ ->
                     [ div [ class "build-animation", class "-not-running", statusToClass buildStatus ] []

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -307,8 +307,9 @@ viewPreview msgs openMenu showMenu now zone org repo build =
 
         statusClass =
             statusToClass build.status
-
-        markdown =
+    in
+    div [ class "build-container", Util.testAttribute "build" ]
+        [ div [ class "build", statusClass ]
             [ div [ class "status", Util.testAttribute "build-status", statusClass ] status
             , div [ class "info" ]
                 [ div [ class "row -left" ]
@@ -334,11 +335,8 @@ viewPreview msgs openMenu showMenu now zone org repo build =
                     [ viewError build
                     ]
                 ]
+            , buildAnimation build.status build.number
             ]
-    in
-    div [ class "build-container", Util.testAttribute "build" ]
-        [ div [ class "build", statusClass ] <|
-            buildStatusStyles markdown build.status build.number
         ]
 
 
@@ -1025,21 +1023,16 @@ statusToClass status =
             class "-error"
 
 
-{-| buildStatusStyles : takes build markdown and adds styled flair based on running status
+{-| buildAnimation : takes build markdown and adds styled flair based on running status
 -}
-buildStatusStyles : List (Html msgs) -> Status -> Int -> List (Html msgs)
-buildStatusStyles markdown buildStatus buildNumber =
-    let
-        animation =
-            case buildStatus of
-                Vela.Running ->
-                    [div [ class "build-animation"] <| List.append (topParticles buildNumber) (bottomParticles buildNumber)]
+buildAnimation : Status -> Int -> Html msgs
+buildAnimation buildStatus buildNumber =
+    case buildStatus of
+        Vela.Running ->
+            div [ class "build-animation" ] <| List.append (topParticles buildNumber) (bottomParticles buildNumber)
 
-                _ ->
-                    [ div [ class "build-animation", class "-not-running", statusToClass buildStatus ] []
-                    ]
-    in
-    markdown ++ animation
+        _ ->
+            div [ class "build-animation", class "-not-running", statusToClass buildStatus ] []
 
 
 {-| topParticles : returns an svg frame to parallax scroll on a running build, set to the top of the build

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -1023,7 +1023,7 @@ statusToClass status =
             class "-error"
 
 
-{-| buildAnimation : takes build markdown and adds styled flair based on running status
+{-| buildAnimation : takes build info and returns div containing styled flair based on running status
 -}
 buildAnimation : Status -> Int -> Html msgs
 buildAnimation buildStatus buildNumber =

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -1029,7 +1029,7 @@ buildAnimation : Status -> Int -> Html msgs
 buildAnimation buildStatus buildNumber =
     case buildStatus of
         Vela.Running ->
-            div [ class "build-animation" ] <| List.append (topParticles buildNumber) (bottomParticles buildNumber)
+            div [ class "build-animation" ] <| (topParticles buildNumber) ++ (bottomParticles buildNumber)
 
         _ ->
             div [ class "build-animation", class "-not-running", statusToClass buildStatus ] []

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -1045,7 +1045,7 @@ buildAnimation : Status -> Int -> Html msgs
 buildAnimation buildStatus buildNumber =
     case buildStatus of
         Vela.Running ->
-            div [ class "build-animation" ] <| (topParticles buildNumber) ++ (bottomParticles buildNumber)
+            div [ class "build-animation" ] <| topParticles buildNumber ++ bottomParticles buildNumber
 
         _ ->
             div [ class "build-animation", class "-not-running", statusToClass buildStatus ] []

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -332,6 +332,8 @@ details.build-toggle {
   min-width: 100%;
   padding: 0;
 
+  z-index: 9999;
+
   font-size: 80%;
 
   list-style: none;
@@ -421,7 +423,6 @@ details.build-toggle {
 .build-container {
   width: 100%;
   margin: 12px 0;
-  overflow: hidden;
 }
 
 .build-preview-error {
@@ -602,6 +603,11 @@ details.build-toggle {
   position: absolute;
 
   width: 100%;
+  height: 100%;
+  
+  overflow-x: clip;
+
+  pointer-events: none;
 }
 
 .-running-start {

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -327,12 +327,11 @@ details.build-toggle {
   position: absolute;
   top: 0.75rem;
   right: 0.25rem;
+  z-index: 9999;
 
   width: max-content;
   min-width: 100%;
   padding: 0;
-
-  z-index: 9999;
 
   font-size: 80%;
 
@@ -604,7 +603,6 @@ details.build-toggle {
 
   width: 100%;
   height: 100%;
-  
   overflow-x: clip;
 
   pointer-events: none;


### PR DESCRIPTION
adding a width/height wrapper in conjunction with `overflow-x: clip` to cause only the animation particles to get hidden when leaving the build-container

also, `z-index: 9999` on the actions menu to place it in front of the svg "particles"

### before

![Screen Shot 2021-12-07 at 11 03 35 AM](https://user-images.githubusercontent.com/48764154/147145470-40ba2256-fafb-4722-b7ad-476fcb295c78.png)

### after

![Screen Shot 2021-12-22 at 1 01 56 PM](https://user-images.githubusercontent.com/48764154/147145505-0fe29bd1-bf63-49e7-8fb3-e27cf35671ad.png)


