### PR TITLE
fix: improve shouldRefresh logic for steps/services

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2412,6 +2412,7 @@ shouldRefresh page build =
             (not <| isComplete bld.status)
                 -- any steps or services are incomplete
                 || (case page of
+                        -- check steps when viewing build tab
                         Pages.Build _ _ _ _ ->
                             case build.steps.steps of
                                 Success steps ->
@@ -2427,10 +2428,7 @@ shouldRefresh page build =
                                 Loading ->
                                     False
 
-                        _ ->
-                            False
-                   )
-                || (case page of
+                        -- check services when viewing services tab
                         Pages.BuildServices _ _ _ _ ->
                             case build.services.services of
                                 Success services ->


### PR DESCRIPTION
fixes a regression introduced by https://github.com/go-vela/ui/pull/642

two changes:
- return `False` when the resource is `NotAsked` to avoid refreshing in scenarios where the user hasnt looked at a tab yet.
- use the current `page` to check only the relevant resource in scenarios where the user has changed tabs.