### PR TITLE
fix(viz): track draw state to apply recenter on fresh draws

### DIFF
--- a/cypress/fixtures/build_graph.json
+++ b/cypress/fixtures/build_graph.json
@@ -1,5 +1,8 @@
 {
   "build_id": 4,
+  "build_number": 4,
+  "org": "github",
+  "repo": "octocat",
   "nodes": {
     "0": {
       "id": 0,

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1071,7 +1071,7 @@ update msg model =
                                 um_ =
                                     updateRepoModels model rm bm ugm
                             in
-                            ( ugm, Cmd.batch [ renderBuildGraph um_ False ] )
+                            ( ugm, renderBuildGraph um_ False )
 
                         _ ->
                             ( model.repo.build.graph, Cmd.none )

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -4361,8 +4361,7 @@ loadBuildGraphPage model org repo buildNumber =
 
       else
         Cmd.batch
-            [ getRepo um org repo
-            , getBuilds um org repo Nothing Nothing Nothing
+            [ getBuilds um org repo Nothing Nothing Nothing
             , getBuild um org repo buildNumber
             , getAllBuildSteps um org repo buildNumber Nothing False
             , getBuildGraph um org repo buildNumber False

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2160,7 +2160,7 @@ update msg model =
 
                                 cmd =
                                     if not sameBuild then
-                                        renderBuildGraph updatedModel False
+                                        renderBuildGraph updatedModel True
 
                                     else
                                         Cmd.none
@@ -4376,7 +4376,7 @@ loadBuildGraphPage model org repo buildNumber =
             , getBuild um org repo buildNumber
             , getAllBuildSteps um org repo buildNumber Nothing False
             , getBuildGraph um org repo buildNumber False
-            , renderBuildGraph um True
+            , renderBuildGraph um <| not sameResource
             ]
     )
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -4367,7 +4367,7 @@ loadBuildGraphPage model org repo buildNumber =
       -- do not load resources if transition is auto refresh, line focus, etc
       -- MUST render graph here, or clicking on nodes won't cause an immediate change
     , if sameBuild && sameResource then
-        renderBuildGraph um False
+        renderBuildGraph um True
 
       else
         Cmd.batch

--- a/src/elm/Pages/Build/Graph/DOT.elm
+++ b/src/elm/Pages/Build/Graph/DOT.elm
@@ -416,7 +416,7 @@ nodeLabelTableAttributes =
 
 {-| nodeAttributes : returns the node-specific dynamic attributes
 -}
-nodeAttributes : BuildModel.PartialModel a -> BuildGraph-> BuildGraphNode -> Dict String Attribute
+nodeAttributes : BuildModel.PartialModel a -> BuildGraph -> BuildGraphNode -> Dict String Attribute
 nodeAttributes model buildGraph node =
     let
         -- embed node information in the element id

--- a/src/elm/Pages/Build/Graph/DOT.elm
+++ b/src/elm/Pages/Build/Graph/DOT.elm
@@ -38,8 +38,8 @@ import Visualization.DOT
 <https://graphviz.org/doc/info/lang.html>
 <https://package.elm-lang.org/packages/elm-community/graph/latest/Graph.DOT>
 -}
-renderDOT : BuildModel.PartialModel a -> Repository -> Build -> BuildGraph -> String
-renderDOT model repo build buildGraph =
+renderDOT : BuildModel.PartialModel a -> BuildGraph -> String
+renderDOT model buildGraph =
     let
         isNodeFocused : String -> BuildGraphNode -> Bool
         isNodeFocused filter n =
@@ -103,15 +103,15 @@ renderDOT model repo build buildGraph =
 
         -- convert nodes and edges to DOT string format
         builtInNodesString =
-            List.map (nodeToString model repo build) builtInNodes
+            List.map (nodeToString model buildGraph) builtInNodes
                 |> String.join "\n"
 
         pipelineNodesString =
-            List.map (nodeToString model repo build) pipelineNodes
+            List.map (nodeToString model buildGraph) pipelineNodes
                 |> String.join "\n"
 
         serviceNodesString =
-            List.map (nodeToString model repo build) serviceNodes
+            List.map (nodeToString model buildGraph) serviceNodes
                 |> String.join "\n"
 
         builtInEdgesString =
@@ -170,8 +170,8 @@ renderDOT model repo build buildGraph =
 a "label" is actually a disguised graphviz table <https://graphviz.org/doc/info/lang.html> that is used to
 render a list of stage-steps as graph content that is recognized by the layout
 -}
-nodeLabel : BuildModel.PartialModel a -> Repository -> Build -> BuildGraphNode -> Bool -> String
-nodeLabel model repo build node showSteps =
+nodeLabel : BuildModel.PartialModel a -> BuildGraph -> BuildGraphNode -> Bool -> String
+nodeLabel model buildGraph node showSteps =
     let
         label =
             node.name
@@ -218,9 +218,9 @@ nodeLabel model repo build node showSteps =
 
         link step =
             Routes.routeToUrl <|
-                Routes.Build repo.org
-                    repo.name
-                    (String.fromInt build.number)
+                Routes.Build buildGraph.org
+                    buildGraph.repo
+                    (String.fromInt buildGraph.buildNumber)
                     (Just <|
                         Focus.resourceFocusFragment
                             "step"
@@ -276,11 +276,11 @@ nodeLabel model repo build node showSteps =
 
 {-| nodeLabel : takes model and a node, and returns the DOT string representation
 -}
-nodeToString : BuildModel.PartialModel a -> Repository -> Build -> Node BuildGraphNode -> String
-nodeToString model repo build node =
+nodeToString : BuildModel.PartialModel a -> BuildGraph -> Node BuildGraphNode -> String
+nodeToString model buildGraph node =
     "  "
         ++ String.fromInt node.id
-        ++ makeAttributes (nodeAttributes model repo build node.label)
+        ++ makeAttributes (nodeAttributes model buildGraph node.label)
 
 
 {-| edgeToString : takes model and a node, and returns the DOT string representation
@@ -416,8 +416,8 @@ nodeLabelTableAttributes =
 
 {-| nodeAttributes : returns the node-specific dynamic attributes
 -}
-nodeAttributes : BuildModel.PartialModel a -> Repository -> Build -> BuildGraphNode -> Dict String Attribute
-nodeAttributes model repo build node =
+nodeAttributes : BuildModel.PartialModel a -> BuildGraph-> BuildGraphNode -> Dict String Attribute
+nodeAttributes model buildGraph node =
     let
         -- embed node information in the element id
         id =
@@ -449,7 +449,7 @@ nodeAttributes model repo build node =
         , ( "id", DefaultJSONLabelEscape id )
         , ( "class", DefaultJSONLabelEscape class )
         , ( "href", DefaultJSONLabelEscape ("#" ++ node.name) )
-        , ( "label", HtmlLabelEscape <| nodeLabel model repo build node showSteps )
+        , ( "label", HtmlLabelEscape <| nodeLabel model buildGraph node showSteps )
         , ( "tooltip", DefaultJSONLabelEscape id )
         ]
 

--- a/src/elm/Pages/Build/Graph/Interop.elm
+++ b/src/elm/Pages/Build/Graph/Interop.elm
@@ -18,12 +18,12 @@ import Vela exposing (encodeBuildGraphRenderData)
 renderBuildGraph : BuildModel.PartialModel a -> Bool -> Cmd msg
 renderBuildGraph model freshDraw =
     -- rendering the full graph requires repo, build and graph
-    case ( model.repo.repo, model.repo.build.build, model.repo.build.graph.graph ) of
-        ( Success r, Success b, Success g ) ->
+    case model.repo.build.graph.graph of
+        Success g ->
             Interop.renderBuildGraph <|
                 encodeBuildGraphRenderData
-                    { dot = renderDOT model r b g
-                    , buildID = b.id
+                    { dot = renderDOT model g
+                    , buildID = g.buildID
                     , filter = model.repo.build.graph.filter
                     , showServices = model.repo.build.graph.showServices
                     , showSteps = model.repo.build.graph.showSteps

--- a/src/elm/Pages/Build/Graph/Interop.elm
+++ b/src/elm/Pages/Build/Graph/Interop.elm
@@ -16,7 +16,7 @@ import Vela exposing (encodeBuildGraphRenderData)
 {-| renderBuildGraph : takes partial build model and render options, and returns a cmd for dispatching a graphviz+d3 render command
 -}
 renderBuildGraph : BuildModel.PartialModel a -> Bool -> Cmd msg
-renderBuildGraph model centerOnDraw =
+renderBuildGraph model freshDraw =
     -- rendering the full graph requires repo, build and graph
     case ( model.repo.repo, model.repo.build.build, model.repo.build.graph.graph ) of
         ( Success r, Success b, Success g ) ->
@@ -28,7 +28,7 @@ renderBuildGraph model centerOnDraw =
                     , showServices = model.repo.build.graph.showServices
                     , showSteps = model.repo.build.graph.showSteps
                     , focusedNode = model.repo.build.graph.focusedNode
-                    , centerOnDraw = centerOnDraw
+                    , freshDraw = freshDraw
                     }
 
         _ ->

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -1386,7 +1386,7 @@ defaultBuildGraphModel =
 
 defaultBuildGraph : BuildGraph
 defaultBuildGraph =
-    BuildGraph Dict.empty []
+    BuildGraph -1 -1 "" "" Dict.empty []
 
 
 encodeBuildGraphRenderData : BuildGraphRenderInteropData -> Encode.Value
@@ -1425,7 +1425,11 @@ type alias BuildGraphModel =
 
 
 type alias BuildGraph =
-    { nodes : Dict Int BuildGraphNode
+    { buildID : Int
+    , buildNumber : Int
+    , org : Org
+    , repo : Repo
+    , nodes : Dict Int BuildGraphNode
     , edges : List BuildGraphEdge
     }
 
@@ -1454,6 +1458,10 @@ type alias BuildGraphEdge =
 decodeBuildGraph : Decoder BuildGraph
 decodeBuildGraph =
     Decode.succeed BuildGraph
+        |> required "build_id" int
+        |> required "build_number" int
+        |> required "org" string
+        |> required "repo" string
         |> required "nodes" (dict2 int decodeBuildGraphNode)
         |> optional "edges" (Decode.list decodeEdge) []
 

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -1398,7 +1398,7 @@ encodeBuildGraphRenderData graphData =
         , ( "focusedNode", Encode.int graphData.focusedNode )
         , ( "showServices", Encode.bool graphData.showServices )
         , ( "showSteps", Encode.bool graphData.showSteps )
-        , ( "centerOnDraw", Encode.bool graphData.centerOnDraw )
+        , ( "freshDraw", Encode.bool graphData.freshDraw )
         ]
 
 
@@ -1409,7 +1409,7 @@ type alias BuildGraphRenderInteropData =
     , focusedNode : Int
     , showServices : Bool
     , showSteps : Bool
-    , centerOnDraw : Bool
+    , freshDraw : Bool
     }
 
 

--- a/src/static/graph.ts
+++ b/src/static/graph.ts
@@ -22,7 +22,8 @@ export function drawGraph(opts, content) {
 
   // check that a valid graph was rendered
   if (buildGraphElement === null || buildGraphElement.node() === null) {
-    return;
+    // control draw state
+    return false;
   }
 
   drawViewbox(opts, buildGraphElement);
@@ -32,6 +33,9 @@ export function drawGraph(opts, content) {
   var edges = drawEdges(opts, buildGraphElement, graphSelectors.edge);
 
   drawNodes(opts, buildGraphElement, graphSelectors.node, edges);
+
+  // control draw state
+  return true;
 }
 
 function drawBaseGraphWithZoom(opts, selector, content) {
@@ -120,6 +124,10 @@ function drawBaseGraphWithZoom(opts, selector, content) {
   }
 
   if (opts.centerOnDraw) {
+    resetZoomAndCenter(opts, zoom);
+  }
+
+  if (!opts.drawn) {
     resetZoomAndCenter(opts, zoom);
   }
 

--- a/src/static/graph.ts
+++ b/src/static/graph.ts
@@ -123,10 +123,6 @@ function drawBaseGraphWithZoom(opts, selector, content) {
     resetZoomAndCenter(opts, zoom);
   }
 
-  if (opts.freshDraw) {
-    resetZoomAndCenter(opts, zoom);
-  }
-
   if (!opts.drawn) {
     resetZoomAndCenter(opts, zoom);
   }

--- a/src/static/graph.ts
+++ b/src/static/graph.ts
@@ -119,7 +119,7 @@ function drawBaseGraphWithZoom(opts, selector, content) {
   buildGraphElement.html(content);
 
   // recenter on draw, when necessary
-  if (!opts.isRefreshDraw) {
+  if (!opts.sameBuild) {
     resetZoomAndCenter(opts, zoom);
   }
 

--- a/src/static/graph.ts
+++ b/src/static/graph.ts
@@ -123,7 +123,7 @@ function drawBaseGraphWithZoom(opts, selector, content) {
     resetZoomAndCenter(opts, zoom);
   }
 
-  if (opts.centerOnDraw) {
+  if (opts.freshDraw) {
     resetZoomAndCenter(opts, zoom);
   }
 

--- a/src/static/graph.ts
+++ b/src/static/graph.ts
@@ -119,11 +119,7 @@ function drawBaseGraphWithZoom(opts, selector, content) {
   buildGraphElement.html(content);
 
   // recenter on draw, when necessary
-  if (!opts.sameBuild) {
-    resetZoomAndCenter(opts, zoom);
-  }
-
-  if (!opts.drawn) {
+  if (!opts.sameBuild || !opts.drawn) {
     resetZoomAndCenter(opts, zoom);
   }
 

--- a/src/static/index.d.ts
+++ b/src/static/index.d.ts
@@ -113,8 +113,8 @@ export type GraphData = {
   showServices: boolean;
   /** @property showSteps: boolean */
   showSteps: boolean;
-  /** @property centerOnDraw: boolean */
-  centerOnDraw: boolean;
+  /** @property freshDraw: boolean */
+  freshDraw: boolean;
 };
 
 export type GraphInteraction = {

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -144,6 +144,9 @@ app.ports.renderBuildGraph.subscribe(function (graphData) {
 
     // construct graph building options
     // reset the draw state when the build changes
+
+    // what if the first freshDraw is skipped, and the next draw is a fresh
+    // but we never reset this drawn to false
     if (opts.currentBuild !== graphData.buildID || graphData.freshDraw) {
       opts.drawn = false;
     }

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -130,6 +130,7 @@ function envOrNull(env: string, subst: string): string | null {
 
 // track rendering options globally to help determine draw logic
 var opts = {
+  drawn: false,
   currentBuild: -1,
   isRefreshDraw: false,
   centerOnDraw: false,
@@ -141,6 +142,12 @@ app.ports.renderBuildGraph.subscribe(function (graphData) {
   const graphviz = Graphviz.load().then(res => {
     var content = res.layout(graphData.dot, 'svg', 'dot');
     // construct graph building options
+
+    // reset draw state when build changes
+    if (opts.currentBuild !== graphData.buildID) {
+      opts.drawn = false;
+    }
+
     opts.isRefreshDraw = opts.currentBuild === graphData.buildID;
     opts.centerOnDraw = graphData.centerOnDraw;
     opts.contentFilter = graphData.filter;
@@ -152,7 +159,7 @@ app.ports.renderBuildGraph.subscribe(function (graphData) {
 
     // dispatch the draw command to avoid elm/js rendering race condition
     setTimeout(() => {
-      Graph.drawGraph(opts, content);
+      opts.drawn = Graph.drawGraph(opts, content);
     }, 0);
   });
 });

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -133,7 +133,7 @@ var opts = {
   drawn: false,
   currentBuild: -1,
   sameBuild: false,
-  centerOnDraw: false,
+  freshDraw: false,
   contentFilter: '',
   onGraphInteraction: {},
 };
@@ -144,12 +144,12 @@ app.ports.renderBuildGraph.subscribe(function (graphData) {
 
     // construct graph building options
     // reset the draw state when the build changes
-    if (opts.currentBuild !== graphData.buildID) {
+    if (opts.currentBuild !== graphData.buildID || graphData.freshDraw) {
       opts.drawn = false;
     }
 
     opts.sameBuild = opts.currentBuild === graphData.buildID;
-    opts.centerOnDraw = graphData.centerOnDraw;
+    opts.freshDraw = graphData.freshDraw;
     opts.contentFilter = graphData.filter;
 
     // track the currently drawn build

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -132,7 +132,7 @@ function envOrNull(env: string, subst: string): string | null {
 var opts = {
   drawn: false,
   currentBuild: -1,
-  isRefreshDraw: false,
+  sameBuild: false,
   centerOnDraw: false,
   contentFilter: '',
   onGraphInteraction: {},
@@ -141,20 +141,21 @@ var opts = {
 app.ports.renderBuildGraph.subscribe(function (graphData) {
   const graphviz = Graphviz.load().then(res => {
     var content = res.layout(graphData.dot, 'svg', 'dot');
-    // construct graph building options
 
-    // reset draw state when build changes
+    // construct graph building options
+    // reset the draw state when the build changes
     if (opts.currentBuild !== graphData.buildID) {
       opts.drawn = false;
     }
 
-    opts.isRefreshDraw = opts.currentBuild === graphData.buildID;
+    opts.sameBuild = opts.currentBuild === graphData.buildID;
     opts.centerOnDraw = graphData.centerOnDraw;
     opts.contentFilter = graphData.filter;
 
     // track the currently drawn build
     opts.currentBuild = graphData.buildID;
 
+    // graph interactivity
     opts.onGraphInteraction = app.ports.onGraphInteraction;
 
     // dispatch the draw command to avoid elm/js rendering race condition


### PR DESCRIPTION
more stability for the elm vs. js render race condition, where the page root doesnt render quick enough for the graph render dispatch

also 
- renames `isRefreshDraw` to `sameBuild` to make it a bit clearer
- renames `centerOnDraw` to `freshDraw` to make it a bit clearer