### PR TITLE
chore(node): bump node and simplify ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,9 @@ name: ci
 # trigger on pull_request or push events
 on:
   push:
-    branches:
   pull_request:
 
 env:
-  NODE_VERSION: '16.13.2'
   CI: 1
 
 # pipeline to execute
@@ -46,7 +44,7 @@ jobs:
             cypress-${{ runner.os }}-bin-v2-
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.nvmrc'
 
       - name: install dependencies
         run: npm ci --prefer-offline --no-audit
@@ -90,7 +88,7 @@ jobs:
             cypress-${{ runner.os }}-bin-v2-
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.nvmrc'
 
       - name: install dependencies
         run: npm ci --prefer-offline --no-audit
@@ -128,7 +126,7 @@ jobs:
             cypress-${{ runner.os }}-bin-v2-
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.nvmrc'
 
       - name: install dependencies
         run: npm ci --prefer-offline --no-audit
@@ -173,7 +171,7 @@ jobs:
             cypress-${{ runner.os }}-bin-v2-
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.nvmrc'
 
       - name: install dependencies
         run: npm ci --prefer-offline --no-audit
@@ -211,7 +209,7 @@ jobs:
             ${{ runner.os }}-modules-v2-
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.nvmrc'
 
       # ┌┐ ┬ ┬┬┬  ┌┬┐
       # ├┴┐│ │││   ││

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ on:
     tags:
       - 'v*'
 
-env:
-  NODE_VERSION: '16.13.2'
-
 # pipeline to execute
 jobs:
   release:
@@ -42,7 +39,7 @@ jobs:
             ${{ runner.os }}-modules-v2-
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.nvmrc'
 
       # ┌┐ ┬ ┬┬┬  ┌┬┐
       # ├┴┐│ │││   ││

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Vela UI",
   "author": "Vela Team",
   "engines": {
-    "node": ">=16.13.0"
+    "node": ">=16.14.0"
   },
   "dependencies": {
     "clipboard": "2.0.10"


### PR DESCRIPTION
bumps node version to keep in line with https://github.com/go-vela/ui/pull/511

also simplifies Github Actions flow to pull node version from nvmrc in root of project instead of defining separately in each action