### PR TITLE
fix(graph): populate buildnumber on model

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2155,8 +2155,11 @@ update msg model =
                                 ugm =
                                     { gm | buildNumber = buildNumber, graph = RemoteData.succeed g }
 
+                                ubm =
+                                    { bm | buildNumber = buildNumber }
+
                                 updatedModel =
-                                    updateRepoModels model rm bm ugm
+                                    updateRepoModels model rm ubm ugm
 
                                 cmd =
                                     if not sameBuild then


### PR DESCRIPTION
fixes the following issue:
1. hard load graph page
1. click on step link
1. unexpand the step log on the resulting page (or expand any other step)
1. 400 error because build number was missing in request

this fix makes sure the buildNumber field is populated when you enter the site on a graph page