### PR TITLE
fix(viz): apply overflow visible to root

### DIFF
--- a/src/scss/_graph.scss
+++ b/src/scss/_graph.scss
@@ -74,8 +74,8 @@
   }
 }
 
-.elm-build-graph-root {
-  flex: 1;
+svg.elm-build-graph-root {
+  overflow: visible;
 }
 
 .elm-build-graph-error {


### PR DESCRIPTION
removing flex and applying overflow visible.
this keeps the root graph correctly centered, while still applying the intended purpose of #738 