### PR TITLE
chore: bump elm deps

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -4,7 +4,7 @@
   "elm-version": "0.19.1",
   "dependencies": {
     "direct": {
-      "NoRedInk/elm-json-decode-pipeline": "1.0.0",
+      "NoRedInk/elm-json-decode-pipeline": "1.0.1",
       "basti1302/elm-human-readable-filesize": "1.2.0",
       "danfishgold/base64-bytes": "1.1.0",
       "elm/browser": "1.0.2",
@@ -17,9 +17,9 @@
       "elm/svg": "1.0.1",
       "elm/time": "1.0.0",
       "elm/url": "1.0.0",
-      "elm-community/list-extra": "8.3.0",
+      "elm-community/list-extra": "8.5.2",
+      "elm-community/maybe-extra": "5.3.0",
       "elm-community/string-extra": "4.0.1",
-      "elm-community/maybe-extra": "5.2.1",
       "feathericons/elm-feather": "1.5.0",
       "jackfranklin/elm-parse-link-header": "2.0.2",
       "jzxhuang/http-extras": "2.1.0",


### PR DESCRIPTION
used `npx elm-json upgrade` to bump some elm dependencies:

https://github.com/NoRedInk/elm-json-decode-pipeline/compare/1.0.0..1.0.1
https://github.com/elm-community/list-extra/compare/8.3.0..8.5.2
https://github.com/elm-community/maybe-extra/compare/5.2.1..5.3.0

see a few perf enhancements in the mix 🥳 