### PR TITLE
enhance: improve tables error/loading experience

### DIFF
--- a/cypress/integration/hooks.spec.js
+++ b/cypress/integration/hooks.spec.js
@@ -25,7 +25,7 @@ context('Hooks', () => {
     it('error banner should show', () => {
       cy.get('[data-test=hooks-error]')
         .should('exist')
-        .contains('try again later');
+        .contains('there was an error');
     });
   });
   context('server returning 5 hooks', () => {

--- a/cypress/integration/secrets.spec.js
+++ b/cypress/integration/secrets.spec.js
@@ -133,7 +133,7 @@ context('Secrets', () => {
     it('error banner should show', () => {
       cy.get('[data-test=org-secrets-error]')
         .should('exist')
-        .contains('try again later');
+        .contains('there was an error');
     });
   });
   context('server returning 5 secrets', () => {

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -4047,6 +4047,20 @@ receiveSecrets model response type_ =
                 e =
                     toFailure error
 
+                -- only show error toasty for 500 error
+                showError =
+                    case error of
+                        Http.Detailed.BadStatus meta _ ->
+                            case meta.statusCode of
+                                500 ->
+                                    addError error
+
+                                _ ->
+                                    Cmd.none
+
+                        _ ->
+                            Cmd.none
+
                 sm =
                     case type_ of
                         Vela.RepoSecret ->
@@ -4058,7 +4072,7 @@ receiveSecrets model response type_ =
                         Vela.SharedSecret ->
                             { secretsModel | sharedSecrets = e }
             in
-            ( { model | secretsModel = sm }, addError error )
+            ( { model | secretsModel = sm }, showError )
 
 
 {-| homeMsgs : prepares the input record required for the Home page to route Msgs back to Main.elm

--- a/src/elm/Pages/Hooks.elm
+++ b/src/elm/Pages/Hooks.elm
@@ -74,7 +74,7 @@ view { hooks, time, org, repo } redeliverHook =
                     (Table.Config
                         "Hooks"
                         "hooks"
-                        "No hooks found for this organization/repo"
+                        (text "No hooks found for this organization/repo")
                         tableHeaders
                         (hooksToRows time hooks_ org repo redeliverHook)
                         Nothing

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -259,7 +259,7 @@ viewSharedSecrets model showManage showAdd =
                 "Shared Secrets"
                 "shared-secrets"
                 noRowsView
-                tableHeaders
+                tableHeadersForSharedSecrets
                 rows
                 actions
     in

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -255,7 +255,7 @@ viewSharedSecrets model showManage showAdd =
                                 Http.BadStatus statusCode ->
                                     case statusCode of
                                         401 ->
-                                            "No shared secrets found for this org/team, most likely due to not being an admin of the source control org"
+                                            "No shared secrets found for this org/team, it is likely that no teams exist or you are not an admin of the source control org"
 
                                         _ ->
                                             "No shared secrets found for this org/team, there was an error with the server (" ++ String.fromInt statusCode ++ ")"

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -273,17 +273,6 @@ secretsToRows type_ secrets =
     List.map (\secret -> Table.Row (addKey secret) (renderSecret type_)) secrets
 
 
-
--- |> List.concat
-
-
-{-| secretsToRowsForSharedSecrets : takes list of secrets and produces list of Table rows
--}
-secretsToRowsForSharedSecrets : SecretType -> Secrets -> Table.Rows Secret Msg
-secretsToRowsForSharedSecrets type_ secrets =
-    List.map (\secret -> Table.Row (addKey secret) (renderSharedSecret type_)) secrets
-
-
 {-| tableHeaders : returns table headers for secrets table
 -}
 tableHeaders : Table.Columns

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -73,17 +73,22 @@ viewRepoSecrets model =
                     )
 
                 Failure error ->
-                    case error of
-                        Http.BadStatus statusCode ->
-                            case statusCode of
-                                401 ->
-                                    ( text "No secrets found for this repo, most likely due to not being an admin of the source control repo", [] )
+                    ( span [ Util.testAttribute "repo-secrets-error" ]
+                        [ text <|
+                            case error of
+                                Http.BadStatus statusCode ->
+                                    case statusCode of
+                                        401 ->
+                                            "No secrets found for this repo, most likely due to not being an admin of the source control repo"
+
+                                        _ ->
+                                            "No secrets found for this repo, there was an error with the server (" ++ String.fromInt statusCode ++ ")"
 
                                 _ ->
-                                    ( text <| "No secrets found for this repo, there was an error with the server (" ++ String.fromInt statusCode ++ ")", [] )
-
-                        _ ->
-                            ( text <| "No secrets found for this repo, there was an error with the server", [] )
+                                    "No secrets found for this repo, there was an error with the server"
+                        ]
+                    , []
+                    )
 
                 _ ->
                     ( largeLoader, [] )
@@ -156,17 +161,22 @@ viewOrgSecrets model showManage showAdd =
                     )
 
                 Failure error ->
-                    case error of
-                        Http.BadStatus statusCode ->
-                            case statusCode of
-                                401 ->
-                                    ( text "No secrets found for this org, most likely due to not being an admin of the source control org", [] )
+                    ( span [ Util.testAttribute "org-secrets-error" ]
+                        [ text <|
+                            case error of
+                                Http.BadStatus statusCode ->
+                                    case statusCode of
+                                        401 ->
+                                            "No secrets found for this org, most likely due to not being an admin of the source control org"
+
+                                        _ ->
+                                            "No secrets found for this org, there was an error with the server (" ++ String.fromInt statusCode ++ ")"
 
                                 _ ->
-                                    ( text <| "No secrets found for this org, there was an error with the server (" ++ String.fromInt statusCode ++ ")", [] )
-
-                        _ ->
-                            ( text <| "No secrets found for this org, there was an error with the server", [] )
+                                    "No secrets found for this org, there was an error with the server"
+                        ]
+                    , []
+                    )
 
                 _ ->
                     ( largeLoader, [] )
@@ -239,17 +249,22 @@ viewSharedSecrets model showManage showAdd =
                     )
 
                 Failure error ->
-                    case error of
-                        Http.BadStatus statusCode ->
-                            case statusCode of
-                                401 ->
-                                    ( text "No shared secrets found for this org/team, most likely due to not being an admin of the source control org", [] )
+                    ( span [ Util.testAttribute "shared-secrets-error" ]
+                        [ text <|
+                            case error of
+                                Http.BadStatus statusCode ->
+                                    case statusCode of
+                                        401 ->
+                                            "No shared secrets found for this org/team, most likely due to not being an admin of the source control org"
+
+                                        _ ->
+                                            "No shared secrets found for this org/team, there was an error with the server (" ++ String.fromInt statusCode ++ ")"
 
                                 _ ->
-                                    ( text <| "No shared secrets found for this org/team, there was an error with the server (" ++ String.fromInt statusCode ++ ")", [] )
-
-                        _ ->
-                            ( text <| "No shared secrets found for this org/team, there was an error with the server", [] )
+                                    "No shared secrets found for this org/team, there was an error with the server"
+                        ]
+                    , []
+                    )
 
                 _ ->
                     ( largeLoader, [] )

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -273,7 +273,6 @@ secretsToRows type_ secrets =
     List.map (\secret -> Table.Row (addKey secret) (renderSecret type_)) secrets
 
 
-
 {-| secretsToRowsForSharedSecrets : takes list of shared secrets and produces list of Table rows
 -}
 secretsToRowsForSharedSecrets : SecretType -> Secrets -> Table.Rows Secret Msg

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -244,7 +244,7 @@ viewSharedSecrets model showManage showAdd =
         ( noRowsView, rows ) =
             case secretsModel.sharedSecrets of
                 Success s ->
-                    ( text "No shared secrets found for this org/team"
+                    ( text "No shared secrets found for this org/team, it is possible that no teams exist or you are not an admin of the source control org"
                     , secretsToRowsForSharedSecrets Vela.SharedSecret s
                     )
 
@@ -255,7 +255,7 @@ viewSharedSecrets model showManage showAdd =
                                 Http.BadStatus statusCode ->
                                     case statusCode of
                                         401 ->
-                                            "No shared secrets found for this org/team, it is likely that no teams exist or you are not an admin of the source control org"
+                                            "No shared secrets found for this org/team, it is possible that no teams exist or you are not an admin of the source control org"
 
                                         _ ->
                                             "No shared secrets found for this org/team, there was an error with the server (" ++ String.fromInt statusCode ++ ")"

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -235,7 +235,7 @@ viewSharedSecrets model showManage showAdd =
             case secretsModel.sharedSecrets of
                 Success s ->
                     ( text "No shared secrets found for this org/team"
-                    , secretsToRows Vela.SharedSecret s
+                    , secretsToRowsForSharedSecrets Vela.SharedSecret s
                     )
 
                 Failure error ->
@@ -271,6 +271,14 @@ viewSharedSecrets model showManage showAdd =
 secretsToRows : SecretType -> Secrets -> Table.Rows Secret Msg
 secretsToRows type_ secrets =
     List.map (\secret -> Table.Row (addKey secret) (renderSecret type_)) secrets
+
+
+
+{-| secretsToRowsForSharedSecrets : takes list of shared secrets and produces list of Table rows
+-}
+secretsToRowsForSharedSecrets : SecretType -> Secrets -> Table.Rows Secret Msg
+secretsToRowsForSharedSecrets type_ secrets =
+    List.map (\secret -> Table.Row (addKey secret) (renderSharedSecret type_)) secrets
 
 
 {-| tableHeaders : returns table headers for secrets table

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -77,7 +77,7 @@ viewRepoSecrets model =
                         Http.BadStatus statusCode ->
                             case statusCode of
                                 401 ->
-                                    ( text "No secrets found for this repo, most likely due to not being an admin of the source control repo.", [] )
+                                    ( text "No secrets found for this repo, most likely due to not being an admin of the source control repo", [] )
 
                                 _ ->
                                     ( text <| "No secrets found for this repo, there was an error with the server (" ++ String.fromInt statusCode ++ ")", [] )
@@ -160,7 +160,7 @@ viewOrgSecrets model showManage showAdd =
                         Http.BadStatus statusCode ->
                             case statusCode of
                                 401 ->
-                                    ( text "No secrets found for this org, most likely due to not being an admin of the source control org.", [] )
+                                    ( text "No secrets found for this org, most likely due to not being an admin of the source control org", [] )
 
                                 _ ->
                                     ( text <| "No secrets found for this org, there was an error with the server (" ++ String.fromInt statusCode ++ ")", [] )
@@ -243,7 +243,7 @@ viewSharedSecrets model showManage showAdd =
                         Http.BadStatus statusCode ->
                             case statusCode of
                                 401 ->
-                                    ( text "No shared secrets found for this org/team, most likely due to not being an admin of the source control org.", [] )
+                                    ( text "No shared secrets found for this org/team, most likely due to not being an admin of the source control org", [] )
 
                                 _ ->
                                     ( text <| "No shared secrets found for this org/team, there was an error with the server (" ++ String.fromInt statusCode ++ ")", [] )

--- a/src/elm/Pages/Secrets/View.elm
+++ b/src/elm/Pages/Secrets/View.elm
@@ -11,6 +11,7 @@ import FeatherIcons
 import Html exposing (Html, a, button, div, h2, span, td, text, tr)
 import Html.Attributes exposing (attribute, class, scope)
 import Html.Events exposing (onClick)
+import Http
 import Pages.Secrets.Form exposing (viewAllowCommandCheckbox, viewEventsSelect, viewHelp, viewImagesInput, viewInput, viewNameInput, viewSubmitButtons, viewValueInput)
 import Pages.Secrets.Model
     exposing
@@ -63,33 +64,40 @@ viewRepoSecrets model =
                             |> FeatherIcons.toHtml [ Svg.Attributes.class "button-icon" ]
                         ]
                     ]
-    in
-    case secretsModel.repoSecrets of
-        Success s ->
-            div []
-                [ Table.view
-                    (Table.Config
-                        "Repo Secrets"
-                        "repo-secrets"
-                        "No secrets found for this repository"
-                        tableHeaders
-                        (secretsToRows Vela.RepoSecret s)
-                        actions
+
+        ( noRowsView, rows ) =
+            case secretsModel.repoSecrets of
+                Success s ->
+                    ( text "No secrets found for this repo"
+                    , secretsToRows Vela.RepoSecret s
                     )
-                ]
 
-        RemoteData.Failure _ ->
-            viewResourceError
-                { resourceLabel =
-                    secretsErrorLabel Vela.RepoSecret
-                        secretsModel.org
-                    <|
-                        Just secretsModel.repo
-                , testLabel = "repo-secrets"
-                }
+                Failure error ->
+                    case error of
+                        Http.BadStatus statusCode ->
+                            case statusCode of
+                                401 ->
+                                    ( text "No secrets found for this repo, most likely due to not being an admin of the source control repo.", [] )
 
-        _ ->
-            div [] [ largeLoader ]
+                                _ ->
+                                    ( text <| "No secrets found for this repo, there was an error with the server (" ++ String.fromInt statusCode ++ ")", [] )
+
+                        _ ->
+                            ( text <| "No secrets found for this repo, there was an error with the server", [] )
+
+                _ ->
+                    ( largeLoader, [] )
+
+        cfg =
+            Table.Config
+                "Repo Secrets"
+                "repo-secrets"
+                noRowsView
+                tableHeaders
+                rows
+                actions
+    in
+    div [] [ Table.view cfg ]
 
 
 {-| viewOrgSecrets : takes secrets model and renders table for viewing org secrets
@@ -139,33 +147,40 @@ viewOrgSecrets model showManage showAdd =
                     [ manageButton
                     , addButton
                     ]
-    in
-    case secretsModel.orgSecrets of
-        Success s ->
-            div []
-                [ Table.view
-                    (Table.Config
-                        "Org Secrets"
-                        "org-secrets"
-                        "No secrets found for this org"
-                        tableHeaders
-                        (secretsToRows Vela.OrgSecret s)
-                        actions
+
+        ( noRowsView, rows ) =
+            case secretsModel.orgSecrets of
+                Success s ->
+                    ( text "No secrets found for this org"
+                    , secretsToRows Vela.OrgSecret s
                     )
-                ]
 
-        RemoteData.Failure _ ->
-            viewResourceError
-                { resourceLabel =
-                    secretsErrorLabel Vela.OrgSecret
-                        secretsModel.org
-                    <|
-                        Nothing
-                , testLabel = "org-secrets"
-                }
+                Failure error ->
+                    case error of
+                        Http.BadStatus statusCode ->
+                            case statusCode of
+                                401 ->
+                                    ( text "No secrets found for this org, most likely due to not being an admin of the source control org.", [] )
 
-        _ ->
-            div [] [ largeLoader ]
+                                _ ->
+                                    ( text <| "No secrets found for this org, there was an error with the server (" ++ String.fromInt statusCode ++ ")", [] )
+
+                        _ ->
+                            ( text <| "No secrets found for this org, there was an error with the server", [] )
+
+                _ ->
+                    ( largeLoader, [] )
+
+        cfg =
+            Table.Config
+                "Org Secrets"
+                "org-secrets"
+                noRowsView
+                tableHeaders
+                rows
+                actions
+    in
+    div [] [ Table.view cfg ]
 
 
 {-| viewSharedSecrets : takes secrets model and renders table for viewing shared secrets
@@ -215,26 +230,40 @@ viewSharedSecrets model showManage showAdd =
                     [ manageButton
                     , addButton
                     ]
-    in
-    case secretsModel.sharedSecrets of
-        Success s ->
-            div []
-                [ Table.view
-                    (Table.Config
-                        "Shared Secrets"
-                        "shared-secrets"
-                        "No secrets found for this org/team"
-                        tableHeadersForSharedSecrets
-                        (secretsToRowsForSharedSecrets Vela.SharedSecret s)
-                        actions
+
+        ( noRowsView, rows ) =
+            case secretsModel.sharedSecrets of
+                Success s ->
+                    ( text "No shared secrets found for this org/team"
+                    , secretsToRows Vela.SharedSecret s
                     )
-                ]
 
-        RemoteData.Failure _ ->
-            div [] [ text "Unable to load Shared Secrets; Most likely due to not being a member of any team in this org" ]
+                Failure error ->
+                    case error of
+                        Http.BadStatus statusCode ->
+                            case statusCode of
+                                401 ->
+                                    ( text "No shared secrets found for this org/team, most likely due to not being an admin of the source control org.", [] )
 
-        _ ->
-            div [] [ text "Loading Shared Secrets", largeLoader ]
+                                _ ->
+                                    ( text <| "No shared secrets found for this org/team, there was an error with the server (" ++ String.fromInt statusCode ++ ")", [] )
+
+                        _ ->
+                            ( text <| "No shared secrets found for this org/team, there was an error with the server", [] )
+
+                _ ->
+                    ( largeLoader, [] )
+
+        cfg =
+            Table.Config
+                "Shared Secrets"
+                "shared-secrets"
+                noRowsView
+                tableHeaders
+                rows
+                actions
+    in
+    div [] [ Table.view cfg ]
 
 
 {-| secretsToRows : takes list of secrets and produces list of Table rows
@@ -248,7 +277,7 @@ secretsToRows type_ secrets =
 -- |> List.concat
 
 
-{-| secretsToRows : takes list of secrets and produces list of Table rows
+{-| secretsToRowsForSharedSecrets : takes list of secrets and produces list of Table rows
 -}
 secretsToRowsForSharedSecrets : SecretType -> Secrets -> Table.Rows Secret Msg
 secretsToRowsForSharedSecrets type_ secrets =

--- a/src/elm/Table.elm
+++ b/src/elm/Table.elm
@@ -65,7 +65,7 @@ type alias Rows data msg =
 type alias Config data msg =
     { label : String
     , testLabel : String
-    , noRows : String
+    , noRows : Html msg
     , columns : Columns
     , rows : Rows data msg
     , headerElement : Maybe (Html msg)
@@ -79,6 +79,9 @@ view { label, testLabel, noRows, columns, rows, headerElement } =
     let
         numRows =
             List.length rows
+
+        numColumns =
+            List.length columns
     in
     Html.table [ class "table-base", Util.testAttribute <| testLabel ++ "-table" ]
         [ Html.caption []
@@ -88,17 +91,17 @@ view { label, testLabel, noRows, columns, rows, headerElement } =
                 ]
             ]
         , thead [] [ tr [] <| List.map (\( className, col ) -> th [ class <| Maybe.withDefault "" className, scope "col" ] [ text <| String.Extra.toTitleCase col ]) columns ]
-        , footer noRows numRows
+        , footer noRows numRows numColumns
         , tbody [] <| List.map (\row_ -> row_.display row_.data) rows
         ]
 
 
 {-| footer : renders data table footer
 -}
-footer : String -> Int -> Html msg
-footer noRows numRows =
+footer : Html msg -> Int -> Int -> Html msg
+footer noRows numRows numColumns =
     if numRows == 0 then
-        Html.tfoot [ class "no-rows" ] [ tr [] [ td [ attribute "colspan" "5" ] [ text noRows ] ] ]
+        Html.tfoot [ class "no-rows" ] [ tr [] [ td [ attribute "colspan" <| String.fromInt numColumns ] [ noRows ] ] ]
 
     else
         text ""


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/571

this aims to slightly improve the experience with some of the resource tables

- removes the toasty popup on secrets errors, unless they are a 500 server error.
- moves error message into the normal tables
- moves loading spinner into the normal tables
- adds some status code context to the error message

- applies the same changes to the hooks tables, for consistency!

## Before

loading:
<img width="1402" alt="Screenshot 2023-03-31 at 3 12 52 PM" src="https://user-images.githubusercontent.com/48764154/229220781-3fbe946f-e686-4066-aba9-2a360ae7e2b1.png">

401 example:
<img width="1396" alt="Screenshot 2023-03-31 at 3 16 22 PM" src="https://user-images.githubusercontent.com/48764154/229221181-d241c5a8-e85d-4497-acc3-11d8adda1c9f.png">

## After

loading:
<img width="1140" alt="Screenshot 2023-03-31 at 4 00 11 PM" src="https://user-images.githubusercontent.com/48764154/229229198-059ff2fa-b1ab-4230-924b-9fb19c7a955b.png">

401 error example:
<img width="1146" alt="Screenshot 2023-03-31 at 3 59 18 PM" src="https://user-images.githubusercontent.com/48764154/229229063-9510121c-3cbe-4407-b7b7-317c718ac514.png">
