### PR TITLE
feat: adding /pulls shortcut route for viewing pull_request builds

### DIFF
--- a/src/elm/Crumbs.elm
+++ b/src/elm/Crumbs.elm
@@ -270,6 +270,13 @@ toPath page =
                     in
                     [ overviewPage, organizationPage, ( repo, Just <| Pages.RepositoryBuilds org repo maybePage maybePerPage maybeEvent ) ]
 
+                Pages.RepositoryBuildsPulls org repo maybePage maybePerPage ->
+                    let
+                        organizationPage =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+                    in
+                    [ overviewPage, organizationPage, ( repo, Just <| Pages.RepositoryBuildsPulls org repo maybePage maybePerPage ) ]
+
                 Pages.RepositoryDeployments org repo maybePage maybePerPage ->
                     let
                         organizationPage =

--- a/src/elm/Help/Commands.elm
+++ b/src/elm/Help/Commands.elm
@@ -99,6 +99,9 @@ commands page =
         Pages.RepositoryBuilds org repo _ _ _ ->
             [ listBuilds org repo ]
 
+        Pages.RepositoryBuildsPulls org repo _ _ ->
+            [ listBuilds org repo ]
+
         Pages.RepositoryDeployments org repo _ _ ->
             [ listDeployments org repo ]
 
@@ -780,6 +783,9 @@ resourceLoaded args =
         Pages.RepositoryBuilds _ _ _ _ _ ->
             args.builds.success
 
+        Pages.RepositoryBuildsPulls _ _ _ _ ->
+            args.builds.success
+
         Pages.RepositoryDeployments _ _ _ _ ->
             args.deployments.success
 
@@ -859,6 +865,9 @@ resourceLoading args =
             args.builds.loading
 
         Pages.RepositoryBuilds _ _ _ _ _ ->
+            args.builds.loading
+
+        Pages.RepositoryBuildsPulls _ _ _ _ ->
             args.builds.loading
 
         Pages.RepositoryDeployments _ _ _ _ ->

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -3391,7 +3391,7 @@ loadRepoBuildsPage model org repo maybePage maybePerPage maybeEvent =
     loadRepoSubPage model org repo <| Pages.RepositoryBuilds org repo maybePage maybePerPage maybeEvent
 
 
-{-| loadRepoBuildsPullsPage : takes model org and repo and loads the appropriate builds.
+{-| loadRepoBuildsPullsPage : takes model org and repo and loads the appropriate builds for the pull_request event only.
 
     loadRepoBuildsPullsPage   Checks if the builds have already been loaded from the repo view. If not, fetches the builds from the Api.
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -3391,7 +3391,7 @@ loadRepoBuildsPage model org repo maybePage maybePerPage maybeEvent =
     loadRepoSubPage model org repo <| Pages.RepositoryBuilds org repo maybePage maybePerPage maybeEvent
 
 
-{-| loadRepoBuildsPullsPage : takes model org and repo and loads the appropriate builds for the pull_request event only.
+{-| loadRepoBuildsPullsPage : takes model org and repo and loads the appropriate builds for the pull\_request event only.
 
     loadRepoBuildsPullsPage   Checks if the builds have already been loaded from the repo view. If not, fetches the builds from the Api.
 

--- a/src/elm/Pages.elm
+++ b/src/elm/Pages.elm
@@ -30,6 +30,7 @@ type Page
     | SharedSecret Engine Org Team Name
     | RepoSettings Org Repo
     | RepositoryBuilds Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage) (Maybe Event)
+    | RepositoryBuildsPulls Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage)
     | OrgBuilds Org (Maybe Pagination.Page) (Maybe Pagination.PerPage) (Maybe Event)
     | RepositoryDeployments Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage)
     | Build Org Repo BuildNumber FocusFragment
@@ -99,6 +100,9 @@ toRoute page =
 
         RepositoryBuilds org repo maybePage maybePerPage maybeEvent ->
             Routes.RepositoryBuilds org repo maybePage maybePerPage maybeEvent
+
+        RepositoryBuildsPulls org repo maybePage maybePerPage ->
+            Routes.RepositoryBuildsPulls org repo maybePage maybePerPage
 
         OrgBuilds org maybePage maybePerPage maybeEvent ->
             Routes.OrgBuilds org maybePage maybePerPage maybeEvent
@@ -183,6 +187,9 @@ strip page =
 
         RepositoryBuilds org repo _ _ _ ->
             RepositoryBuilds org repo Nothing Nothing Nothing
+
+        RepositoryBuildsPulls org repo _ _ ->
+            RepositoryBuildsPulls org repo Nothing Nothing
 
         RepositoryDeployments org repo _ _ ->
             RepositoryDeployments org repo Nothing Nothing

--- a/src/elm/Routes.elm
+++ b/src/elm/Routes.elm
@@ -37,6 +37,7 @@ type Route
     | SharedSecret Engine Org Team Name
     | RepoSettings Org Repo
     | RepositoryBuilds Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage) (Maybe Event)
+    | RepositoryBuildsPulls Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage)
     | RepositoryDeployments Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage)
     | AddDeploymentRoute Org Repo
     | PromoteDeployment Org Repo BuildNumber
@@ -80,6 +81,7 @@ routes =
         , map PromoteDeployment (string </> string </> s "deployment" </> string)
         , map OrgBuilds (string </> s "builds" <?> Query.int "page" <?> Query.int "per_page" <?> Query.string "event")
         , map RepositoryBuilds (string </> string <?> Query.int "page" <?> Query.int "per_page" <?> Query.string "event")
+        , map RepositoryBuildsPulls (string </> string </> s "pulls" <?> Query.int "page" <?> Query.int "per_page")
         , map RepositoryDeployments (string </> string </> s "deployments" <?> Query.int "page" <?> Query.int "per_page")
         , map Build (string </> string </> string </> fragment identity)
         , map BuildServices (string </> string </> string </> s "services" </> fragment identity)
@@ -157,6 +159,9 @@ routeToUrl route =
 
         RepositoryBuilds org repo maybePage maybePerPage maybeEvent ->
             "/" ++ org ++ "/" ++ repo ++ UB.toQuery (Pagination.toQueryParams maybePage maybePerPage ++ eventToQueryParam maybeEvent)
+
+        RepositoryBuildsPulls org repo maybePage maybePerPage ->
+            "/" ++ org ++ "/" ++ repo ++ "/pulls" ++ UB.toQuery (Pagination.toQueryParams maybePage maybePerPage)
 
         RepositoryDeployments org repo maybePage maybePerPage ->
             "/" ++ org ++ "/" ++ repo ++ "/deployments" ++ UB.toQuery (Pagination.toQueryParams maybePage maybePerPage)


### PR DESCRIPTION
see title, this adds a route shortcut `/org/repo/builds/pulls` for easily viewing only pull request builds.
its basically a shortcut to using `?event=pull_request`  
the idea came from the ease of moving between the SCM and a hosted vela instance. 

if this gets approvals, i will most likely add `/tags` and `/deployments` 


<img width="880" alt="Screenshot 2023-04-26 at 10 33 50 AM" src="https://user-images.githubusercontent.com/48764154/234627611-52475264-cf13-482c-b4f7-2f09be2d09c1.png">

_**Note:**_ it is adding a "reserved route" 