### PR TITLE
fix: crumb link consistency

### DIFF
--- a/cypress/integration/crumbs.spec.js
+++ b/cypress/integration/crumbs.spec.js
@@ -92,10 +92,7 @@ context('Crumbs', () => {
     });
     it('repo crumb should redirect to repo builds', () => {
       cy.get('[data-test=crumb-octocat]').click();
-      cy.location('pathname').should(
-        'eq',
-        '/github/octocat',
-      );
+      cy.location('pathname').should('eq', '/github/octocat');
     });
     it('Repo Secrets crumb should redirect to repo secrets', () => {
       cy.get('[data-test=crumb-repo-secrets]').click();

--- a/cypress/integration/crumbs.spec.js
+++ b/cypress/integration/crumbs.spec.js
@@ -90,8 +90,15 @@ context('Crumbs', () => {
       cy.get('[data-test=crumb-octocat]').should('exist');
       cy.get('[data-test=crumb-password]').should('exist');
     });
-    it('Secrets crumb should redirect to repo secrets', () => {
+    it('repo crumb should redirect to repo builds', () => {
       cy.get('[data-test=crumb-octocat]').click();
+      cy.location('pathname').should(
+        'eq',
+        '/github/octocat',
+      );
+    });
+    it('Repo Secrets crumb should redirect to repo secrets', () => {
+      cy.get('[data-test=crumb-repo-secrets]').click();
       cy.location('pathname').should(
         'eq',
         '/-/secrets/native/repo/github/octocat',

--- a/src/elm/Crumbs.elm
+++ b/src/elm/Crumbs.elm
@@ -163,23 +163,20 @@ toPath page =
 
                 Pages.AddOrgSecret engine org ->
                     let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
-
                         orgSecrets =
-                            ( "Secrets", Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
                     in
-                    [ overviewPage, organizationPage, orgSecrets, ( "Add", Nothing ) ]
+                    [ overviewPage, orgSecrets, ( "Secret", Nothing ), ( "Add", Nothing ) ]
 
                 Pages.AddRepoSecret engine org repo ->
                     let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+                        orgSecrets =
+                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
 
-                        currentRepo =
+                        repoSecrets =
                             ( repo, Just <| Pages.RepoSecrets engine org repo Nothing Nothing )
                     in
-                    [ overviewPage, organizationPage, currentRepo, ( "Add", Nothing ) ]
+                    [ overviewPage, orgSecrets, repoSecrets, ( "Secret", Nothing ), ( "Add", Nothing ) ]
 
                 Pages.AddDeployment org repo ->
                     let
@@ -189,7 +186,7 @@ toPath page =
                         currentRepo =
                             ( repo, Just <| Pages.RepositoryDeployments org repo Nothing Nothing )
                     in
-                    [ overviewPage, orgPage, currentRepo, ( "Add Deployment", Nothing ) ]
+                    [ overviewPage, orgPage, currentRepo, ( "Deployment", Nothing ), ( "Add", Nothing ) ]
 
                 Pages.PromoteDeployment org repo _ ->
                     let
@@ -199,12 +196,12 @@ toPath page =
                         currentRepo =
                             ( repo, Just <| Pages.RepositoryDeployments org repo Nothing Nothing )
                     in
-                    [ overviewPage, orgPage, currentRepo, ( "Add Deployment", Nothing ) ]
+                    [ overviewPage, orgPage, currentRepo, ( "Deployment", Nothing ), ( "Add", Nothing ) ]
 
                 Pages.AddSharedSecret engine org team ->
                     let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+                        orgSecrets =
+                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
 
                         teamPage =
                             ( team, Nothing )
@@ -212,38 +209,35 @@ toPath page =
                         sharedSecrets =
                             ( "Shared Secrets", Just <| Pages.SharedSecrets engine org team Nothing Nothing )
                     in
-                    [ overviewPage, organizationPage, teamPage, sharedSecrets, ( "Add", Nothing ) ]
+                    [ overviewPage, orgSecrets, teamPage, sharedSecrets, ( "Add", Nothing ) ]
 
                 Pages.OrgSecret engine org name ->
                     let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
-
                         orgSecrets =
-                            ( "Secrets", Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
 
                         nameCrumb =
                             ( name, Nothing )
                     in
-                    [ overviewPage, organizationPage, orgSecrets, nameCrumb ]
+                    [ overviewPage, orgSecrets, ( "Secret", Nothing ), nameCrumb ]
 
                 Pages.RepoSecret engine org repo name ->
                     let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+                        orgSecrets =
+                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
 
-                        currentRepo =
+                        repoSecrets =
                             ( repo, Just <| Pages.RepoSecrets engine org repo Nothing Nothing )
 
                         nameCrumb =
                             ( name, Nothing )
                     in
-                    [ overviewPage, organizationPage, currentRepo, nameCrumb ]
+                    [ overviewPage, orgSecrets, repoSecrets, ( "Secret", Nothing ), nameCrumb ]
 
                 Pages.SharedSecret engine org team name ->
                     let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+                        orgSecrets =
+                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
 
                         teamPage =
                             ( team, Nothing )
@@ -254,7 +248,7 @@ toPath page =
                         nameCrumb =
                             ( name, Nothing )
                     in
-                    [ overviewPage, organizationPage, teamPage, sharedSecrets, nameCrumb ]
+                    [ overviewPage, orgSecrets, teamPage, sharedSecrets, nameCrumb ]
 
                 Pages.OrgBuilds org _ _ _ ->
                     let

--- a/src/elm/Crumbs.elm
+++ b/src/elm/Crumbs.elm
@@ -78,286 +78,331 @@ item crumb currentPage =
 toPath : Page -> List Crumb
 toPath page =
     let
-        overviewPage =
+        -- crumbs used across multiple pages
+        overviewCrumbLink =
             ( "Overview", Just Pages.Overview )
 
-        accountPage =
+        accountCrumbStatic =
             ( "Account", Nothing )
 
-        sourceRepositoriesPage =
+        sourceRepositoriesCrumbLink =
             ( "Source Repositories", Just Pages.SourceRepositories )
 
-        notFoundPage =
-            ( "Not Found", Nothing )
+        addCrumbStatic =
+            ( "Add", Nothing )
 
         pages =
             case page of
                 Pages.Overview ->
-                    [ overviewPage ]
+                    [ overviewCrumbLink ]
 
                 Pages.SourceRepositories ->
-                    [ overviewPage, accountPage, sourceRepositoriesPage ]
+                    [ overviewCrumbLink, accountCrumbStatic, sourceRepositoriesCrumbLink ]
 
                 Pages.OrgRepositories org _ _ ->
                     let
-                        organizationPage =
+                        orgCrumbStatic =
                             ( org, Nothing )
                     in
-                    [ overviewPage, organizationPage ]
+                    [ overviewCrumbLink, orgCrumbStatic ]
 
                 Pages.Hooks org repo _ _ ->
                     let
-                        organizationPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        currentRepo =
+                        repoCrumbStatic =
                             ( repo, Nothing )
                     in
-                    [ overviewPage
-                    , organizationPage
-                    , currentRepo
-                    ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoCrumbStatic ]
 
                 Pages.RepoSettings org repo ->
                     let
-                        organizationPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        currentRepo =
+                        repoCrumbStatic =
                             ( repo, Nothing )
                     in
-                    [ overviewPage
-                    , organizationPage
-                    , currentRepo
-                    ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoCrumbStatic ]
 
                 Pages.OrgSecrets _ org _ _ ->
                     let
-                        organizationPage =
+                        orgCrumbStatic =
                             ( org, Nothing )
                     in
-                    [ overviewPage, organizationPage ]
+                    [ overviewCrumbLink, orgCrumbStatic ]
 
                 Pages.RepoSecrets _ org repo _ _ ->
                     let
-                        organizationPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        currentRepo =
+                        repoCrumbStatic =
                             ( repo, Nothing )
                     in
-                    [ overviewPage, organizationPage, currentRepo ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoCrumbStatic ]
 
                 Pages.SharedSecrets _ org team maybePage _ ->
                     let
-                        organizationPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        teamPage =
+                        teamCrumbStatic =
                             ( team, Nothing )
 
-                        sharedSecrets =
+                        sharedSecretsCrumbStatic =
                             ( "Shared Secrets" ++ pageToString maybePage, Nothing )
                     in
-                    [ overviewPage, organizationPage, teamPage, sharedSecrets ]
+                    [ overviewCrumbLink, orgReposCrumbLink, teamCrumbStatic, sharedSecretsCrumbStatic ]
 
                 Pages.AddOrgSecret engine org ->
                     let
-                        orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+
+                        orgSecretsCrumbLink =
+                            ( "Org Secrets", Just <| Pages.OrgSecrets engine org Nothing Nothing )
                     in
-                    [ overviewPage, orgSecrets, ( "Secret", Nothing ), ( "Add", Nothing ) ]
+                    [ overviewCrumbLink, orgReposCrumbLink, orgSecretsCrumbLink, addCrumbStatic ]
 
                 Pages.AddRepoSecret engine org repo ->
                     let
-                        orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        repoSecrets =
-                            ( repo, Just <| Pages.RepoSecrets engine org repo Nothing Nothing )
+                        repoBuildsCrumbLink =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
+                        repoSecretsCrumbLink =
+                            ( "Repo Secrets", Just <| Pages.RepoSecrets engine org repo Nothing Nothing )
                     in
-                    [ overviewPage, orgSecrets, repoSecrets, ( "Secret", Nothing ), ( "Add", Nothing ) ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoBuildsCrumbLink, repoSecretsCrumbLink, addCrumbStatic ]
 
                 Pages.AddDeployment org repo ->
                     let
-                        orgPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        currentRepo =
-                            ( repo, Just <| Pages.RepositoryDeployments org repo Nothing Nothing )
+                        repoBuildsCrumbLink =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
+                        deploymentsCrumbLink =
+                            ( "Deployments", Just <| Pages.RepositoryDeployments org repo Nothing Nothing )
                     in
-                    [ overviewPage, orgPage, currentRepo, ( "Deployment", Nothing ), ( "Add", Nothing ) ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoBuildsCrumbLink, deploymentsCrumbLink, addCrumbStatic ]
 
                 Pages.PromoteDeployment org repo _ ->
                     let
-                        orgPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        currentRepo =
-                            ( repo, Just <| Pages.RepositoryDeployments org repo Nothing Nothing )
+                        repoBuildsCrumbLink =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
+                        deploymentsCrumbLink =
+                            ( "Deployments", Just <| Pages.RepositoryDeployments org repo Nothing Nothing )
                     in
-                    [ overviewPage, orgPage, currentRepo, ( "Deployment", Nothing ), ( "Add", Nothing ) ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoBuildsCrumbLink, deploymentsCrumbLink, addCrumbStatic ]
 
                 Pages.AddSharedSecret engine org team ->
                     let
-                        orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        teamPage =
+                        teamCrumbStatic =
                             ( team, Nothing )
 
-                        sharedSecrets =
+                        sharedSecretsCrumbLink =
                             ( "Shared Secrets", Just <| Pages.SharedSecrets engine org team Nothing Nothing )
                     in
-                    [ overviewPage, orgSecrets, teamPage, sharedSecrets, ( "Add", Nothing ) ]
+                    [ overviewCrumbLink, orgReposCrumbLink, teamCrumbStatic, sharedSecretsCrumbLink, addCrumbStatic ]
 
                 Pages.OrgSecret engine org name ->
                     let
-                        orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        nameCrumb =
+                        orgSecretsCrumbLink =
+                            ( "Org Secrets", Just <| Pages.OrgSecrets engine org Nothing Nothing )
+
+                        nameCrumbStatic =
                             ( name, Nothing )
                     in
-                    [ overviewPage, orgSecrets, ( "Secret", Nothing ), nameCrumb ]
+                    [ overviewCrumbLink, orgReposCrumbLink, orgSecretsCrumbLink, nameCrumbStatic ]
 
                 Pages.RepoSecret engine org repo name ->
                     let
-                        orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        repoSecrets =
-                            ( repo, Just <| Pages.RepoSecrets engine org repo Nothing Nothing )
+                        repoBuildsCrumbLink =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
 
-                        nameCrumb =
+                        repoSecretsCrumbLink =
+                            ( "Repo Secrets", Just <| Pages.RepoSecrets engine org repo Nothing Nothing )
+
+                        nameCrumbStatic =
                             ( name, Nothing )
                     in
-                    [ overviewPage, orgSecrets, repoSecrets, ( "Secret", Nothing ), nameCrumb ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoBuildsCrumbLink, repoSecretsCrumbLink, nameCrumbStatic ]
 
                 Pages.SharedSecret engine org team name ->
                     let
-                        orgSecrets =
-                            ( org, Just <| Pages.OrgSecrets engine org Nothing Nothing )
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        teamPage =
+                        teamCrumbStatic =
                             ( team, Nothing )
 
-                        sharedSecrets =
+                        sharedSecretsCrumbLink =
                             ( "Shared Secrets", Just <| Pages.SharedSecrets engine org team Nothing Nothing )
 
-                        nameCrumb =
+                        nameCrumbStatic =
                             ( name, Nothing )
                     in
-                    [ overviewPage, orgSecrets, teamPage, sharedSecrets, nameCrumb ]
+                    [ overviewCrumbLink, orgReposCrumbLink, teamCrumbStatic, sharedSecretsCrumbLink, nameCrumbStatic ]
 
                 Pages.OrgBuilds org _ _ _ ->
                     let
                         organizationPage =
                             ( org, Nothing )
                     in
-                    [ overviewPage, organizationPage ]
+                    [ overviewCrumbLink, organizationPage ]
 
-                Pages.RepositoryBuilds org repo maybePage maybePerPage maybeEvent ->
+                Pages.RepositoryBuilds org repo _ _ _ ->
                     let
-                        organizationPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
-                    in
-                    [ overviewPage, organizationPage, ( repo, Just <| Pages.RepositoryBuilds org repo maybePage maybePerPage maybeEvent ) ]
 
-                Pages.RepositoryBuildsPulls org repo maybePage maybePerPage ->
-                    let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+                        repoCrumbStatic =
+                            ( repo, Nothing )
                     in
-                    [ overviewPage, organizationPage, ( repo, Just <| Pages.RepositoryBuildsPulls org repo maybePage maybePerPage ) ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoCrumbStatic ]
 
-                Pages.RepositoryBuildsTags org repo maybePage maybePerPage ->
+                Pages.RepositoryBuildsPulls org repo _ _ ->
                     let
-                        organizationPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
-                    in
-                    [ overviewPage, organizationPage, ( repo, Just <| Pages.RepositoryBuildsTags org repo maybePage maybePerPage ) ]
 
-                Pages.RepositoryDeployments org repo maybePage maybePerPage ->
-                    let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+                        repoCrumbStatic =
+                            ( repo, Nothing )
                     in
-                    [ overviewPage, organizationPage, ( repo, Just <| Pages.RepositoryDeployments org repo maybePage maybePerPage ) ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoCrumbStatic ]
+
+                Pages.RepositoryBuildsTags org repo _ _ ->
+                    let
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+
+                        repoCrumbStatic =
+                            ( repo, Nothing )
+                    in
+                    [ overviewCrumbLink, orgReposCrumbLink, repoCrumbStatic ]
+
+                Pages.RepositoryDeployments org repo _ _ ->
+                    let
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+
+                        repoCrumbStatic =
+                            ( repo, Nothing )
+                    in
+                    [ overviewCrumbLink, orgReposCrumbLink, repoCrumbStatic ]
 
                 Pages.Build org repo buildNumber _ ->
                     let
-                        organizationPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+
+                        repoBuildsCrumbLink =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
+                        buildNumberCrumbStatic =
+                            ( "#" ++ buildNumber, Nothing )
                     in
-                    [ overviewPage
-                    , organizationPage
-                    , ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
-                    , ( "#" ++ buildNumber, Nothing )
-                    ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoBuildsCrumbLink, buildNumberCrumbStatic ]
 
                 Pages.BuildServices org repo buildNumber _ ->
                     let
-                        organizationPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+
+                        repoBuildsCrumbLink =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
+                        buildNumberCrumbStatic =
+                            ( "#" ++ buildNumber, Nothing )
                     in
-                    [ overviewPage
-                    , organizationPage
-                    , ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
-                    , ( "#" ++ buildNumber, Nothing )
-                    ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoBuildsCrumbLink, buildNumberCrumbStatic ]
 
                 Pages.BuildPipeline org repo buildNumber _ _ ->
                     let
-                        organizationPage =
+                        orgReposCrumbLink =
                             ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
 
-                        repoBuildsPage =
+                        repoBuildsCrumbLink =
                             ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
+                        buildNumberCrumbStatic =
+                            ( "#" ++ buildNumber, Nothing )
                     in
-                    [ overviewPage
-                    , organizationPage
-                    , repoBuildsPage
-                    , ( "#" ++ buildNumber, Nothing )
-                    ]
+                    [ overviewCrumbLink, orgReposCrumbLink, repoBuildsCrumbLink, buildNumberCrumbStatic ]
+
+                Pages.Schedule org repo name ->
+                    let
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+
+                        repoBuildsCrumbLink =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
+                        schedulesCrumbLink =
+                            ( "Schedules", Just <| Pages.Schedules org repo Nothing Nothing )
+
+                        nameCrumbStatic =
+                            ( name, Nothing )
+                    in
+                    [ overviewCrumbLink, orgReposCrumbLink, repoBuildsCrumbLink, schedulesCrumbLink, nameCrumbStatic ]
+
+                Pages.Schedules org repo _ _ ->
+                    let
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+
+                        repoCrumbStatic =
+                            ( repo, Nothing )
+                    in
+                    [ overviewCrumbLink, orgReposCrumbLink, repoCrumbStatic ]
+
+                Pages.AddSchedule org repo ->
+                    let
+                        orgReposCrumbLink =
+                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
+
+                        repoBuildsCrumbLink =
+                            ( repo, Just <| Pages.RepositoryBuilds org repo Nothing Nothing Nothing )
+
+                        schedulesCrumbLink =
+                            ( "Schedules", Just <| Pages.Schedules org repo Nothing Nothing )
+                    in
+                    [ overviewCrumbLink, orgReposCrumbLink, repoBuildsCrumbLink, schedulesCrumbLink, addCrumbStatic ]
 
                 Pages.Login ->
                     []
 
                 Pages.Settings ->
-                    [ ( "Overview", Just Pages.Overview ), ( "My Settings", Nothing ) ]
+                    let
+                        settingsCrumbStatic =
+                            ( "My Settings", Nothing )
+                    in
+                    [ overviewCrumbLink, settingsCrumbStatic ]
 
                 Pages.NotFound ->
-                    [ overviewPage, notFoundPage ]
-
-                Pages.Schedule org repo name ->
                     let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
-
-                        currentRepo =
-                            ( repo, Just <| Pages.Schedules org repo Nothing Nothing )
+                        notFoundCrumbStatic =
+                            ( "Not Found", Nothing )
                     in
-                    [ overviewPage, organizationPage, currentRepo, ( "Schedule", Nothing ), ( name, Nothing ) ]
-
-                Pages.Schedules org repo _ _ ->
-                    let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
-
-                        currentRepo =
-                            ( repo, Just <| Pages.Schedules org repo Nothing Nothing )
-                    in
-                    [ overviewPage, organizationPage, currentRepo ]
-
-                Pages.AddSchedule org repo ->
-                    let
-                        organizationPage =
-                            ( org, Just <| Pages.OrgRepositories org Nothing Nothing )
-
-                        currentRepo =
-                            ( repo, Just <| Pages.Schedules org repo Nothing Nothing )
-                    in
-                    [ overviewPage, organizationPage, currentRepo, ( "Schedule", Nothing ), ( "Add", Nothing ) ]
+                    [ overviewCrumbLink, notFoundCrumbStatic ]
     in
     pages


### PR DESCRIPTION
### making the crumbs consistent.

with this change, if you're viewing secrets, the crumbs can redirect you back to secrets (for org,repo respectively)
the `Org` and `Repo` crumbs will now _*always*_ link to the org repos, and repo builds pages.

it also makes the usage of "Secret" > "Add" and "Schedule" > "Add" more consistent by making the crumbs display the resource if you're not viewing a repo tab

### example before

<img width="765" alt="Screenshot 2023-06-08 at 1 19 47 PM" src="https://github.com/go-vela/ui/assets/48764154/21d1f8ba-8afa-4130-bc72-25d336a4b63b">

### after  (updated)

<img width="752" alt="Screenshot 2023-06-09 at 11 32 15 AM" src="https://github.com/go-vela/ui/assets/48764154/f0c8d295-4d33-4322-a23d-9736ed36c29b">

which matches the others more consistently now

<img width="736" alt="Screenshot 2023-06-09 at 11 29 34 AM" src="https://github.com/go-vela/ui/assets/48764154/f011310d-f98d-49c3-b153-a802316f95d5">

<img width="609" alt="Screenshot 2023-06-09 at 11 29 48 AM" src="https://github.com/go-vela/ui/assets/48764154/3b3c5561-35cd-49fd-9001-412e7cd987ad">

<img width="723" alt="Screenshot 2023-06-09 at 11 29 56 AM" src="https://github.com/go-vela/ui/assets/48764154/e920ddf1-f775-43fc-a464-86e65301f737">

