### PR TITLE
enhance(audit): use established skip styling

### DIFF
--- a/src/elm/SvgBuilder.elm
+++ b/src/elm/SvgBuilder.elm
@@ -336,8 +336,50 @@ hookSkipped =
         , height "20"
         , ariaHidden
         ]
-        [ Svg.path [ attribute "vector-effect" "non-scaling-stroke", d "M15 20.1l6.923 6.9L42 5" ] []
-        , Svg.path [ attribute "vector-effect" "non-scaling-stroke", d "M43 22v16.333A4.668 4.668 0 0138.333 43H5.667A4.668 4.668 0 011 38.333V5.667A4.668 4.668 0 015.667 1h25.666" ] []
+        [ Svg.path
+            [ attribute "vector-effect" "non-scaling-stroke"
+            , d "M5.667 1h32.666A4.668 4.668 0 0143 5.667v32.666A4.668 4.668 0 0138.333 43H5.667A4.668 4.668 0 011 38.333V5.667A4.668 4.668 0 015.667 1z"
+            ]
+            []
+        , Svg.path
+            [ attribute "vector-effect" "non-scaling-stroke", d "M30.88 16.987l-9.744-5.625-9.747 9.383" ]
+            []
+        , Svg.path
+            [ attribute "vector-effect" "non-scaling-stroke"
+            , d "M33 14l1 6h-6z"
+            , Svg.Attributes.fill "var(--color-lavender)"
+            ]
+            []
+        , Svg.rect
+            [ attribute "vector-effect" "non-scaling-stroke"
+            , Svg.Attributes.fill "var(--color-lavender)"
+            , Svg.Attributes.x "10"
+            , Svg.Attributes.y "28"
+            , Svg.Attributes.width "4"
+            , Svg.Attributes.height "4"
+            , Svg.Attributes.rx "3"
+            ]
+            []
+        , Svg.rect
+            [ attribute "vector-effect" "non-scaling-stroke"
+            , Svg.Attributes.fill "var(--color-lavender)"
+            , Svg.Attributes.x "20"
+            , Svg.Attributes.y "28"
+            , Svg.Attributes.width "4"
+            , Svg.Attributes.height "4"
+            , Svg.Attributes.rx "3"
+            ]
+            []
+        , Svg.rect
+            [ attribute "vector-effect" "non-scaling-stroke"
+            , Svg.Attributes.fill "var(--color-lavender)"
+            , Svg.Attributes.x "30"
+            , Svg.Attributes.y "28"
+            , Svg.Attributes.width "4"
+            , Svg.Attributes.height "4"
+            , Svg.Attributes.rx "3"
+            ]
+            []
         ]
 
 

--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -106,7 +106,7 @@ td .key .list-item {
   color: var(--color-text);
 
   border-bottom: 1px solid var(--color-bg-light);
-  border-left: 2px solid var(--color-cyan);
+  border-left: 2px solid var(--color-lavender);
 
   td {
     padding-top: 0;
@@ -120,7 +120,7 @@ td .key .list-item {
 
 .table-base tr.-skipped {
   border-bottom: none;
-  border-left: 2px solid var(--color-cyan);
+  border-left: 2px solid var(--color-lavender);
 }
 
 .table-base .error-content {
@@ -144,7 +144,7 @@ td .key .list-item {
 }
 
 .hook-status.-skipped {
-  stroke: var(--color-cyan);
+  stroke: var(--color-lavender);
 }
 
 .hook-status.-failure {


### PR DESCRIPTION
just a small enhancement on top of the awesome work in https://github.com/go-vela/ui/pull/732

before:
![image](https://github.com/go-vela/ui/assets/49894298/68ab2a75-4803-4c32-bb55-3a1599b03518)

after:
![image](https://github.com/go-vela/ui/assets/49894298/b5414a20-4196-4ff1-b38f-85d4e096a84f)
