### PR TITLE
fix: remove trusted flag from default repo enable

### DIFF
--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -999,7 +999,7 @@ type alias EnableRepositoryPayload =
 
 defaultEnableRepositoryPayload : EnableRepositoryPayload
 defaultEnableRepositoryPayload =
-    EnableRepositoryPayload "" "" "" "" "" False True True True True False False False
+    EnableRepositoryPayload "" "" "" "" "" False False True True True False False False
 
 
 type alias UpdateRepositoryPayload =


### PR DESCRIPTION
this field is being ignored by the server, but incoming changes may alter that.
removing it.