### PR TITLE
fix: a couple of UI fixes

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -66,7 +66,7 @@ import Html.Attributes
         , type_
         )
 import Html.Events exposing (onClick)
-import Html.Lazy exposing (lazy, lazy2, lazy3, lazy4, lazy5, lazy7, lazy8)
+import Html.Lazy exposing (lazy, lazy2, lazy3, lazy5, lazy7, lazy8)
 import Http
 import Http.Detailed
 import Interop

--- a/src/elm/Pages/Build/History.elm
+++ b/src/elm/Pages/Build/History.elm
@@ -94,9 +94,6 @@ recentBuildLink page org repo buildNumber build idx =
             if buildNumber == build.number then
                 class "-current"
 
-            else if buildNumber > build.number then
-                class "-older"
-
             else
                 class ""
     in

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -24,7 +24,7 @@ import Focus
         , resourceAndLineToFocusId
         , resourceToFocusId
         )
-import Html exposing (Html, a, button, code, details, div, li, small, span, strong, summary, table, td, text, time, tr, ul)
+import Html exposing (Html, a, button, code, details, div, li, small, span, strong, summary, table, td, text, tr, ul)
 import Html.Attributes
     exposing
         ( attribute

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -1396,9 +1396,9 @@ details.build-toggle {
 // build filters
 .build-bar {
   display: flex;
-  margin: 1rem 0;
   flex-direction: row;
   justify-content: space-between;
+  margin: 1rem 0;
 
   background-color: var(--color-bg-dark);
 }
@@ -1407,6 +1407,7 @@ details.build-toggle {
   flex-flow: wrap;
   justify-content: flex-start;
   padding: 1rem;
+
   font-size: 1rem;
 
   background-color: var(--color-bg-dark);

--- a/src/scss/_main.scss
+++ b/src/scss/_main.scss
@@ -713,7 +713,7 @@ details.build-toggle {
 
 .build-history-title {
   display: inline;
-  padding: 0.4rem 0 0.4rem 0.4rem;
+  padding: 0.4rem 0;
 
   font-size: 0.8em;
 }
@@ -735,19 +735,11 @@ details.build-toggle {
 }
 
 .recent-build-link.-current {
-  transform: translateX(5px);
-
-  transition: transform 0.1s;
-
-  will-change: transform;
+  margin: 0 0.2rem;
 }
 
-.recent-build-link.-older {
-  transform: translateX(10px);
-
-  transition: transform 0.1s;
-
-  will-change: transform;
+.recent-build:first-child .recent-build-link.-current {
+  margin: 0 0.2rem 0 0;
 }
 
 .build-history .recent-build-link .-icon {
@@ -1404,6 +1396,7 @@ details.build-toggle {
 // build filters
 .build-bar {
   display: flex;
+  margin: 1rem 0;
   flex-direction: row;
   justify-content: space-between;
 
@@ -1413,9 +1406,7 @@ details.build-toggle {
 .build-filters {
   flex-flow: wrap;
   justify-content: flex-start;
-  margin: 1rem 0;
   padding: 1rem;
-
   font-size: 1rem;
 
   background-color: var(--color-bg-dark);


### PR DESCRIPTION
The first fix is an issue introduced in v0.13.0-rc. The timestamp addition grew the filter bar vertically and started really hugging the list controls. Fix was to move margins from previous sole filter component to wrapper container that was added.

before:
![build_bar_before](https://user-images.githubusercontent.com/1301201/151742549-b54799f4-3410-45f7-93ac-4a976c9a04fa.png)
after:
![build_bar_after](https://user-images.githubusercontent.com/1301201/151742553-2113e552-7c20-4b50-ab52-c2ae9b6a6d11.png)

The second fix is for the recent build widget that has been there for a few versions. The text was not aligned on the left side - neither was the first item (if it was active). Also reduced distance between items slightly to match line weight used throughout.

before:
![recent_builds_before](https://user-images.githubusercontent.com/1301201/151743305-6070f10c-119f-4aaf-887e-1dfafe82b4bc.png)
after:
![recent_builds_after](https://user-images.githubusercontent.com/1301201/151743308-6419b467-73be-4dc9-8819-9a8129e4d761.png)

Also removing some unused imports.
