### PR TITLE
fix(build): handle runtime for build.started == 0

### DIFF
--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -321,7 +321,7 @@ viewPreview msgs openMenu showMenu now zone org repo showTimestamp build =
                     runtime
 
                 _ ->
-                    if build.finished /= 0 then
+                    if build.started /= 0 && build.finished /= 0 then
                         runtime
 
                     else


### PR DESCRIPTION
fixes an issue where a build has no `started` but it has a `finished` (errors)

<img width="579" alt="Screenshot 2023-04-24 at 3 33 27 PM" src="https://user-images.githubusercontent.com/48764154/234110527-2bdb5f40-94d5-4575-93fa-3b5f33fd25c6.png">


looks like this now

<img width="492" alt="Screenshot 2023-04-24 at 3 40 41 PM" src="https://user-images.githubusercontent.com/48764154/234111805-e8d736b3-daf1-455a-a766-073c5b197f5c.png">

