### PR TITLE
fix(schedules): correct encoding of update schedule payload for active field

### DIFF
--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -1788,11 +1788,11 @@ decodeSchedules =
 
 
 encodeUpdateSchedule : UpdateSchedulePayload -> Encode.Value
-encodeUpdateSchedule secret =
+encodeUpdateSchedule schedule =
     Encode.object
-        [ ( "name", encodeOptional Encode.string secret.name )
-        , ( "entry", encodeOptional Encode.string secret.entry )
-        , ( "enabled", encodeOptional Encode.bool secret.enabled )
+        [ ( "name", encodeOptional Encode.string schedule.name )
+        , ( "entry", encodeOptional Encode.string schedule.entry )
+        , ( "active", encodeOptional Encode.bool schedule.enabled )
         ]
 
 


### PR DESCRIPTION
Calls to enable/disable an existing schedule in the UI do not work because the payload is encoded as `enabled: bool` rather than `active: bool`.