### PR TITLE
fix: typo in reposubpage loading

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -3040,7 +3040,7 @@ loadOrgSubPage model org toPage =
                                                 |> updateBuildsEvent maybeEvent
 
                                         _ ->
-                                            rm
+                                            rm_
                                                 |> updateBuildsPage Nothing
                                                 |> updateBuildsPerPage Nothing
                                                 |> updateBuildsEvent Nothing
@@ -3158,7 +3158,7 @@ loadRepoSubPage model org repo toPage =
                                                 |> updateBuildsEvent maybeEvent
 
                                         _ ->
-                                            rm
+                                            rm_
                                                 |> updateBuildsPage Nothing
                                                 |> updateBuildsPerPage Nothing
                                                 |> updateBuildsEvent Nothing
@@ -3172,7 +3172,7 @@ loadRepoSubPage model org repo toPage =
                                                 |> updateDeploymentsPerPage maybePerPage
 
                                         _ ->
-                                            rm
+                                            rm_
                                                 |> updateDeploymentsPage Nothing
                                                 |> updateDeploymentsPerPage Nothing
                                )
@@ -3185,7 +3185,7 @@ loadRepoSubPage model org repo toPage =
                                                 |> updateHooksPerPage maybePerPage
 
                                         _ ->
-                                            rm
+                                            rm_
                                                 |> updateHooksPage Nothing
                                                 |> updateHooksPerPage Nothing
                                )

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -3248,7 +3248,7 @@ loadRepoSubPage model org repo toPage =
                             | repo =
                                 rm
                                     |> updateHooksPage maybePage
-                                    |> updateHooksPage maybePerPage
+                                    |> updateHooksPerPage maybePerPage
                           }
                         , getHooks model o r maybePage maybePerPage
                         )


### PR DESCRIPTION
these small typos are causing some cypress issues where page/tab loading is causing repo model to get overwritten 