### PR TITLE
feat: add key to secrets tables

### DIFF
--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -29,6 +29,7 @@ import Vela
         ( Secret
         , SecretType(..)
         , Secrets
+        , secretToKey
         , secretTypeToString
         , secretsErrorLabel
         )
@@ -256,6 +257,7 @@ secretsToRowsForSharedSecrets type_ secrets =
 tableHeaders : Table.Columns
 tableHeaders =
     [ ( Nothing, "name" )
+    , ( Nothing, "key" )
     , ( Nothing, "type" )
     , ( Nothing, "events" )
     , ( Nothing, "images" )
@@ -269,6 +271,7 @@ tableHeadersForSharedSecrets : Table.Columns
 tableHeadersForSharedSecrets =
     [ ( Nothing, "name" )
     , ( Nothing, "team" )
+    , ( Nothing, "key" )
     , ( Nothing, "type" )
     , ( Nothing, "events" )
     , ( Nothing, "images" )
@@ -288,6 +291,12 @@ renderSecret type_ secret =
             , Util.testAttribute <| "secrets-row-name"
             ]
             [ a [ updateSecretHref type_ secret ] [ text secret.name ] ]
+        , td
+            [ attribute "data-label" "key"
+            , scope "row"
+            , class "break-word"
+            ]
+            [ text <| secretToKey secret ]
         , td
             [ attribute "data-label" "type"
             , scope "row"
@@ -336,6 +345,12 @@ renderSharedSecret type_ secret =
             , Util.testAttribute <| "secrets-row-team"
             ]
             [ a [ Routes.href <| Routes.SharedSecrets "native" (percentEncode secret.org) (percentEncode secret.team) Nothing Nothing ] [ text secret.team ] ]
+        , td
+            [ attribute "data-label" "key"
+            , scope "row"
+            , class "break-word"
+            ]
+            [ text <| secretToKey secret ]
         , td
             [ attribute "data-label" "type"
             , scope "row"

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -110,6 +110,7 @@ module Vela exposing
     , encodeUpdateSecret
     , encodeUpdateUser
     , isComplete
+    , secretToKey
     , secretTypeToString
     , secretsErrorLabel
     , statusToFavicon
@@ -1702,6 +1703,7 @@ type alias Secret =
     , org : Org
     , repo : Repo
     , team : Key
+    , key : String
     , name : String
     , type_ : SecretType
     , images : List String
@@ -1789,6 +1791,21 @@ maybeSecretTypeToMaybeString type_ =
             Nothing
 
 
+{-| secretToKey : helper to create secret key
+-}
+secretToKey : Secret -> String
+secretToKey secret =
+    case secret.type_ of
+        SharedSecret ->
+            secret.org ++ "/" ++ secret.team ++ "/" ++ secret.name
+
+        OrgSecret ->
+            secret.org ++ "/" ++ secret.name
+
+        RepoSecret ->
+            secret.org ++ "/" ++ secret.repo ++ "/" ++ secret.name
+
+
 decodeSecret : Decoder Secret
 decodeSecret =
     Decode.succeed Secret
@@ -1796,6 +1813,7 @@ decodeSecret =
         |> optional "org" string ""
         |> optional "repo" string ""
         |> optional "team" string ""
+        |> optional "key" string ""
         |> optional "name" string ""
         |> optional "type" secretTypeDecoder RepoSecret
         |> optional "images" (Decode.list string) []


### PR DESCRIPTION
This PR is for part 1 of https://github.com/go-vela/community/issues/516

Adds the key column. to repo, org, and shared secrets tables