### PR TITLE
chore(deps): pin nginx image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fholzer/nginx-brotli:v1.24.0
+FROM fholzer/nginx-brotli:v1.24.0@sha256:55b6e7e04fa7eaf1bb0be210b9ea106292686deab6349a6efb9b52d229b0e940
 
 RUN apk update && \
     apk add --no-cache ca-certificates && \

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM fholzer/nginx-brotli:v1.24.0
+FROM fholzer/nginx-brotli:v1.24.0@sha256:55b6e7e04fa7eaf1bb0be210b9ea106292686deab6349a6efb9b52d229b0e940
 
 RUN apk update && \
     apk add --no-cache ca-certificates && \


### PR DESCRIPTION
While we figure out how to stop renovate from suggesting we pin `docker-compose` service images, this will address https://github.com/go-vela/ui/pull/705 for now