### PR TITLE
fix: login blip when refreshing a page

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -3202,7 +3202,14 @@ setNewPage route model =
            browser's back button
         --}
         ( _, Unauthenticated ) ->
-            ( { model | page = if model.authRedirect then model.page else Pages.Login  }
+            ( { model
+                | page =
+                    if model.authRedirect then
+                        model.page
+
+                    else
+                        Pages.Login
+              }
             , Interop.setRedirect <| Encode.string <| Url.toString model.entryURL
             )
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -3198,9 +3198,10 @@ setNewPage route model =
 
            Note: we're not using .pushUrl to retain ability for user to use
            browser's back button
+           Note: we retain the current page to avoid blipping content when the user refreshes the page
         --}
         ( _, Unauthenticated ) ->
-            ( { model | page = Pages.Login }
+            ( { model | page = model.page }
             , Interop.setRedirect <| Encode.string <| Url.toString model.entryURL
             )
 


### PR DESCRIPTION
this fixes a "Login Page" blip when you refresh the browser

it adds a boolean to track when a page is loading for the first time without an auth redirect, and skips the redirect to `Pages.Login` until `TokenResponse` can flip the boolean to `False`.  

it retains all of the current functionality since when the user is unauthenticated, for example if the cookies are cleared, or the token in cookies expires, token refresh will fail and cause the Login page redirect.


## before (slowed down to express the issue)

https://github.com/go-vela/ui/assets/48764154/7bc5595f-2635-4517-9996-914377196f5a

## after

https://github.com/go-vela/ui/assets/48764154/6e0a9a8a-b32f-4002-90d4-9297253ca2e7


