### PR TITLE
fix(schedules): add precise date+time to last_updated and last_scheduled

### DIFF
--- a/src/elm/Pages/Build/History.elm
+++ b/src/elm/Pages/Build/History.elm
@@ -133,8 +133,8 @@ recentBuildTooltip now timezone build =
                 , em [] [ text build.event ]
                 ]
             , buildInfo build
-            , viewTooltipField "started:" <| Util.humanReadableWithDefault timezone build.started
-            , viewTooltipField "finished:" <| Util.humanReadableWithDefault timezone build.finished
+            , viewTooltipField "started:" <| Util.humanReadableDateWithDefault timezone build.started
+            , viewTooltipField "finished:" <| Util.humanReadableDateWithDefault timezone build.finished
             , viewTooltipField "duration:" <| Util.formatRunTime now build.started build.finished
             , viewTooltipField "worker:" build.host
             , viewTooltipField "author:" build.author

--- a/src/elm/Pages/Schedules/View.elm
+++ b/src/elm/Pages/Schedules/View.elm
@@ -173,7 +173,7 @@ renderSchedule zone org repo schedule =
             , scope "row"
             , class "break-word"
             ]
-            [ text <| Util.humanReadableWithDefault zone schedule.scheduled_at ]
+            [ text <| Util.humanReadableDateTimeWithDefault zone schedule.scheduled_at ]
         , td
             [ attribute "data-label" "updated by"
             , scope "row"
@@ -185,7 +185,7 @@ renderSchedule zone org repo schedule =
             , scope "row"
             , class "break-word"
             ]
-            [ text <| Util.humanReadableWithDefault zone schedule.updated_at ]
+            [ text <| Util.humanReadableDateTimeWithDefault zone schedule.updated_at ]
         ]
 
 

--- a/src/elm/Util.elm
+++ b/src/elm/Util.elm
@@ -22,7 +22,8 @@ module Util exposing
     , formatTestTag
     , getNameFromRef
     , humanReadableDateTimeFormatter
-    , humanReadableWithDefault
+    , humanReadableDateTimeWithDefault
+    , humanReadableDateWithDefault
     , isLoading
     , isSuccess
     , largeLoader
@@ -84,22 +85,26 @@ millisToSeconds millis =
     millis // 1000
 
 
-{-| dateToHumanReadable : takes timezone and posix timestamp and returns human readable date string
+{-| humanReadableDateWithDefault : takes timezone and posix timestamp and returns human readable date string with a default value for 0
 -}
-dateToHumanReadable : Zone -> Int -> String
-dateToHumanReadable timezone time =
-    humanReadableDateFormatter timezone <| Time.millisToPosix <| secondsToMillis time
-
-
-{-| humanReadableWithDefault : takes timezone and posix timestamp and returns human readable date string with a default value for 0
--}
-humanReadableWithDefault : Zone -> Int -> String
-humanReadableWithDefault timezone t =
+humanReadableDateWithDefault : Zone -> Int -> String
+humanReadableDateWithDefault timezone t =
     if t == 0 then
         "-"
 
     else
-        dateToHumanReadable timezone t
+        humanReadableDateFormatter timezone <| Time.millisToPosix <| secondsToMillis t
+
+
+{-| humanReadableDateTimeWithDefault : takes timezone and posix timestamp and returns human readable date time string with a default value for 0
+-}
+humanReadableDateTimeWithDefault : Zone -> Int -> String
+humanReadableDateTimeWithDefault timezone t =
+    if t == 0 then
+        "-"
+
+    else
+        humanReadableDateTimeFormatter timezone <| Time.millisToPosix <| secondsToMillis t
 
 
 {-| humanReadableDateFormatter : formats a zone and date into human readable chunks
@@ -120,17 +125,15 @@ humanReadableDateFormatter =
 humanReadableDateTimeFormatter : Zone -> Posix -> String
 humanReadableDateTimeFormatter =
     DateFormat.format
-        [ DateFormat.monthNameAbbreviated
-        , DateFormat.text " "
-        , DateFormat.dayOfMonthSuffix
-        , DateFormat.text ", "
+        [ DateFormat.monthFixed
+        , DateFormat.text "/"
+        , DateFormat.dayOfMonthFixed
+        , DateFormat.text "/"
         , DateFormat.yearNumber
         , DateFormat.text " at "
         , DateFormat.hourFixed
         , DateFormat.text ":"
         , DateFormat.minuteFixed
-        , DateFormat.text ":"
-        , DateFormat.secondFixed
         , DateFormat.text " "
         , DateFormat.amPmUppercase
         ]


### PR DESCRIPTION
see title. it could be added as hover, but i think for last updated timestamps and other audit-fields similar to that should just render as the full timestamp.

examples:

### Before
<img width="1438" alt="Screenshot 2023-08-23 at 2 28 19 PM" src="https://github.com/go-vela/ui/assets/48764154/d62bf847-576c-4941-a318-74ce06c160b5">


### After
<img width="1444" alt="Screenshot 2023-08-23 at 2 26 00 PM" src="https://github.com/go-vela/ui/assets/48764154/dd62aa74-863f-45d2-aa80-9958888acafa">
