### PR TITLE
enhance(cancel): improve msg label for cancel events

### DIFF
--- a/cypress/fixtures/build_canceled.json
+++ b/cypress/fixtures/build_canceled.json
@@ -5,7 +5,7 @@
   "parent": 1,
   "event": "push",
   "status": "canceled",
-  "error": "build canceled in favor of build 7",
+  "error": "build auto canceled in favor of build 7",
   "enqueued": 1572980376,
   "created": 1572980376,
   "started": 1572980375,

--- a/cypress/integration/build.spec.js
+++ b/cypress/integration/build.spec.js
@@ -314,7 +314,7 @@ context('Build', () => {
       it('build error should contain error', () => {
         cy.get('[data-test=build-error]').contains('auto canceled:');
         cy.get('[data-test=build-error]').contains(
-          'build auto canceled in favor of build 7',
+          'build auto canceled in favor of build #7',
         );
       });
 

--- a/cypress/integration/build.spec.js
+++ b/cypress/integration/build.spec.js
@@ -312,9 +312,9 @@ context('Build', () => {
       });
 
       it('build error should contain error', () => {
-        cy.get('[data-test=build-error]').contains('msg:');
+        cy.get('[data-test=build-error]').contains('auto canceled:');
         cy.get('[data-test=build-error]').contains(
-          'build canceled in favor of build 7',
+          'build auto canceled in favor of build 7',
         );
       });
 

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -1116,9 +1116,12 @@ viewError build =
 
         Vela.Canceled ->
             let
-                message =
+                defaultLabel =
+                    text "canceled:"
+
+                ( label, message ) =
                     if String.isEmpty build.error then
-                        text "no error message"
+                        ( defaultLabel, text "no error message" )
 
                     else
                         let
@@ -1127,13 +1130,13 @@ viewError build =
                                     |> List.Extra.last
                                     |> Maybe.withDefault ""
                         in
-                        -- check if the last part of the error message was a digit
+                        -- check if the last part of the error message was a number
                         -- to handle auto canceled build messages which come in the
                         -- form of "build was auto canceled in favor of build 42"
                         case String.toInt tgtBuild of
                             -- not an auto cancel message, use the returned error msg
                             Nothing ->
-                                text build.error
+                                ( defaultLabel, text build.error )
 
                             -- some special treatment to turn build number
                             -- into a link to the respective build
@@ -1152,10 +1155,12 @@ viewError build =
                                     msg =
                                         String.replace tgtBuild "" build.error
                                 in
-                                span [] [ text msg, a [ href newLink, Util.testAttribute "new-build-link" ] [ text tgtBuild ] ]
+                                ( text "auto canceled:"
+                                , span [] [ text msg, a [ href newLink, Util.testAttribute "new-build-link" ] [ text tgtBuild ] ]
+                                )
             in
             div [ class "error", Util.testAttribute "build-error" ]
-                [ span [ class "label" ] [ text "msg:" ]
+                [ span [ class "label" ] [ label ]
                 , span [ class "message" ] [ message ]
                 ]
 

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -1156,7 +1156,7 @@ viewError build =
                                         String.replace tgtBuild "" build.error
                                 in
                                 ( text "auto canceled:"
-                                , span [] [ text msg, a [ href newLink, Util.testAttribute "new-build-link" ] [ text tgtBuild ] ]
+                                , span [] [ text msg, a [ href newLink, Util.testAttribute "new-build-link" ] [ text ("#" ++ tgtBuild) ] ]
                                 )
             in
             div [ class "error", Util.testAttribute "build-error" ]


### PR DESCRIPTION
small pr to improve message labeling for cancel events. canceled builds will either get a `canceled:` or `auto canceled:` message label.

also prefixes `#` to the build link for increased click area, especially for single digit builds. 

example for "auto canceled" status:

before:
![image](https://github.com/go-vela/ui/assets/1301201/c7ef0101-98c9-4057-892a-cdd01aa3e544)

after:
![image](https://github.com/go-vela/ui/assets/1301201/2a9815a8-a2ef-41a8-93c9-e50f5e100a58)




also spent some time to look at "autocanceled" vs "auto canceled" vs "auto-canceled", the latter of which i prefer most but there seems to be no concrete rules around this, so i left it as-is (and it avoids having to update the server component that returns the actual error message).