### PR TITLE
enhance: utilize default repo events from api

### DIFF
--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -999,7 +999,7 @@ type alias EnableRepositoryPayload =
 
 defaultEnableRepositoryPayload : EnableRepositoryPayload
 defaultEnableRepositoryPayload =
-    EnableRepositoryPayload "" "" "" "" "" False False True False True False False False
+    EnableRepositoryPayload "" "" "" "" "" False False True False False False False False
 
 
 type alias UpdateRepositoryPayload =


### PR DESCRIPTION
Let the server set the default repo events to take advantage of the code added within https://github.com/go-vela/server/pull/758.

xref: https://github.com/go-vela/community/issues/745