### PR TITLE
fix(viz): flex style and overflow for small graphs

### DIFF
--- a/src/scss/_graph.scss
+++ b/src/scss/_graph.scss
@@ -59,6 +59,7 @@
   align-items: flex-start;
   width: 100%;
   min-height: 300px;
+  overflow: hidden;
 
   background: var(--color-bg);
   border: 1px solid var(--color-bg-light);
@@ -71,6 +72,10 @@
 
     margin: 1rem;
   }
+}
+
+.elm-build-graph-root {
+  flex: 1;
 }
 
 .elm-build-graph-error {


### PR DESCRIPTION
fixes an issue where single row graphs werent flexing to fill the container.
this does that and applies overflow hidden to the container