### PR TITLE
fix: move add shared secret button

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2544,7 +2544,7 @@ viewContent model =
         Pages.SharedSecrets engine org team _ _ ->
             ( String.join "/" [ org, team ] ++ " " ++ engine ++ " shared secrets"
             , div []
-                [ Html.map SecretsUpdate <| lazy3 Pages.Secrets.View.viewSharedSecrets model False False
+                [ Html.map SecretsUpdate <| lazy3 Pages.Secrets.View.viewSharedSecrets model False True
                 , Pager.view model.secretsModel.sharedSecretsPager Pager.prevNextLabels GotoPage
                 ]
             )

--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -143,17 +143,6 @@ navButtons model { fetchSourceRepos, toggleFavorite, restartBuild, cancelBuild }
         Pages.RepoSecrets _ org repo _ _ ->
             starToggle org repo toggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo
 
-        Pages.SharedSecrets engine org team _ _ ->
-            div [ class "buttons" ]
-                [ a
-                    [ class "button"
-                    , class "-outline"
-                    , Routes.href <|
-                        Routes.AddSharedSecret engine org team
-                    ]
-                    [ text "Add Shared Secret" ]
-                ]
-
         Pages.Build org repo _ _ ->
             div [ class "buttons" ]
                 [ cancelBuildButton org repo model.repo.build.build cancelBuild


### PR DESCRIPTION
moving the "add shared secret" button into the actual table.

## before
<img width="1722" alt="Screenshot 2023-06-09 at 3 49 17 PM" src="https://github.com/go-vela/ui/assets/48764154/258ed1a0-561c-4044-a7ea-7dba4cf6ccf5">

## after
<img width="1720" alt="Screenshot 2023-06-09 at 3 49 07 PM" src="https://github.com/go-vela/ui/assets/48764154/0a5f5b73-86e9-40db-b85c-2cf5b0168be6">
