### PR TITLE
feat(events): add release webhook event

### DIFF
--- a/cypress/fixtures/enable_repo_response.json
+++ b/cypress/fixtures/enable_repo_response.json
@@ -18,6 +18,7 @@
   "allow_push": true,
   "allow_deploy": false,
   "allow_tag": false,
+  "allow_release": false,
   "allow_comment": false,
   "pipeline_type": "yaml"
 }

--- a/cypress/fixtures/overview_page.json
+++ b/cypress/fixtures/overview_page.json
@@ -18,7 +18,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_release": false
   },
   {
     "id": 18,
@@ -39,7 +40,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_release": false
   },
   {
     "id": 17,
@@ -60,7 +62,8 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_release": false
   },
   {
     "id": 16,
@@ -81,6 +84,7 @@
     "allow_pull": false,
     "allow_push": true,
     "allow_deploy": false,
-    "allow_tag": false
+    "allow_tag": false,
+    "allow_release": false
   }
 ]

--- a/cypress/fixtures/repositories.json
+++ b/cypress/fixtures/repositories.json
@@ -19,6 +19,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -42,6 +43,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -65,6 +67,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false
   },
   {
@@ -87,6 +90,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   }

--- a/cypress/fixtures/repositories_100.json
+++ b/cypress/fixtures/repositories_100.json
@@ -19,6 +19,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -42,6 +43,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -65,6 +67,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -88,6 +91,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -111,6 +115,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -134,6 +139,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -157,6 +163,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -180,6 +187,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -203,6 +211,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -226,6 +235,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -249,6 +259,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -272,6 +283,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -295,6 +307,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -318,6 +331,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -341,6 +355,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -364,6 +379,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -387,6 +403,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -410,6 +427,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -433,6 +451,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -456,6 +475,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -479,6 +499,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -502,6 +523,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -525,6 +547,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -548,6 +571,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -571,6 +595,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -594,6 +619,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -617,6 +643,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -640,6 +667,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -663,6 +691,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -686,6 +715,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -709,6 +739,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -732,6 +763,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -755,6 +787,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -778,6 +811,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -801,6 +835,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -824,6 +859,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -847,6 +883,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -870,6 +907,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -893,6 +931,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -916,6 +955,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -939,6 +979,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -962,6 +1003,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -985,6 +1027,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1008,6 +1051,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1031,6 +1075,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1054,6 +1099,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1077,6 +1123,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1100,6 +1147,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1123,6 +1171,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1146,6 +1195,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1169,6 +1219,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1192,6 +1243,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1215,6 +1267,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1238,6 +1291,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1261,6 +1315,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1284,6 +1339,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1307,6 +1363,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1330,6 +1387,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1353,6 +1411,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1376,6 +1435,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1399,6 +1459,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1422,6 +1483,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1445,6 +1507,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1468,6 +1531,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1491,6 +1555,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1514,6 +1579,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1537,6 +1603,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1560,6 +1627,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1583,6 +1651,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1606,6 +1675,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1629,6 +1699,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1652,6 +1723,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1675,6 +1747,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1698,6 +1771,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1721,6 +1795,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1744,6 +1819,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1767,6 +1843,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1790,6 +1867,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1813,6 +1891,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1836,6 +1915,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1859,6 +1939,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1882,6 +1963,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1905,6 +1987,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1928,6 +2011,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1951,6 +2035,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1974,6 +2059,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -1997,6 +2083,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2020,6 +2107,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2043,6 +2131,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2066,6 +2155,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2089,6 +2179,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2112,6 +2203,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2135,6 +2227,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2158,6 +2251,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2181,6 +2275,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2204,6 +2299,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2227,6 +2323,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2250,6 +2347,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2273,6 +2371,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -2296,6 +2395,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   }

--- a/cypress/fixtures/repositories_10a.json
+++ b/cypress/fixtures/repositories_10a.json
@@ -19,6 +19,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -42,6 +43,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -65,6 +67,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -88,6 +91,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -111,6 +115,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -134,6 +139,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -157,6 +163,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -180,6 +187,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -203,6 +211,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -226,6 +235,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   }

--- a/cypress/fixtures/repositories_10b.json
+++ b/cypress/fixtures/repositories_10b.json
@@ -19,6 +19,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -42,6 +43,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -65,6 +67,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -88,6 +91,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -111,6 +115,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -134,6 +139,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -157,6 +163,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -180,6 +187,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -203,6 +211,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -226,6 +235,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   }

--- a/cypress/fixtures/repositories_5.json
+++ b/cypress/fixtures/repositories_5.json
@@ -19,6 +19,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -42,6 +43,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -65,6 +67,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -88,6 +91,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   },
@@ -111,6 +115,7 @@
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
+    "allow_release": false,
     "allow_comment": false,
     "pipeline_type": "yaml"
   }

--- a/cypress/fixtures/repository.json
+++ b/cypress/fixtures/repository.json
@@ -18,6 +18,7 @@
   "allow_push": true,
   "allow_deploy": false,
   "allow_tag": false,
+  "allow_release": false,
   "allow_comment": false,
   "pipeline_type": "yaml"
 }

--- a/cypress/fixtures/repository_inactive.json
+++ b/cypress/fixtures/repository_inactive.json
@@ -18,6 +18,7 @@
   "allow_push": true,
   "allow_deploy": false,
   "allow_tag": false,
+  "allow_release": false,
   "allow_comment": false,
   "pipeline_type": "yaml"
 }

--- a/cypress/fixtures/repository_updated.json
+++ b/cypress/fixtures/repository_updated.json
@@ -18,6 +18,7 @@
   "allow_push": false,
   "allow_deploy": true,
   "allow_tag": true,
+  "allow_release": false,
   "allow_comment": false,
   "pipeline_type": "yaml"
 }

--- a/cypress/fixtures/source_repos.json
+++ b/cypress/fixtures/source_repos.json
@@ -20,6 +20,7 @@
       "allow_push": true,
       "allow_deploy": false,
       "allow_tag": false,
+      "allow_release": false,
       "allow_comment": false
     },
     {
@@ -42,6 +43,7 @@
       "allow_push": true,
       "allow_deploy": false,
       "allow_tag": false,
+      "allow_release": false,
       "allow_comment": false
     },
     {
@@ -64,6 +66,7 @@
       "allow_push": true,
       "allow_deploy": false,
       "allow_tag": false,
+      "allow_release": false,
       "allow_comment": false
     },
     {
@@ -86,6 +89,7 @@
       "allow_push": true,
       "allow_deploy": false,
       "allow_tag": false,
+      "allow_release": false,
       "allow_comment": false
     }
   ],
@@ -110,6 +114,7 @@
       "allow_push": true,
       "allow_deploy": false,
       "allow_tag": false,
+      "allow_release": false,
       "allow_comment": false
     }
   ]

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2661,7 +2661,7 @@ viewBuildsFilter shouldRender org repo maybeEvent =
     let
         eventEnum : List String
         eventEnum =
-            [ "all", "push", "pull_request", "tag", "deployment", "comment" ]
+            [ "all", "push", "pull_request", "tag", "release", "deployment", "comment" ]
 
         eventToMaybe : String -> Maybe Event
         eventToMaybe event =

--- a/src/elm/Pages/RepoSettings.elm
+++ b/src/elm/Pages/RepoSettings.elm
@@ -303,6 +303,11 @@ events repo msg =
                 repo.allow_tag
               <|
                 msg repo.org repo.name "allow_tag"
+            , checkbox "Release"
+                "allow_release"
+                repo.allow_release
+              <|
+                msg repo.org repo.name "allow_release"
             , checkbox "Comment"
                 "allow_comment"
                 repo.allow_comment
@@ -805,6 +810,7 @@ validEventsUpdate originalRepo repoUpdate =
                 || Maybe.withDefault repo.allow_pull repoUpdate.allow_pull
                 || Maybe.withDefault repo.allow_deploy repoUpdate.allow_deploy
                 || Maybe.withDefault repo.allow_tag repoUpdate.allow_tag
+                || Maybe.withDefault repo.allow_release repoUpdate.allow_release
                 || Maybe.withDefault repo.allow_comment repoUpdate.allow_comment
 
         _ ->
@@ -851,6 +857,9 @@ msgPrefix field =
 
         "allow_tag" ->
             "Tag events for $ "
+
+        "allow_release" ->
+            "Release events for $ "
 
         "allow_comment" ->
             "Comment events for $ "

--- a/src/elm/Pages/Secrets/Form.elm
+++ b/src/elm/Pages/Secrets/Form.elm
@@ -197,6 +197,11 @@ viewEventsSelect secretUpdate =
                 (eventEnabled "tag" secretUpdate.events)
               <|
                 OnChangeEvent "tag"
+            , checkbox "Release"
+                "release"
+                (eventEnabled "release" secretUpdate.events)
+              <|
+                OnChangeEvent "release"
             , checkbox "Comment"
                 "comment"
                 (eventEnabled "comment" secretUpdate.events)

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -844,6 +844,7 @@ type alias Repository =
     , allow_push : Bool
     , allow_deploy : Bool
     , allow_tag : Bool
+    , allow_release : Bool
     , allow_comment : Bool
     , enabled : Enabled
     , enabling : Enabling
@@ -894,6 +895,7 @@ decodeRepository =
         |> optional "allow_push" bool False
         |> optional "allow_deploy" bool False
         |> optional "allow_tag" bool False
+        |> optional "allow_release" bool False
         |> optional "allow_comment" bool False
         -- "enabled"
         |> optional "active" enabledDecoder NotAsked
@@ -976,6 +978,7 @@ encodeEnableRepository repo =
         , ( "allow_push", Encode.bool <| repo.allow_push )
         , ( "allow_deploy", Encode.bool <| repo.allow_deploy )
         , ( "allow_tag", Encode.bool <| repo.allow_tag )
+        , ( "allow_release", Encode.bool <| repo.allow_release )
         , ( "allow_comment", Encode.bool <| repo.allow_comment )
         ]
 
@@ -993,13 +996,14 @@ type alias EnableRepositoryPayload =
     , allow_push : Bool
     , allow_deploy : Bool
     , allow_tag : Bool
+    , allow_release : Bool
     , allow_comment : Bool
     }
 
 
 defaultEnableRepositoryPayload : EnableRepositoryPayload
 defaultEnableRepositoryPayload =
-    EnableRepositoryPayload "" "" "" "" "" False True True True True False False False
+    EnableRepositoryPayload "" "" "" "" "" False True True True True False False False False
 
 
 type alias UpdateRepositoryPayload =
@@ -1010,6 +1014,7 @@ type alias UpdateRepositoryPayload =
     , allow_push : Maybe Bool
     , allow_deploy : Maybe Bool
     , allow_tag : Maybe Bool
+    , allow_release : Maybe Bool
     , allow_comment : Maybe Bool
     , visibility : Maybe String
     , limit : Maybe Int
@@ -1025,7 +1030,7 @@ type alias Field =
 
 defaultUpdateRepositoryPayload : UpdateRepositoryPayload
 defaultUpdateRepositoryPayload =
-    UpdateRepositoryPayload Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+    UpdateRepositoryPayload Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 
 encodeUpdateRepository : UpdateRepositoryPayload -> Encode.Value
@@ -1038,6 +1043,7 @@ encodeUpdateRepository repo =
         , ( "allow_push", encodeOptional Encode.bool repo.allow_push )
         , ( "allow_deploy", encodeOptional Encode.bool repo.allow_deploy )
         , ( "allow_tag", encodeOptional Encode.bool repo.allow_tag )
+        , ( "allow_release", encodeOptional Encode.bool repo.allow_release )
         , ( "allow_comment", encodeOptional Encode.bool repo.allow_comment )
         , ( "visibility", encodeOptional Encode.string repo.visibility )
         , ( "build_limit", encodeOptional Encode.int repo.limit )
@@ -1090,6 +1096,9 @@ buildUpdateRepoBoolPayload field value =
 
         "allow_tag" ->
             { defaultUpdateRepositoryPayload | allow_tag = Just value }
+
+        "allow_release" ->
+            { defaultUpdateRepositoryPayload | allow_release = Just value }
 
         "allow_comment" ->
             { defaultUpdateRepositoryPayload | allow_comment = Just value }


### PR DESCRIPTION
This is one in a series of PRs that enables Vela users to define pipeline steps for GitHub release events. This feature was originally requested in [#518](https://github.com/go-vela/community/issues/518) in the community repository. 

While a release requires a tag, the opposite cannot be said--tags are independent events and can exist without the presence of a release. As such, it can be useful to distinguish between the different event types. For my particular use case, I'd like to use a Gradle plugin that uses tags to automatically version my repository. In this setup, merging a PR to the main branch would serve as the trigger to increment the version (i.e., tagging the applicable commit) and deploy to stage. Creating a release and selecting the newly-created tag would serve as the trigger to deploy to production. This requires that the release event type be supported by Vela.

### Related PRs

* [types](https://github.com/go-vela/types/pull/272)
* [server](https://github.com/go-vela/server/pull/730)
* [cli](https://github.com/go-vela/cli/pull/394)