### PR TITLE
feat: adding /tags shortcut route for viewing tag builds

### DIFF
--- a/cypress/integration/builds.spec.js
+++ b/cypress/integration/builds.spec.js
@@ -348,4 +348,38 @@ context('Builds', () => {
       cy.url().should('contain', '?event=comment');
     });
   });
+
+  context('build filter /pulls shortcut', () => {
+    beforeEach(() => {
+      cy.stubBuildsFilter();
+      cy.login('/github/octocat/pulls');
+      cy.get('[data-test=build-filter]').as('buildsFilter');
+    });
+
+    it('renders builds filter', () => {
+      cy.get('@buildsFilter').should('be.visible');
+    });
+
+    it('should only show two pull events', () => {
+      cy.get('[data-test=build]').should('be.visible').should('have.length', 2);
+      cy.url().should('not.contain', '?event=pull_request');
+    });
+  });
+
+  context('build filter /tags shortcut', () => {
+    beforeEach(() => {
+      cy.stubBuildsFilter();
+      cy.login('/github/octocat/tags');
+      cy.get('[data-test=build-filter]').as('buildsFilter');
+    });
+
+    it('renders builds filter', () => {
+      cy.get('@buildsFilter').should('be.visible');
+    });
+
+    it('should only show one tag event', () => {
+      cy.get('[data-test=build]').should('be.visible').should('have.length', 1);
+      cy.url().should('not.contain', '?event=tag');
+    });
+  });
 });

--- a/src/elm/Crumbs.elm
+++ b/src/elm/Crumbs.elm
@@ -277,6 +277,13 @@ toPath page =
                     in
                     [ overviewPage, organizationPage, ( repo, Just <| Pages.RepositoryBuildsPulls org repo maybePage maybePerPage ) ]
 
+                Pages.RepositoryBuildsTags org repo maybePage maybePerPage ->
+                    let
+                        organizationPage =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+                    in
+                    [ overviewPage, organizationPage, ( repo, Just <| Pages.RepositoryBuildsTags org repo maybePage maybePerPage ) ]
+
                 Pages.RepositoryDeployments org repo maybePage maybePerPage ->
                     let
                         organizationPage =

--- a/src/elm/Help/Commands.elm
+++ b/src/elm/Help/Commands.elm
@@ -102,6 +102,9 @@ commands page =
         Pages.RepositoryBuildsPulls org repo _ _ ->
             [ listBuilds org repo ]
 
+        Pages.RepositoryBuildsTags org repo _ _ ->
+            [ listBuilds org repo ]
+
         Pages.RepositoryDeployments org repo _ _ ->
             [ listDeployments org repo ]
 
@@ -786,6 +789,9 @@ resourceLoaded args =
         Pages.RepositoryBuildsPulls _ _ _ _ ->
             args.builds.success
 
+        Pages.RepositoryBuildsTags _ _ _ _ ->
+            args.builds.success
+
         Pages.RepositoryDeployments _ _ _ _ ->
             args.deployments.success
 
@@ -868,6 +874,9 @@ resourceLoading args =
             args.builds.loading
 
         Pages.RepositoryBuildsPulls _ _ _ _ ->
+            args.builds.loading
+
+        Pages.RepositoryBuildsTags _ _ _ _ ->
             args.builds.loading
 
         Pages.RepositoryDeployments _ _ _ _ ->

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -3334,6 +3334,9 @@ loadRepoSubPage model org repo toPage =
                         Pages.RepositoryBuildsPulls o r maybePage maybePerPage ->
                             getBuilds model o r maybePage maybePerPage (Just "pull_request")
 
+                        Pages.RepositoryBuildsTags o r maybePage maybePerPage ->
+                            getBuilds model o r maybePage maybePerPage (Just "tag")
+
                         _ ->
                             getBuilds model org repo Nothing Nothing Nothing
                     , case toPage of

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -3426,7 +3426,7 @@ loadRepoBuildsPage model org repo maybePage maybePerPage maybeEvent =
     loadRepoSubPage model org repo <| Pages.RepositoryBuilds org repo maybePage maybePerPage maybeEvent
 
 
-{-| loadRepoBuildsPullsPage : takes model org and repo and loads the appropriate builds for the pull_request event only.
+{-| loadRepoBuildsPullsPage : takes model org and repo and loads the appropriate builds for the pull\_request event only.
 
     loadRepoBuildsPullsPage   Checks if the builds have already been loaded from the repo view. If not, fetches the builds from the Api.
 
@@ -3435,12 +3435,14 @@ loadRepoBuildsPullsPage : Model -> Org -> Repo -> Maybe Pagination.Page -> Maybe
 loadRepoBuildsPullsPage model org repo maybePage maybePerPage =
     loadRepoSubPage model org repo <| Pages.RepositoryBuildsPulls org repo maybePage maybePerPage
 
+
 {-| loadRepoBuildsTagsPage : takes model org and repo and loads the appropriate builds for the tag event only.
-    loadRepoBuildsTagsPage   Checks if the builds have already been loaded from the repo view. If not, fetches the builds from the Api.
+loadRepoBuildsTagsPage Checks if the builds have already been loaded from the repo view. If not, fetches the builds from the Api.
 -}
 loadRepoBuildsTagsPage : Model -> Org -> Repo -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> ( Model, Cmd Msg )
 loadRepoBuildsTagsPage model org repo maybePage maybePerPage =
     loadRepoSubPage model org repo <| Pages.RepositoryBuildsTags org repo maybePage maybePerPage
+
 
 loadRepoDeploymentsPage : Model -> Org -> Repo -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> ( Model, Cmd Msg )
 loadRepoDeploymentsPage model org repo maybePage maybePerPage =

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2680,6 +2680,35 @@ viewContent model =
                 ]
             )
 
+        Pages.RepositoryBuildsTags org repo maybePage _ ->
+            let
+                shouldRenderFilter : Bool
+                shouldRenderFilter =
+                    case ( model.repo.builds.builds, Just "tag" ) of
+                        ( Success result, Nothing ) ->
+                            not <| List.length result == 0
+
+                        ( Success _, _ ) ->
+                            True
+
+                        ( Loading, _ ) ->
+                            True
+
+                        _ ->
+                            False
+            in
+            ( String.join "/" [ org, repo ] ++ " builds" ++ Util.pageToString maybePage
+            , div []
+                [ div [ class "build-bar" ]
+                    [ viewBuildsFilter shouldRenderFilter org repo (Just "tag")
+                    , viewTimeToggle shouldRenderFilter model.repo.builds.showTimestamp
+                    ]
+                , Pager.view model.repo.builds.pager Pager.defaultLabels GotoPage
+                , lazy8 Pages.Builds.view model.repo.builds buildMsgs model.buildMenuOpen model.time model.zone org repo (Just "tag")
+                , Pager.view model.repo.builds.pager Pager.defaultLabels GotoPage
+                ]
+            )
+
         Pages.Build org repo buildNumber _ ->
             ( "Build #" ++ buildNumber ++ " - " ++ String.join "/" [ org, repo ]
             , Pages.Build.View.viewBuild
@@ -2983,6 +3012,9 @@ setNewPage route model =
 
         ( Routes.RepositoryBuildsPulls org repo maybePage maybePerPage, Authenticated _ ) ->
             loadRepoBuildsPullsPage model org repo maybePage maybePerPage
+
+        ( Routes.RepositoryBuildsTags org repo maybePage maybePerPage, Authenticated _ ) ->
+            loadRepoBuildsTagsPage model org repo maybePage maybePerPage
 
         ( Routes.RepositoryDeployments org repo maybePage maybePerPage, Authenticated _ ) ->
             loadRepoDeploymentsPage model org repo maybePage maybePerPage
@@ -3391,7 +3423,7 @@ loadRepoBuildsPage model org repo maybePage maybePerPage maybeEvent =
     loadRepoSubPage model org repo <| Pages.RepositoryBuilds org repo maybePage maybePerPage maybeEvent
 
 
-{-| loadRepoBuildsPullsPage : takes model org and repo and loads the appropriate builds for the pull\_request event only.
+{-| loadRepoBuildsPullsPage : takes model org and repo and loads the appropriate builds for the pull_request event only.
 
     loadRepoBuildsPullsPage   Checks if the builds have already been loaded from the repo view. If not, fetches the builds from the Api.
 
@@ -3400,6 +3432,12 @@ loadRepoBuildsPullsPage : Model -> Org -> Repo -> Maybe Pagination.Page -> Maybe
 loadRepoBuildsPullsPage model org repo maybePage maybePerPage =
     loadRepoSubPage model org repo <| Pages.RepositoryBuildsPulls org repo maybePage maybePerPage
 
+{-| loadRepoBuildsTagsPage : takes model org and repo and loads the appropriate builds for the tag event only.
+    loadRepoBuildsTagsPage   Checks if the builds have already been loaded from the repo view. If not, fetches the builds from the Api.
+-}
+loadRepoBuildsTagsPage : Model -> Org -> Repo -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> ( Model, Cmd Msg )
+loadRepoBuildsTagsPage model org repo maybePage maybePerPage =
+    loadRepoSubPage model org repo <| Pages.RepositoryBuildsTags org repo maybePage maybePerPage
 
 loadRepoDeploymentsPage : Model -> Org -> Repo -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> ( Model, Cmd Msg )
 loadRepoDeploymentsPage model org repo maybePage maybePerPage =

--- a/src/elm/Pages.elm
+++ b/src/elm/Pages.elm
@@ -31,6 +31,7 @@ type Page
     | RepoSettings Org Repo
     | RepositoryBuilds Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage) (Maybe Event)
     | RepositoryBuildsPulls Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage)
+    | RepositoryBuildsTags Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage)
     | OrgBuilds Org (Maybe Pagination.Page) (Maybe Pagination.PerPage) (Maybe Event)
     | RepositoryDeployments Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage)
     | Build Org Repo BuildNumber FocusFragment
@@ -103,6 +104,9 @@ toRoute page =
 
         RepositoryBuildsPulls org repo maybePage maybePerPage ->
             Routes.RepositoryBuildsPulls org repo maybePage maybePerPage
+
+        RepositoryBuildsTags org repo maybePage maybePerPage ->
+            Routes.RepositoryBuildsTags org repo maybePage maybePerPage
 
         OrgBuilds org maybePage maybePerPage maybeEvent ->
             Routes.OrgBuilds org maybePage maybePerPage maybeEvent
@@ -190,6 +194,9 @@ strip page =
 
         RepositoryBuildsPulls org repo _ _ ->
             RepositoryBuildsPulls org repo Nothing Nothing
+
+        RepositoryBuildsTags org repo _ _ ->
+            RepositoryBuildsTags org repo Nothing Nothing
 
         RepositoryDeployments org repo _ _ ->
             RepositoryDeployments org repo Nothing Nothing

--- a/src/elm/Routes.elm
+++ b/src/elm/Routes.elm
@@ -38,6 +38,7 @@ type Route
     | RepoSettings Org Repo
     | RepositoryBuilds Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage) (Maybe Event)
     | RepositoryBuildsPulls Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage)
+    | RepositoryBuildsTags Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage)
     | RepositoryDeployments Org Repo (Maybe Pagination.Page) (Maybe Pagination.PerPage)
     | AddDeploymentRoute Org Repo
     | PromoteDeployment Org Repo BuildNumber
@@ -82,6 +83,7 @@ routes =
         , map OrgBuilds (string </> s "builds" <?> Query.int "page" <?> Query.int "per_page" <?> Query.string "event")
         , map RepositoryBuilds (string </> string <?> Query.int "page" <?> Query.int "per_page" <?> Query.string "event")
         , map RepositoryBuildsPulls (string </> string </> s "pulls" <?> Query.int "page" <?> Query.int "per_page")
+        , map RepositoryBuildsTags (string </> string </> s "tags" <?> Query.int "page" <?> Query.int "per_page")
         , map RepositoryDeployments (string </> string </> s "deployments" <?> Query.int "page" <?> Query.int "per_page")
         , map Build (string </> string </> string </> fragment identity)
         , map BuildServices (string </> string </> string </> s "services" </> fragment identity)
@@ -162,6 +164,9 @@ routeToUrl route =
 
         RepositoryBuildsPulls org repo maybePage maybePerPage ->
             "/" ++ org ++ "/" ++ repo ++ "/pulls" ++ UB.toQuery (Pagination.toQueryParams maybePage maybePerPage)
+
+        RepositoryBuildsTags org repo maybePage maybePerPage ->
+            "/" ++ org ++ "/" ++ repo ++ "/tags" ++ UB.toQuery (Pagination.toQueryParams maybePage maybePerPage)
 
         RepositoryDeployments org repo maybePage maybePerPage ->
             "/" ++ org ++ "/" ++ repo ++ "/deployments" ++ UB.toQuery (Pagination.toQueryParams maybePage maybePerPage)


### PR DESCRIPTION
see: https://github.com/go-vela/ui/pull/656
same change, but for tag event
this adds a route shortcut `/org/repo/builds/tags` for easily viewing only tag builds.
its basically a shortcut to using `?event=tag`


i find myself swapping between github and vela, and like the convenience of being able to swap the host and like when the vela url matches with filtered content.

<img width="958" alt="Screenshot 2023-05-16 at 9 33 15 AM" src="https://github.com/go-vela/ui/assets/48764154/378e6576-21fa-4cc6-8301-25f657fc924c">

_**Note:**_ it is adding a "reserved route" 
