### PR TITLE
Feat: Add ability to copy secret to clipboard

### DIFF
--- a/cypress/integration/secrets.spec.js
+++ b/cypress/integration/secrets.spec.js
@@ -85,6 +85,7 @@ context('Secrets', () => {
             .contains('repo');
         });
       });
+
     });
   });
 
@@ -164,6 +165,32 @@ context('Secrets', () => {
         cy.get('[data-test=secrets-row]').first().as('firstSecret');
         cy.get('[data-test=secrets-row]').last().as('lastSecret');
       });
+
+      it('should show copy', () => {
+        cy.get('@firstSecret').within(() => {
+          cy.get('[data-test=secrets-row-copy]').should('exist');
+        });
+        cy.get('@lastSecret').within(() => {
+          cy.get('[data-test=secrets-row-copy]').should('exist');
+        });
+      });
+
+      it('should copy secret to clipboard and alert', () => {
+        cy.get('@firstSecret').within(() => {
+          cy.get('[data-test=copy-secret]').click();
+        });
+          cy.get('[data-test=alerts]').should('exist').contains('Copied');
+      });
+
+      it('should show key', () => {
+        cy.get('@firstSecret').within(() => {
+          cy.get('[data-test=secrets-row-key]').contains('github/docker_username');
+        });
+        cy.get('@lastSecret').within(() => {
+          cy.get('[data-test=secrets-row-key]').contains('github/deployment');
+        });
+      });
+
       it('should show name', () => {
         cy.get('@firstSecret').within(() => {
           cy.get('[data-test=secrets-row-name]').contains('docker_username');
@@ -172,6 +199,7 @@ context('Secrets', () => {
           cy.get('[data-test=secrets-row-name]').contains('deployment');
         });
       });
+
       it('clicking name should route to edit secret page', () => {
         cy.get('@firstSecret').within(() => {
           cy.get('[data-test=secrets-row-name] > a').click({ force: true });
@@ -181,6 +209,7 @@ context('Secrets', () => {
           );
         });
       });
+
       it('clicking name with special character should use encoded url', () => {
         cy.get('@lastSecret').within(() => {
           cy.get('[data-test=secrets-row-name] > a').click({ force: true });

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -457,7 +457,7 @@ type Msg
     | AdjustTime Posix
     | Tick Interval Posix
       -- Components
-    | AddSecretUpdate Pages.Secrets.Model.Msg -- KM: rename these to not-add-secret
+    | SecretsUpdate Pages.Secrets.Model.Msg
     | AddDeploymentUpdate Pages.Deployments.Model.Msg
       -- Other
     | HandleError Error
@@ -1888,7 +1888,7 @@ update msg model =
                     ( model, refreshPageHidden model data )
 
         -- Components
-        AddSecretUpdate m ->
+        SecretsUpdate m ->
             let
                 ( newModel, action ) =
                     Pages.Secrets.Update.update model m
@@ -2430,56 +2430,56 @@ viewContent model =
         Pages.RepoSecrets engine org repo _ _ ->
             ( String.join "/" [ org, repo ] ++ " " ++ engine ++ " repo secrets"
             , div []
-                [ Html.map (\_ -> NoOp) <| lazy Pages.Secrets.View.viewRepoSecrets model -- KM: map all these to SecretsUpdate :/
-                , Html.map (\_ -> NoOp) <| lazy3 Pages.Secrets.View.viewOrgSecrets model True False
+                [ Html.map SecretsUpdate <| lazy Pages.Secrets.View.viewRepoSecrets model
+                , Html.map SecretsUpdate <| lazy3 Pages.Secrets.View.viewOrgSecrets model True False
                 ]
             )
 
         Pages.OrgSecrets engine org maybePage _ ->
             ( String.join "/" [ org ] ++ " " ++ engine ++ " org secrets" ++ Util.pageToString maybePage
             , div []
-                [ Html.map (\_ -> NoOp) <| lazy3 Pages.Secrets.View.viewOrgSecrets model False True
+                [ Html.map SecretsUpdate <| lazy3 Pages.Secrets.View.viewOrgSecrets model False True
                 , Pager.view model.secretsModel.orgSecretsPager Pager.prevNextLabels GotoPage
-                , Html.map (\_ -> NoOp) <| lazy3 Pages.Secrets.View.viewSharedSecrets model True False
+                , Html.map SecretsUpdate <| lazy3 Pages.Secrets.View.viewSharedSecrets model True False
                 ]
             )
 
         Pages.SharedSecrets engine org team _ _ ->
             ( String.join "/" [ org, team ] ++ " " ++ engine ++ " shared secrets"
             , div []
-                [ Html.map (\_ -> NoOp) <| lazy3 Pages.Secrets.View.viewSharedSecrets model False False -- KM: down to here
+                [ Html.map SecretsUpdate <| lazy3 Pages.Secrets.View.viewSharedSecrets model False False
                 , Pager.view model.secretsModel.sharedSecretsPager Pager.prevNextLabels GotoPage
                 ]
             )
 
         Pages.AddOrgSecret engine _ ->
             ( "add " ++ engine ++ " org secret"
-            , Html.map AddSecretUpdate <| lazy Pages.Secrets.View.addSecret model -- KM: rename these to not-add-secret
+            , Html.map SecretsUpdate <| lazy Pages.Secrets.View.addSecret model
             )
 
         Pages.AddRepoSecret engine _ _ ->
             ( "add " ++ engine ++ " repo secret"
-            , Html.map AddSecretUpdate <| lazy Pages.Secrets.View.addSecret model
+            , Html.map SecretsUpdate <| lazy Pages.Secrets.View.addSecret model
             )
 
         Pages.AddSharedSecret engine _ _ ->
             ( "add " ++ engine ++ " shared secret"
-            , Html.map AddSecretUpdate <| lazy Pages.Secrets.View.addSecret model
+            , Html.map SecretsUpdate <| lazy Pages.Secrets.View.addSecret model
             )
 
         Pages.OrgSecret engine org name ->
             ( String.join "/" [ org, name ] ++ " update " ++ engine ++ " org secret"
-            , Html.map AddSecretUpdate <| lazy Pages.Secrets.View.editSecret model
+            , Html.map SecretsUpdate <| lazy Pages.Secrets.View.editSecret model
             )
 
         Pages.RepoSecret engine org repo name ->
             ( String.join "/" [ org, repo, name ] ++ " update " ++ engine ++ " repo secret"
-            , Html.map AddSecretUpdate <| lazy Pages.Secrets.View.editSecret model
+            , Html.map SecretsUpdate <| lazy Pages.Secrets.View.editSecret model
             )
 
         Pages.SharedSecret engine org team name ->
             ( String.join "/" [ org, team, name ] ++ " update " ++ engine ++ " shared secret"
-            , Html.map AddSecretUpdate <| lazy Pages.Secrets.View.editSecret model
+            , Html.map SecretsUpdate <| lazy Pages.Secrets.View.editSecret model
             )
 
         Pages.AddDeployment org repo ->

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -4175,7 +4175,7 @@ pipelineMsgs =
 
 initSecretsModel : Pages.Secrets.Model.Model Msg
 initSecretsModel =
-    Pages.Secrets.Update.init SecretResponse RepoSecretsResponse OrgSecretsResponse SharedSecretsResponse AddSecretResponse UpdateSecretResponse DeleteSecretResponse
+    Pages.Secrets.Update.init Copy SecretResponse RepoSecretsResponse OrgSecretsResponse SharedSecretsResponse AddSecretResponse UpdateSecretResponse DeleteSecretResponse
 
 
 initDeploymentsModel : Pages.Deployments.Model.Model Msg

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -457,7 +457,7 @@ type Msg
     | AdjustTime Posix
     | Tick Interval Posix
       -- Components
-    | AddSecretUpdate Pages.Secrets.Model.Msg
+    | AddSecretUpdate Pages.Secrets.Model.Msg -- KM: rename these to not-add-secret
     | AddDeploymentUpdate Pages.Deployments.Model.Msg
       -- Other
     | HandleError Error
@@ -2430,7 +2430,7 @@ viewContent model =
         Pages.RepoSecrets engine org repo _ _ ->
             ( String.join "/" [ org, repo ] ++ " " ++ engine ++ " repo secrets"
             , div []
-                [ Html.map (\_ -> NoOp) <| lazy Pages.Secrets.View.viewRepoSecrets model
+                [ Html.map (\_ -> NoOp) <| lazy Pages.Secrets.View.viewRepoSecrets model -- KM: map all these to SecretsUpdate :/
                 , Html.map (\_ -> NoOp) <| lazy3 Pages.Secrets.View.viewOrgSecrets model True False
                 ]
             )
@@ -2447,14 +2447,14 @@ viewContent model =
         Pages.SharedSecrets engine org team _ _ ->
             ( String.join "/" [ org, team ] ++ " " ++ engine ++ " shared secrets"
             , div []
-                [ Html.map (\_ -> NoOp) <| lazy3 Pages.Secrets.View.viewSharedSecrets model False False
+                [ Html.map (\_ -> NoOp) <| lazy3 Pages.Secrets.View.viewSharedSecrets model False False -- KM: down to here
                 , Pager.view model.secretsModel.sharedSecretsPager Pager.prevNextLabels GotoPage
                 ]
             )
 
         Pages.AddOrgSecret engine _ ->
             ( "add " ++ engine ++ " org secret"
-            , Html.map AddSecretUpdate <| lazy Pages.Secrets.View.addSecret model
+            , Html.map AddSecretUpdate <| lazy Pages.Secrets.View.addSecret model -- KM: rename these to not-add-secret
             )
 
         Pages.AddRepoSecret engine _ _ ->

--- a/src/elm/Pages/Secrets/Model.elm
+++ b/src/elm/Pages/Secrets/Model.elm
@@ -24,8 +24,7 @@ import Http.Detailed
 import LinkHeader exposing (WebLink)
 import Pages exposing (Page)
 import RemoteData exposing (WebData)
-import Vela exposing (Engine, Key, Org, Repo, Secret, SecretType, Secrets, Team)
-import Vela exposing (Copy)
+import Vela exposing (Copy, Engine, Key, Org, Repo, Secret, SecretType, Secrets, Team)
 
 
 
@@ -123,7 +122,8 @@ type Msg
     | AddSecret Engine
     | UpdateSecret Engine
     | DeleteSecret Engine
-    | CancelDeleteSecret -- KM: add Copy sub Msg
+    | Copy String
+    | CancelDeleteSecret
 
 
 type DeleteSecretState

--- a/src/elm/Pages/Secrets/Model.elm
+++ b/src/elm/Pages/Secrets/Model.elm
@@ -25,6 +25,7 @@ import LinkHeader exposing (WebLink)
 import Pages exposing (Page)
 import RemoteData exposing (WebData)
 import Vela exposing (Engine, Key, Org, Repo, Secret, SecretType, Secrets, Team)
+import Vela exposing (Copy)
 
 
 
@@ -58,6 +59,7 @@ type alias Model msg =
     , sharedSecretsPager : List WebLink
     , secret : WebData Secret
     , form : SecretForm
+    , copy : Copy msg
     , secretResponse : SecretResponse msg
     , repoSecretsResponse : SecretsResponse msg
     , orgSecretsResponse : SecretsResponse msg

--- a/src/elm/Pages/Secrets/Model.elm
+++ b/src/elm/Pages/Secrets/Model.elm
@@ -123,7 +123,7 @@ type Msg
     | AddSecret Engine
     | UpdateSecret Engine
     | DeleteSecret Engine
-    | CancelDeleteSecret
+    | CancelDeleteSecret -- KM: add Copy sub Msg
 
 
 type DeleteSecretState

--- a/src/elm/Pages/Secrets/Update.elm
+++ b/src/elm/Pages/Secrets/Update.elm
@@ -434,10 +434,9 @@ update model msg =
                       }
                     , Cmd.none
                     )
-                
-                Pages.Secrets.Model.Copy str ->
-                    (secretsModel, Util.dispatch <| secretsModel.copy str)   
 
+                Pages.Secrets.Model.Copy str ->
+                    ( secretsModel, Util.dispatch <| secretsModel.copy str )
     in
     ( { model | secretsModel = sm }, action )
 

--- a/src/elm/Pages/Secrets/Update.elm
+++ b/src/elm/Pages/Secrets/Update.elm
@@ -34,14 +34,14 @@ import Routes
 import Util exposing (stringToMaybe)
 import Vela
     exposing
-        ( Secret
+        ( Copy
+        , Secret
         , SecretType(..)
         , UpdateSecretPayload
         , buildUpdateSecretPayload
         , encodeUpdateSecret
         , secretTypeToString
         )
-import Vela exposing (Copy)
 
 
 
@@ -434,7 +434,10 @@ update model msg =
                       }
                     , Cmd.none
                     )
-                    -- KM: add copy Sub Msg Util.dispatch back to Main.elm (for toasties)
+                
+                Pages.Secrets.Model.Copy str ->
+                    (secretsModel, Util.dispatch <| secretsModel.copy str)   
+
     in
     ( { model | secretsModel = sm }, action )
 

--- a/src/elm/Pages/Secrets/Update.elm
+++ b/src/elm/Pages/Secrets/Update.elm
@@ -41,6 +41,7 @@ import Vela
         , encodeUpdateSecret
         , secretTypeToString
         )
+import Vela exposing (Copy)
 
 
 
@@ -49,8 +50,8 @@ import Vela
 
 {-| init : takes msg updates from Main.elm and initializes secrets page input arguments
 -}
-init : SecretResponse msg -> SecretsResponse msg -> SecretsResponse msg -> SecretsResponse msg -> AddSecretResponse msg -> UpdateSecretResponse msg -> DeleteSecretResponse msg -> Model msg
-init secretResponse repoSecretsResponse orgSecretsResponse sharedSecretsResponse addSecretResponse updateSecretResponse deleteSecretResponse =
+init : Copy msg -> SecretResponse msg -> SecretsResponse msg -> SecretsResponse msg -> SecretsResponse msg -> AddSecretResponse msg -> UpdateSecretResponse msg -> DeleteSecretResponse msg -> Model msg
+init copy secretResponse repoSecretsResponse orgSecretsResponse sharedSecretsResponse addSecretResponse updateSecretResponse deleteSecretResponse =
     Model "native"
         ""
         ""
@@ -64,6 +65,7 @@ init secretResponse repoSecretsResponse orgSecretsResponse sharedSecretsResponse
         []
         NotAsked
         defaultSecretUpdate
+        copy
         secretResponse
         repoSecretsResponse
         orgSecretsResponse

--- a/src/elm/Pages/Secrets/Update.elm
+++ b/src/elm/Pages/Secrets/Update.elm
@@ -434,6 +434,7 @@ update model msg =
                       }
                     , Cmd.none
                     )
+                    -- KM: add copy Sub Msg Util.dispatch back to Main.elm (for toasties)
     in
     ( { model | secretsModel = sm }, action )
 

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -29,6 +29,7 @@ import Vela
         ( Secret
         , SecretType(..)
         , Secrets
+        , secretToKey
         , secretTypeToString
         , secretsErrorLabel
         )
@@ -256,6 +257,7 @@ secretsToRowsForSharedSecrets type_ secrets =
 tableHeaders : Table.Columns
 tableHeaders =
     [ ( Nothing, "name" )
+    , ( Nothing, "key" )
     , ( Nothing, "type" )
     , ( Nothing, "events" )
     , ( Nothing, "images" )
@@ -269,6 +271,7 @@ tableHeadersForSharedSecrets : Table.Columns
 tableHeadersForSharedSecrets =
     [ ( Nothing, "name" )
     , ( Nothing, "team" )
+    , ( Nothing, "key" )
     , ( Nothing, "type" )
     , ( Nothing, "events" )
     , ( Nothing, "images" )
@@ -288,6 +291,12 @@ renderSecret type_ secret =
             , Util.testAttribute <| "secrets-row-name"
             ]
             [ a [ updateSecretHref type_ secret ] [ text secret.name ] ]
+        , td
+            [ attribute "data-label" "key"
+            , scope "row"
+            , class "break-word"
+            ]
+            [ text <| secretToKey secret ]
         , td
             [ attribute "data-label" "type"
             , scope "row"
@@ -336,6 +345,12 @@ renderSharedSecret type_ secret =
             , Util.testAttribute <| "secrets-row-team"
             ]
             [ a [ Routes.href <| Routes.SharedSecrets "native" (percentEncode secret.org) (percentEncode secret.team) Nothing Nothing ] [ text secret.team ] ]
+        , td
+            [ attribute "data-label" "key"
+            , scope "row"
+            , class "break-word"
+            ]
+            [ text <| secretToKey secret ]
         , td
             [ attribute "data-label" "type"
             , scope "row"

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -74,7 +74,7 @@ viewRepoSecrets model =
                         "repo-secrets"
                         "No secrets found for this repository"
                         tableHeaders
-                        (secretsToRows Vela.RepoSecret s)
+                        (secretsToRows Vela.RepoSecret s <| Just secretsModel.copy)
                         actions
                     )
                 ]
@@ -150,7 +150,7 @@ viewOrgSecrets model showManage showAdd =
                         "org-secrets"
                         "No secrets found for this org"
                         tableHeaders
-                        (secretsToRows Vela.OrgSecret s)
+                        (secretsToRows Vela.OrgSecret s secretsModel.copy)
                         actions
                     )
                 ]
@@ -227,7 +227,7 @@ viewSharedSecrets model showManage showAdd =
                         "shared-secrets"
                         "No secrets found for this org/team"
                         tableHeadersForSharedSecrets
-                        (secretsToRowsForSharedSecrets Vela.SharedSecret s)
+                        (secretsToRowsForSharedSecrets Vela.SharedSecret s secretsModel.copy)
                         actions
                     )
                 ]
@@ -241,17 +241,17 @@ viewSharedSecrets model showManage showAdd =
 
 {-| secretsToRows : takes list of secrets and produces list of Table rows
 -}
-secretsToRows : SecretType -> Secrets -> Table.Rows Secret Msg
-secretsToRows type_ secrets =
-    List.map (\secret -> Table.Row (addKey secret) (renderSecret type_)) secrets
+secretsToRows : SecretType -> Secrets -> Copy msg -> Table.Rows Secret Msg
+secretsToRows type_ secrets copy =
+    List.map (\secret -> Table.Row (addKey secret) (renderSecret type_ copy)) secrets
+    -- |> List.concat
 
 
 {-| secretsToRows : takes list of secrets and produces list of Table rows
 -}
-secretsToRowsForSharedSecrets : SecretType -> Secrets -> Table.Rows Secret Msg
-secretsToRowsForSharedSecrets type_ secrets =
-    List.map (\secret -> Table.Row (addKey secret) (renderSharedSecret type_)) secrets
-
+secretsToRowsForSharedSecrets : SecretType -> Secrets -> Copy msg -> Table.Rows Secret Msg
+secretsToRowsForSharedSecrets type_ secrets copy =
+    List.map (\secret -> Table.Row (addKey secret) (renderSharedSecret type_ copy)) secrets
 
 {-| tableHeaders : returns table headers for secrets table
 -}
@@ -284,15 +284,15 @@ tableHeadersForSharedSecrets =
 
 {-| renderSecret : takes secret and secret type and renders a table row
 -}
-renderSecret : SecretType -> Secret -> Html msg
-renderSecret type_ secret =
+renderSecret : SecretType -> Copy msg -> Secret -> Html msg
+renderSecret type_ copy secret =
     tr [ Util.testAttribute <| "secrets-row" ]
         [ td  
             [ attribute "data-label" ""
             , scope "row"
             , class "break-word"
             ]
-            [ copyButton (copySecret secret) ]
+            [ copyButton (copySecret secret) copy ]
         , td
             [ attribute "data-label" "name"
             , scope "row"
@@ -337,15 +337,15 @@ renderSecret type_ secret =
 
 {-| renderSecret : takes secret and secret type and renders a table row
 -}
-renderSharedSecret : SecretType -> Secret -> Html msg
-renderSharedSecret type_ secret =
+renderSharedSecret : SecretType -> Copy msg -> Secret -> Html msg
+renderSharedSecret type_ copy secret =
     tr [ Util.testAttribute <| "secrets-row" ]
         [ td  
             [ attribute "data-label" ""
             , scope "row"
             , class "break-word"
             ]
-            [ copyButton (copySecret secret) ]
+            [ copyButton (copySecret secret) copy]
         , td
             [ attribute "data-label" "name"
             , scope "row"
@@ -461,27 +461,23 @@ copySecret secret =
                yaml ++ "shared"
 
 {-| copyButton : copy button that copys secret yaml to clipboard -}
--- copyButton : String -> Maybe (Copy msg) -> Html msg
--- copyButton copyYaml copy =
-copyButton : String  -> Html msg
-copyButton copyYaml = 
-    -- case copy of
-    --     Just copyMsg ->
+copyButton : String -> Copy msg -> Html msg
+copyButton copyYaml copy =
+-- copyButton : String  -> Html msg
+-- copyButton copyYaml = 
     button
         [ class "copy-button"
         , attribute "aria-label" <| "copy secret yaml '" ++ copyYaml ++ "' to clipboard "
         , class "button"
         , class "-icon"
-        -- , Html.Events.onClick <| copyYaml
+        , Html.Events.onClick <| copy copyYaml
         , attribute "data-clipboard-text" copyYaml
         ]
         [ FeatherIcons.copy
             |> FeatherIcons.withSize 18
             |> FeatherIcons.toHtml []
         ]
-        -- Nothing ->
-        --     text ""
-        
+    
 
 
 -- ADD SECRET

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -289,6 +289,7 @@ renderSecret type_ secret =
             [ attribute "data-label" ""
             , scope "row"
             , class "break-word"
+            , Util.testAttribute <| "secrets-row-copy"
             ]
             [ copyButton (copySecret secret)]
         , td
@@ -302,6 +303,7 @@ renderSecret type_ secret =
             [ attribute "data-label" "key"
             , scope "row"
             , class "break-word"
+            , Util.testAttribute <| "secrets-row-key"
             ]
             [ text <| secret.key ]
         , td
@@ -342,6 +344,7 @@ renderSharedSecret type_ secret =
             [ attribute "data-label" ""
             , scope "row"
             , class "break-word"
+            , Util.testAttribute <| "secrets-row-copy"
             ]
             [ copyButton (copySecret secret)]
         , td
@@ -362,6 +365,7 @@ renderSharedSecret type_ secret =
             [ attribute "data-label" "key"
             , scope "row"
             , class "break-word"
+            , Util.testAttribute <| "secrets-row-key"
             ]
             [ text <| secret.key ]
         , td
@@ -468,6 +472,7 @@ copyButton copyYaml =
         , class "-icon"
         , Html.Events.onClick <| Pages.Secrets.Model.Copy copyYaml
         , attribute "data-clipboard-text" copyYaml
+        , Util.testAttribute "copy-secret"
         ]
         [ FeatherIcons.copy
             |> FeatherIcons.withSize 18

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -26,14 +26,12 @@ import Url exposing (percentEncode)
 import Util exposing (largeLoader)
 import Vela
     exposing
-        ( Copy
-        , Secret
+        ( Secret
         , SecretType(..)
         , Secrets
         , secretTypeToString
         , secretsErrorLabel
         )
-
 
 
 -- VIEW
@@ -74,7 +72,7 @@ viewRepoSecrets model =
                         "repo-secrets"
                         "No secrets found for this repository"
                         tableHeaders
-                        (secretsToRows Vela.RepoSecret s <| Just secretsModel.copy)
+                        (secretsToRows Vela.RepoSecret s)
                         actions
                     )
                 ]
@@ -150,7 +148,7 @@ viewOrgSecrets model showManage showAdd =
                         "org-secrets"
                         "No secrets found for this org"
                         tableHeaders
-                        (secretsToRows Vela.OrgSecret s secretsModel.copy)
+                        (secretsToRows Vela.OrgSecret s)
                         actions
                     )
                 ]
@@ -227,7 +225,7 @@ viewSharedSecrets model showManage showAdd =
                         "shared-secrets"
                         "No secrets found for this org/team"
                         tableHeadersForSharedSecrets
-                        (secretsToRowsForSharedSecrets Vela.SharedSecret s secretsModel.copy)
+                        (secretsToRowsForSharedSecrets Vela.SharedSecret s)
                         actions
                     )
                 ]
@@ -241,17 +239,17 @@ viewSharedSecrets model showManage showAdd =
 
 {-| secretsToRows : takes list of secrets and produces list of Table rows
 -}
-secretsToRows : SecretType -> Secrets -> Copy msg -> Table.Rows Secret Msg -- KM: remove Copy msg params
-secretsToRows type_ secrets copy =
-    List.map (\secret -> Table.Row (addKey secret) (renderSecret type_ copy)) secrets
+secretsToRows : SecretType -> Secrets -> Table.Rows Secret Msg
+secretsToRows type_ secrets =
+    List.map (\secret -> Table.Row (addKey secret) (renderSecret type_)) secrets
     -- |> List.concat
 
 
 {-| secretsToRows : takes list of secrets and produces list of Table rows
--}
-secretsToRowsForSharedSecrets : SecretType -> Secrets -> Copy msg -> Table.Rows Secret Msg
-secretsToRowsForSharedSecrets type_ secrets copy =
-    List.map (\secret -> Table.Row (addKey secret) (renderSharedSecret type_ copy)) secrets
+-} 
+secretsToRowsForSharedSecrets : SecretType -> Secrets -> Table.Rows Secret Msg
+secretsToRowsForSharedSecrets type_ secrets =
+    List.map (\secret -> Table.Row (addKey secret) (renderSharedSecret type_)) secrets
 
 {-| tableHeaders : returns table headers for secrets table
 -}
@@ -284,15 +282,15 @@ tableHeadersForSharedSecrets =
 
 {-| renderSecret : takes secret and secret type and renders a table row
 -}
-renderSecret : SecretType -> Copy msg -> Secret -> Html msg -- KM: msg should be Msg
-renderSecret type_ copy secret =
+renderSecret : SecretType -> Secret -> Html Msg
+renderSecret type_ secret =
     tr [ Util.testAttribute <| "secrets-row" ]
         [ td  
             [ attribute "data-label" ""
             , scope "row"
             , class "break-word"
             ]
-            [ copyButton (copySecret secret) copy ]
+            [ copyButton (copySecret secret)]
         , td
             [ attribute "data-label" "name"
             , scope "row"
@@ -337,15 +335,15 @@ renderSecret type_ copy secret =
 
 {-| renderSecret : takes secret and secret type and renders a table row
 -}
-renderSharedSecret : SecretType -> Copy msg -> Secret -> Html msg
-renderSharedSecret type_ copy secret =
+renderSharedSecret : SecretType -> Secret -> Html Msg
+renderSharedSecret type_ secret =
     tr [ Util.testAttribute <| "secrets-row" ]
         [ td  
             [ attribute "data-label" ""
             , scope "row"
             , class "break-word"
             ]
-            [ copyButton (copySecret secret) copy]
+            [ copyButton (copySecret secret)]
         , td
             [ attribute "data-label" "name"
             , scope "row"
@@ -461,16 +459,14 @@ copySecret secret =
                yaml ++ "shared"
 
 {-| copyButton : copy button that copys secret yaml to clipboard -}
-copyButton : String -> Copy msg -> Html msg -- KM: remove copy param + capital Msg
-copyButton copyYaml copy =
--- copyButton : String  -> Html msg
--- copyButton copyYaml = 
+copyButton : String -> Html Msg
+copyButton copyYaml =
     button
         [ class "copy-button"
         , attribute "aria-label" <| "copy secret yaml '" ++ copyYaml ++ "' to clipboard "
         , class "button"
         , class "-icon"
-        , Html.Events.onClick <| copy copyYaml -- KM: use strict Pages.Secrets.Model.Copy
+        , Html.Events.onClick <| Pages.Secrets.Model.Copy copyYaml
         , attribute "data-clipboard-text" copyYaml
         ]
         [ FeatherIcons.copy

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -241,7 +241,7 @@ viewSharedSecrets model showManage showAdd =
 
 {-| secretsToRows : takes list of secrets and produces list of Table rows
 -}
-secretsToRows : SecretType -> Secrets -> Copy msg -> Table.Rows Secret Msg
+secretsToRows : SecretType -> Secrets -> Copy msg -> Table.Rows Secret Msg -- KM: remove Copy msg params
 secretsToRows type_ secrets copy =
     List.map (\secret -> Table.Row (addKey secret) (renderSecret type_ copy)) secrets
     -- |> List.concat
@@ -284,7 +284,7 @@ tableHeadersForSharedSecrets =
 
 {-| renderSecret : takes secret and secret type and renders a table row
 -}
-renderSecret : SecretType -> Copy msg -> Secret -> Html msg
+renderSecret : SecretType -> Copy msg -> Secret -> Html msg -- KM: msg should be Msg
 renderSecret type_ copy secret =
     tr [ Util.testAttribute <| "secrets-row" ]
         [ td  
@@ -461,7 +461,7 @@ copySecret secret =
                yaml ++ "shared"
 
 {-| copyButton : copy button that copys secret yaml to clipboard -}
-copyButton : String -> Copy msg -> Html msg
+copyButton : String -> Copy msg -> Html msg -- KM: remove copy param + capital Msg
 copyButton copyYaml copy =
 -- copyButton : String  -> Html msg
 -- copyButton copyYaml = 
@@ -470,7 +470,7 @@ copyButton copyYaml copy =
         , attribute "aria-label" <| "copy secret yaml '" ++ copyYaml ++ "' to clipboard "
         , class "button"
         , class "-icon"
-        , Html.Events.onClick <| copy copyYaml
+        , Html.Events.onClick <| copy copyYaml -- KM: use strict Pages.Secrets.Model.Copy
         , attribute "data-clipboard-text" copyYaml
         ]
         [ FeatherIcons.copy

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -34,7 +34,9 @@ import Vela
         )
 
 
+
 -- VIEW
+
 
 {-| viewRepoSecrets : takes secrets model and renders table for viewing repo secrets
 -}
@@ -61,7 +63,6 @@ viewRepoSecrets model =
                             |> FeatherIcons.toHtml [ Svg.Attributes.class "button-icon" ]
                         ]
                     ]
-
     in
     case secretsModel.repoSecrets of
         Success s ->
@@ -214,7 +215,6 @@ viewSharedSecrets model showManage showAdd =
                     [ manageButton
                     , addButton
                     ]
-        
     in
     case secretsModel.sharedSecrets of
         Success s ->
@@ -242,14 +242,18 @@ viewSharedSecrets model showManage showAdd =
 secretsToRows : SecretType -> Secrets -> Table.Rows Secret Msg
 secretsToRows type_ secrets =
     List.map (\secret -> Table.Row (addKey secret) (renderSecret type_)) secrets
-    -- |> List.concat
+
+
+
+-- |> List.concat
 
 
 {-| secretsToRows : takes list of secrets and produces list of Table rows
--} 
+-}
 secretsToRowsForSharedSecrets : SecretType -> Secrets -> Table.Rows Secret Msg
 secretsToRowsForSharedSecrets type_ secrets =
     List.map (\secret -> Table.Row (addKey secret) (renderSharedSecret type_)) secrets
+
 
 {-| tableHeaders : returns table headers for secrets table
 -}
@@ -285,20 +289,20 @@ tableHeadersForSharedSecrets =
 renderSecret : SecretType -> Secret -> Html Msg
 renderSecret type_ secret =
     tr [ Util.testAttribute <| "secrets-row" ]
-        [ td  
+        [ td
             [ attribute "data-label" ""
             , scope "row"
             , class "break-word"
             , Util.testAttribute <| "secrets-row-copy"
             ]
-            [ copyButton (copySecret secret)]
+            [ copyButton (copySecret secret) ]
         , td
             [ attribute "data-label" "name"
             , scope "row"
             , class "break-word"
             , Util.testAttribute <| "secrets-row-name"
             ]
-            [a [ updateSecretHref type_ secret ] [ text secret.name ]]
+            [ a [ updateSecretHref type_ secret ] [ text secret.name ] ]
         , td
             [ attribute "data-label" "key"
             , scope "row"
@@ -340,13 +344,13 @@ renderSecret type_ secret =
 renderSharedSecret : SecretType -> Secret -> Html Msg
 renderSharedSecret type_ secret =
     tr [ Util.testAttribute <| "secrets-row" ]
-        [ td  
+        [ td
             [ attribute "data-label" ""
             , scope "row"
             , class "break-word"
             , Util.testAttribute <| "secrets-row-copy"
             ]
-            [ copyButton (copySecret secret)]
+            [ copyButton (copySecret secret) ]
         , td
             [ attribute "data-label" "name"
             , scope "row"
@@ -446,23 +450,27 @@ updateSecretHref type_ secret =
                 Routes.SharedSecret "native" secret.org encodedTeam encodedName
 
 
-{-| copySecret : takes a secret and returns the yaml struct of the secret -}
+{-| copySecret : takes a secret and returns the yaml struct of the secret
+-}
 copySecret : Secret -> String
 copySecret secret =
-    let 
-        yaml ="- name: " ++ secret.name ++ "\n  key: " ++ secret.key ++ "\n  engine: native\n  type: "
+    let
+        yaml =
+            "- name: " ++ secret.name ++ "\n  key: " ++ secret.key ++ "\n  engine: native\n  type: "
     in
-     case secret.type_ of
-            Vela.OrgSecret ->
-                yaml ++  "org"
+    case secret.type_ of
+        Vela.OrgSecret ->
+            yaml ++ "org"
 
-            Vela.RepoSecret ->
-               yaml ++ "repo"
+        Vela.RepoSecret ->
+            yaml ++ "repo"
 
-            Vela.SharedSecret ->
-               yaml ++ "shared"
+        Vela.SharedSecret ->
+            yaml ++ "shared"
 
-{-| copyButton : copy button that copys secret yaml to clipboard -}
+
+{-| copyButton : copy button that copys secret yaml to clipboard
+-}
 copyButton : String -> Html Msg
 copyButton copyYaml =
     button
@@ -478,7 +486,7 @@ copyButton copyYaml =
             |> FeatherIcons.withSize 18
             |> FeatherIcons.toHtml []
         ]
-    
+
 
 
 -- ADD SECRET
@@ -539,19 +547,21 @@ addForm secretsModel =
             ]
         ]
 
+
 {-| addKey : helper to create secret key
 -}
 addKey : Secret -> Secret
 addKey secret =
     case secret.type_ of
         SharedSecret ->
-            {secret | key = secret.org ++ "/" ++ secret.team ++ "/" ++ secret.name}
+            { secret | key = secret.org ++ "/" ++ secret.team ++ "/" ++ secret.name }
 
         OrgSecret ->
-            { secret | key = secret.org ++ "/" ++ secret.name}
+            { secret | key = secret.org ++ "/" ++ secret.name }
 
         RepoSecret ->
-            { secret | key = secret.org ++ "/" ++ secret.repo ++ "/" ++ secret.name}
+            { secret | key = secret.org ++ "/" ++ secret.repo ++ "/" ++ secret.name }
+
 
 
 -- EDIT SECRET

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -110,6 +110,7 @@ module Vela exposing
     , encodeUpdateSecret
     , encodeUpdateUser
     , isComplete
+    , secretToKey
     , secretTypeToString
     , secretsErrorLabel
     , statusToFavicon
@@ -1702,6 +1703,7 @@ type alias Secret =
     , org : Org
     , repo : Repo
     , team : Key
+    , key : String
     , name : String
     , type_ : SecretType
     , images : List String
@@ -1789,6 +1791,21 @@ maybeSecretTypeToMaybeString type_ =
             Nothing
 
 
+{-| secretToKey : helper to create secret key
+-}
+secretToKey : Secret -> String
+secretToKey secret =
+    case secret.type_ of
+        SharedSecret ->
+            secret.org ++ "/" ++ secret.team ++ "/" ++ secret.name
+
+        OrgSecret ->
+            secret.org ++ "/" ++ secret.name
+
+        RepoSecret ->
+            secret.org ++ "/" ++ secret.repo ++ "/" ++ secret.name
+
+
 decodeSecret : Decoder Secret
 decodeSecret =
     Decode.succeed Secret
@@ -1796,6 +1813,7 @@ decodeSecret =
         |> optional "org" string ""
         |> optional "repo" string ""
         |> optional "team" string ""
+        |> optional "key" string ""
         |> optional "name" string ""
         |> optional "type" secretTypeDecoder RepoSecret
         |> optional "images" (Decode.list string) []

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -110,7 +110,6 @@ module Vela exposing
     , encodeUpdateSecret
     , encodeUpdateUser
     , isComplete
-    , secretToKey
     , secretTypeToString
     , secretsErrorLabel
     , statusToFavicon
@@ -1789,21 +1788,6 @@ maybeSecretTypeToMaybeString type_ =
 
         _ ->
             Nothing
-
-
-{-| secretToKey : helper to create secret key
--}
-secretToKey : Secret -> String
-secretToKey secret =
-    case secret.type_ of
-        SharedSecret ->
-            secret.org ++ "/" ++ secret.team ++ "/" ++ secret.name
-
-        OrgSecret ->
-            secret.org ++ "/" ++ secret.name
-
-        RepoSecret ->
-            secret.org ++ "/" ++ secret.repo ++ "/" ++ secret.name
 
 
 decodeSecret : Decoder Secret


### PR DESCRIPTION
Part 2 of https://github.com/go-vela/community/issues/516

Copies the secret how it should be formatted for yml

For example: 
copy button on octocat/hello-world/demo_secret would copy
```
  - name: demo_secret
    key:  octocat/hello-world/demo_secret
    engine: native
    type: repo
```

Also adds tests for this and the key field added to the table