### PR TITLE
chore: remove Pipeline page

### DIFF
--- a/src/elm/Crumbs.elm
+++ b/src/elm/Crumbs.elm
@@ -313,20 +313,6 @@ toPath page =
                     , ( "#" ++ buildNumber, Nothing )
                     ]
 
-                Pages.Pipeline org repo _ _ _ ->
-                    let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
-
-                        repoBuildsPage =
-                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
-                    in
-                    [ overviewPage
-                    , organizationPage
-                    , repoBuildsPage
-                    , ( "Pipeline", Nothing )
-                    ]
-
                 Pages.Login ->
                     []
 

--- a/src/elm/Help/Commands.elm
+++ b/src/elm/Help/Commands.elm
@@ -111,9 +111,6 @@ commands page =
         Pages.BuildPipeline org repo buildNumber _ _ _ ->
             [ viewBuild org repo buildNumber, restartBuild org repo buildNumber ]
 
-        Pages.Pipeline _ _ _ _ _ ->
-            []
-
         Pages.RepoSettings org repo ->
             [ viewRepo org repo, repairRepo org repo, chownRepo org repo ]
 
@@ -795,9 +792,6 @@ resourceLoaded args =
         Pages.BuildPipeline _ _ _ _ _ _ ->
             args.build.success
 
-        Pages.Pipeline _ _ _ _ _ ->
-            True
-
         Pages.AddOrgSecret secretEngine org ->
             noBlanks [ secretEngine, org ]
 
@@ -878,9 +872,6 @@ resourceLoading args =
 
         Pages.BuildPipeline _ _ _ _ _ _ ->
             args.build.loading
-
-        Pages.Pipeline _ _ _ _ _ ->
-            False
 
         Pages.OrgSecrets _ _ _ _ ->
             args.secrets.loading

--- a/src/elm/Pages.elm
+++ b/src/elm/Pages.elm
@@ -35,7 +35,6 @@ type Page
     | Build Org Repo BuildNumber FocusFragment
     | BuildServices Org Repo BuildNumber FocusFragment
     | BuildPipeline Org Repo BuildNumber Ref (Maybe ExpandTemplatesQuery) (Maybe Fragment)
-    | Pipeline Org Repo Ref (Maybe ExpandTemplatesQuery) (Maybe Fragment)
     | Settings
     | Login
     | NotFound
@@ -115,9 +114,6 @@ toRoute page =
 
         BuildPipeline org repo buildNumber ref expanded lineFocus ->
             Routes.BuildPipeline org repo buildNumber ref expanded lineFocus
-
-        Pipeline org repo ref expanded lineFocus ->
-            Routes.Pipeline org repo ref expanded lineFocus
 
         Settings ->
             Routes.Settings
@@ -199,9 +195,6 @@ strip page =
 
         BuildPipeline org repo buildNumber ref _ _ ->
             BuildPipeline org repo buildNumber ref Nothing Nothing
-
-        Pipeline org repo ref _ _ ->
-            Pipeline org repo ref Nothing Nothing
 
         Settings ->
             Settings

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -61,11 +61,11 @@ type alias Msgs msg =
 
 
 type alias Get msg =
-    Org -> Repo -> Maybe BuildNumber -> Ref -> FocusFragment -> Bool -> msg
+    Org -> Repo -> BuildNumber -> Ref -> FocusFragment -> Bool -> msg
 
 
 type alias Expand msg =
-    Org -> Repo -> Maybe BuildNumber -> Ref -> FocusFragment -> Bool -> msg
+    Org -> Repo -> BuildNumber -> Ref -> FocusFragment -> Bool -> msg
 
 
 type alias Download msg =

--- a/src/elm/Routes.elm
+++ b/src/elm/Routes.elm
@@ -44,7 +44,6 @@ type Route
     | Build Org Repo BuildNumber FocusFragment
     | BuildServices Org Repo BuildNumber FocusFragment
     | BuildPipeline Org Repo BuildNumber Ref (Maybe ExpandTemplatesQuery) FocusFragment
-    | Pipeline Org Repo Ref (Maybe ExpandTemplatesQuery) FocusFragment
     | Settings
     | Login
     | Logout
@@ -82,7 +81,6 @@ routes =
         , map OrgBuilds (string </> s "builds" <?> Query.int "page" <?> Query.int "per_page" <?> Query.string "event")
         , map RepositoryBuilds (string </> string <?> Query.int "page" <?> Query.int "per_page" <?> Query.string "event")
         , map RepositoryDeployments (string </> string </> s "deployments" <?> Query.int "page" <?> Query.int "per_page")
-        , map Pipeline (string </> string </> string </> s "pipeline" <?> Query.string "expand" </> fragment identity)
         , map Build (string </> string </> string </> fragment identity)
         , map BuildServices (string </> string </> string </> s "services" </> fragment identity)
         , map BuildPipeline (string </> string </> string </> s "pipeline" </> string <?> Query.string "expand" </> fragment identity)
@@ -180,9 +178,6 @@ routeToUrl route =
 
         BuildPipeline org repo buildNumber ref expand lineFocus ->
             "/" ++ org ++ "/" ++ repo ++ "/" ++ buildNumber ++ "/pipeline" ++ "/" ++ ref ++ (UB.toQuery <| List.filterMap identity <| [ maybeToQueryParam expand "expand" ]) ++ Maybe.withDefault "" lineFocus
-
-        Pipeline org repo ref expand lineFocus ->
-            "/" ++ org ++ "/" ++ repo ++ "/pipeline" ++ (UB.toQuery <| List.filterMap identity <| [ maybeToQueryParam expand "expand" ]) ++ Maybe.withDefault "" lineFocus
 
         Authenticate { code, state } ->
             "/account/authenticate" ++ paramsToQueryString { code = code, state = state }

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -756,7 +756,7 @@ updateBuildPipelineOrgRepo org repo pipeline =
     { pipeline | org = org, repo = repo }
 
 
-updateBuildPipelineBuildNumber : Maybe BuildNumber -> PipelineModel -> PipelineModel
+updateBuildPipelineBuildNumber : BuildNumber -> PipelineModel -> PipelineModel
 updateBuildPipelineBuildNumber update pipeline =
     { pipeline | buildNumber = update }
 
@@ -1150,7 +1150,7 @@ type alias PipelineModel =
     , expanding : Bool
     , org : Org
     , repo : Repo
-    , buildNumber : Maybe BuildNumber
+    , buildNumber : BuildNumber
     , ref : Ref
     , expand : Maybe String
     , lineFocus : LogFocus
@@ -1160,7 +1160,7 @@ type alias PipelineModel =
 
 defaultPipeline : PipelineModel
 defaultPipeline =
-    PipelineModel ( NotAsked, "" ) False False "" "" Nothing "" Nothing ( Nothing, Nothing ) Nothing
+    PipelineModel ( NotAsked, "" ) False False "" "" "" "" Nothing ( Nothing, Nothing ) Nothing
 
 
 type alias PipelineConfig =


### PR DESCRIPTION
this is part of the effort for https://github.com/go-vela/community/issues/587

### what
removing the "Pipeline" page completely

### why
it no longer matches the api spec which directly correlates a "pipeline" to a "build".
https://github.com/go-vela/community/issues/460

it also prepares for https://github.com/go-vela/ui/pull/551 which refines the pipeline url + pipeline tabs into a better experience 
