### PR TITLE
refactor(elm): implement Shared module

### DIFF
--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -53,6 +53,7 @@ module Api exposing
     , updateSecret
     )
 
+import Shared
 import Api.Endpoint as Endpoint exposing (Endpoint)
 import Api.Pagination as Pagination
 import Auth.Jwt exposing (JwtAccessToken, decodeJwtAccessToken)
@@ -153,11 +154,7 @@ type ListResponse a
 {-| PartialModel : an abbreviated version of the main model
 -}
 type alias PartialModel a =
-    { a
-        | velaAPI : String
-        , session : Session
-    }
-
+    { a | shared : Shared.Model }
 
 
 -- HELPERS
@@ -426,15 +423,15 @@ tryString msg request_ =
 
 getLogout : PartialModel a -> Request String
 getLogout model =
-    get model.velaAPI Endpoint.Logout Json.Decode.string
-        |> withAuth model.session
+    get model.shared.velaAPI Endpoint.Logout Json.Decode.string
+        |> withAuth model.shared.session
 
 
 {-| getToken : gets a new token with refresh token in cookie
 -}
 getToken : PartialModel a -> Request JwtAccessToken
 getToken model =
-    get model.velaAPI Endpoint.Token decodeJwtAccessToken
+    get model.shared.velaAPI Endpoint.Token decodeJwtAccessToken
 
 
 {-| getInitialToken : fetches a the initial token from the authentication endpoint
@@ -442,159 +439,159 @@ which will also set the refresh token cookie
 -}
 getInitialToken : PartialModel a -> AuthParams -> Request JwtAccessToken
 getInitialToken model { code, state } =
-    get model.velaAPI (Endpoint.Authenticate { code = code, state = state }) decodeJwtAccessToken
+    get model.shared.velaAPI (Endpoint.Authenticate { code = code, state = state }) decodeJwtAccessToken
 
 
 {-| getCurrentUser : fetches a user from the current user endpoint
 -}
 getCurrentUser : PartialModel a -> Request CurrentUser
 getCurrentUser model =
-    get model.velaAPI Endpoint.CurrentUser decodeCurrentUser
-        |> withAuth model.session
+    get model.shared.velaAPI Endpoint.CurrentUser decodeCurrentUser
+        |> withAuth model.shared.session
 
 
 {-| updateCurrentUser : updates the currently authenticated user with the current user endpoint
 -}
 updateCurrentUser : PartialModel a -> Http.Body -> Request CurrentUser
 updateCurrentUser model body =
-    put model.velaAPI Endpoint.CurrentUser body decodeCurrentUser
-        |> withAuth model.session
+    put model.shared.velaAPI Endpoint.CurrentUser body decodeCurrentUser
+        |> withAuth model.shared.session
 
 
 {-| getRepo : fetches single repo by org and repo name
 -}
 getRepo : PartialModel a -> Org -> Repo -> Request Repository
 getRepo model org repo =
-    get model.velaAPI (Endpoint.Repository org repo) decodeRepository
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Repository org repo) decodeRepository
+        |> withAuth model.shared.session
 
 
 {-| getOrgRepositories : fetches repos by org
 -}
 getOrgRepositories : PartialModel a -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> Org -> Request (List Repository)
 getOrgRepositories model maybePage maybePerPage org =
-    get model.velaAPI (Endpoint.OrgRepositories maybePage maybePerPage org) decodeRepositories
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.OrgRepositories maybePage maybePerPage org) decodeRepositories
+        |> withAuth model.shared.session
 
 
 {-| getSourceRepositories : fetches source repositories by username for creating them via api
 -}
 getSourceRepositories : PartialModel a -> Request SourceRepositories
 getSourceRepositories model =
-    get model.velaAPI Endpoint.UserSourceRepositories decodeSourceRepositories
-        |> withAuth model.session
+    get model.shared.velaAPI Endpoint.UserSourceRepositories decodeSourceRepositories
+        |> withAuth model.shared.session
 
 
 {-| deleteRepo : removes an enabled repository
 -}
 deleteRepo : PartialModel a -> Repository -> Request String
 deleteRepo model repository =
-    delete model.velaAPI (Endpoint.Repository repository.org repository.name) Json.Decode.string
-        |> withAuth model.session
+    delete model.shared.velaAPI (Endpoint.Repository repository.org repository.name) Json.Decode.string
+        |> withAuth model.shared.session
 
 
 {-| chownRepo : changes ownership of a repository
 -}
 chownRepo : PartialModel a -> Repository -> Request String
 chownRepo model repository =
-    patch model.velaAPI (Endpoint.RepositoryChown repository.org repository.name)
-        |> withAuth model.session
+    patch model.shared.velaAPI (Endpoint.RepositoryChown repository.org repository.name)
+        |> withAuth model.shared.session
 
 
 {-| repairRepo: re-enables a webhook for a repository
 -}
 repairRepo : PartialModel a -> Repository -> Request String
 repairRepo model repository =
-    patch model.velaAPI (Endpoint.RepositoryRepair repository.org repository.name)
-        |> withAuth model.session
+    patch model.shared.velaAPI (Endpoint.RepositoryRepair repository.org repository.name)
+        |> withAuth model.shared.session
 
 
 {-| enableRepository : enables a repository
 -}
 enableRepository : PartialModel a -> Http.Body -> Request Repository
 enableRepository model body =
-    post model.velaAPI (Endpoint.Repositories Nothing Nothing) body decodeRepository
-        |> withAuth model.session
+    post model.shared.velaAPI (Endpoint.Repositories Nothing Nothing) body decodeRepository
+        |> withAuth model.shared.session
 
 
 {-| updateRepository : updates a repository
 -}
 updateRepository : PartialModel a -> Org -> Repo -> Http.Body -> Request Repository
 updateRepository model org repo body =
-    put model.velaAPI (Endpoint.Repository org repo) body decodeRepository
-        |> withAuth model.session
+    put model.shared.velaAPI (Endpoint.Repository org repo) body decodeRepository
+        |> withAuth model.shared.session
 
 
 {-| getPipelineConfig : fetches vela pipeline by repository
 -}
 getPipelineConfig : PartialModel a -> Org -> Repo -> Ref -> Request PipelineConfig
 getPipelineConfig model org repository ref =
-    get model.velaAPI (Endpoint.PipelineConfig org repository ref) decodePipelineConfig
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.PipelineConfig org repository ref) decodePipelineConfig
+        |> withAuth model.shared.session
 
 
 {-| expandPipelineConfig : expands vela pipeline by repository
 -}
 expandPipelineConfig : PartialModel a -> Org -> Repo -> Ref -> Request String
 expandPipelineConfig model org repository ref =
-    post model.velaAPI (Endpoint.ExpandPipelineConfig org repository ref) Http.emptyBody decodePipelineExpand
-        |> withAuth model.session
+    post model.shared.velaAPI (Endpoint.ExpandPipelineConfig org repository ref) Http.emptyBody decodePipelineExpand
+        |> withAuth model.shared.session
 
 
 {-| getPipelineTemplates : fetches vela pipeline templates by repository
 -}
 getPipelineTemplates : PartialModel a -> Org -> Repo -> Ref -> Request Templates
 getPipelineTemplates model org repository ref =
-    get model.velaAPI (Endpoint.PipelineTemplates org repository ref) decodePipelineTemplates
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.PipelineTemplates org repository ref) decodePipelineTemplates
+        |> withAuth model.shared.session
 
 
 {-| restartBuild : restarts a build
 -}
 restartBuild : PartialModel a -> Org -> Repo -> BuildNumber -> Request Build
 restartBuild model org repository buildNumber =
-    post model.velaAPI (Endpoint.Build org repository buildNumber) Http.emptyBody decodeBuild
-        |> withAuth model.session
+    post model.shared.velaAPI (Endpoint.Build org repository buildNumber) Http.emptyBody decodeBuild
+        |> withAuth model.shared.session
 
 
 {-| approveBuild : approves a build
 -}
 approveBuild : PartialModel a -> Org -> Repo -> BuildNumber -> Request String
 approveBuild model org repository buildNumber =
-    post model.velaAPI (Endpoint.ApproveBuild org repository buildNumber) Http.emptyBody Json.Decode.string
-        |> withAuth model.session
+    post model.shared.velaAPI (Endpoint.ApproveBuild org repository buildNumber) Http.emptyBody Json.Decode.string
+        |> withAuth model.shared.session
 
 
 {-| cancelBuild : cancels a build
 -}
 cancelBuild : PartialModel a -> Org -> Repo -> BuildNumber -> Request Build
 cancelBuild model org repository buildNumber =
-    delete model.velaAPI (Endpoint.CancelBuild org repository buildNumber) decodeBuild
-        |> withAuth model.session
+    delete model.shared.velaAPI (Endpoint.CancelBuild org repository buildNumber) decodeBuild
+        |> withAuth model.shared.session
 
 
 {-| getOrgBuilds : fetches vela builds by org
 -}
 getOrgBuilds : PartialModel a -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> Maybe Event -> Org -> Request Builds
 getOrgBuilds model maybePage maybePerPage maybeEvent org =
-    get model.velaAPI (Endpoint.OrgBuilds maybePage maybePerPage maybeEvent org) decodeBuilds
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.OrgBuilds maybePage maybePerPage maybeEvent org) decodeBuilds
+        |> withAuth model.shared.session
 
 
 {-| getBuilds : fetches vela builds by repository
 -}
 getBuilds : PartialModel a -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> Maybe Event -> Org -> Repo -> Request Builds
 getBuilds model maybePage maybePerPage maybeEvent org repository =
-    get model.velaAPI (Endpoint.Builds maybePage maybePerPage maybeEvent org repository) decodeBuilds
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Builds maybePage maybePerPage maybeEvent org repository) decodeBuilds
+        |> withAuth model.shared.session
 
 
 {-| getBuild : fetches vela build by repository and build number
 -}
 getBuild : PartialModel a -> Org -> Repo -> BuildNumber -> Request Build
 getBuild model org repository buildNumber =
-    get model.velaAPI (Endpoint.Build org repository buildNumber) decodeBuild
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Build org repository buildNumber) decodeBuild
+        |> withAuth model.shared.session
 
 
 {-| getAllSteps : used in conjuction with 'tryAll', it retrieves all pages of the resource
@@ -605,120 +602,120 @@ getBuild model org repository buildNumber =
 getAllSteps : PartialModel a -> Org -> Repo -> BuildNumber -> Request Step
 getAllSteps model org repository buildNumber =
     -- we are using the max perPage setting of 100 to reduce the number of calls
-    get model.velaAPI (Endpoint.Steps (Just 1) (Just 100) org repository buildNumber) decodeStep
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Steps (Just 1) (Just 100) org repository buildNumber) decodeStep
+        |> withAuth model.shared.session
 
 
 {-| getStepLogs : fetches vela build step log by repository, build number and step number
 -}
 getStepLogs : PartialModel a -> Org -> Repo -> BuildNumber -> StepNumber -> Request Log
 getStepLogs model org repository buildNumber stepNumber =
-    get model.velaAPI (Endpoint.StepLogs org repository buildNumber stepNumber) decodeLog
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.StepLogs org repository buildNumber stepNumber) decodeLog
+        |> withAuth model.shared.session
 
 
 {-| getAllServices : used in conjuction with 'tryAll', it retrieves all pages for a build service
 -}
 getAllServices : PartialModel a -> Org -> Repo -> BuildNumber -> Request Service
 getAllServices model org repository buildNumber =
-    get model.velaAPI (Endpoint.Services (Just 1) (Just 100) org repository buildNumber) decodeService
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Services (Just 1) (Just 100) org repository buildNumber) decodeService
+        |> withAuth model.shared.session
 
 
 {-| getServiceLogs : fetches vela build service log by repository, build number and service number
 -}
 getServiceLogs : PartialModel a -> Org -> Repo -> BuildNumber -> ServiceNumber -> Request Log
 getServiceLogs model org repository buildNumber serviceNumber =
-    get model.velaAPI (Endpoint.ServiceLogs org repository buildNumber serviceNumber) decodeLog
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.ServiceLogs org repository buildNumber serviceNumber) decodeLog
+        |> withAuth model.shared.session
 
 
 {-| getHooks : fetches hooks for the given repository
 -}
 getHooks : PartialModel a -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> Org -> Repo -> Request Hooks
 getHooks model maybePage maybePerPage org repository =
-    get model.velaAPI (Endpoint.Hooks maybePage maybePerPage org repository) decodeHooks
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Hooks maybePage maybePerPage org repository) decodeHooks
+        |> withAuth model.shared.session
 
 
 {-| redeliverHook : redelivers a hook
 -}
 redeliverHook : PartialModel a -> Org -> Repo -> HookNumber -> Request String
 redeliverHook model org repository hookNumber =
-    post model.velaAPI (Endpoint.Hook org repository hookNumber) Http.emptyBody Json.Decode.string
-        |> withAuth model.session
+    post model.shared.velaAPI (Endpoint.Hook org repository hookNumber) Http.emptyBody Json.Decode.string
+        |> withAuth model.shared.session
 
 
 {-| getAllSecrets : fetches secrets for the given type org and key
 -}
 getAllSecrets : PartialModel a -> Engine -> Type -> Org -> Key -> Request Secret
 getAllSecrets model engine type_ org key =
-    get model.velaAPI (Endpoint.Secrets (Just 1) (Just 100) engine type_ org key) decodeSecret
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Secrets (Just 1) (Just 100) engine type_ org key) decodeSecret
+        |> withAuth model.shared.session
 
 
 {-| getSecrets : fetches secrets for the given type org and key
 -}
 getSecrets : PartialModel a -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> Engine -> Type -> Org -> Key -> Request Secrets
 getSecrets model maybePage maybePerPage engine type_ org key =
-    get model.velaAPI (Endpoint.Secrets maybePage maybePerPage engine type_ org key) decodeSecrets
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Secrets maybePage maybePerPage engine type_ org key) decodeSecrets
+        |> withAuth model.shared.session
 
 
 {-| getSecret : fetches secret for the given type org key and name
 -}
 getSecret : PartialModel a -> Engine -> Type -> Org -> Key -> Name -> Request Secret
 getSecret model engine type_ org key name =
-    get model.velaAPI (Endpoint.Secret engine type_ org key name) decodeSecret
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Secret engine type_ org key name) decodeSecret
+        |> withAuth model.shared.session
 
 
 {-| updateSecret : updates a secret
 -}
 updateSecret : PartialModel a -> Engine -> Type -> Org -> Key -> Name -> Http.Body -> Request Secret
 updateSecret model engine type_ org key name body =
-    put model.velaAPI (Endpoint.Secret engine type_ org key name) body decodeSecret
-        |> withAuth model.session
+    put model.shared.velaAPI (Endpoint.Secret engine type_ org key name) body decodeSecret
+        |> withAuth model.shared.session
 
 
 {-| addSecret : adds a secret
 -}
 addSecret : PartialModel a -> Engine -> Type -> Org -> Key -> Http.Body -> Request Secret
 addSecret model engine type_ org key body =
-    post model.velaAPI (Endpoint.Secrets Nothing Nothing engine type_ org key) body decodeSecret
-        |> withAuth model.session
+    post model.shared.velaAPI (Endpoint.Secrets Nothing Nothing engine type_ org key) body decodeSecret
+        |> withAuth model.shared.session
 
 
 {-| getDeployments : fetches vela deployments by repository
 -}
 getDeployments : PartialModel a -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> Org -> Repo -> Request (List Deployment)
 getDeployments model maybePage maybePerPage org repository =
-    get model.velaAPI (Endpoint.Deployments maybePage maybePerPage org repository) decodeDeployments
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Deployments maybePage maybePerPage org repository) decodeDeployments
+        |> withAuth model.shared.session
 
 
 {-| getDeployment : fetches vela deployments by repository and deploymentId
 -}
 getDeployment : PartialModel a -> Org -> Repo -> Maybe DeploymentId -> Request Deployment
 getDeployment model org repo deploymentId =
-    get model.velaAPI (Endpoint.Deployment org repo deploymentId) decodeDeployment
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Deployment org repo deploymentId) decodeDeployment
+        |> withAuth model.shared.session
 
 
 {-| addDeployment : adds a deployment
 -}
 addDeployment : PartialModel a -> Org -> Repo -> Http.Body -> Request Deployment
 addDeployment model org key body =
-    post model.velaAPI (Endpoint.Deployment org key Nothing) body decodeDeployment
-        |> withAuth model.session
+    post model.shared.velaAPI (Endpoint.Deployment org key Nothing) body decodeDeployment
+        |> withAuth model.shared.session
 
 
 {-| deleteSecret : deletes a secret
 -}
 deleteSecret : PartialModel a -> Engine -> Type -> Org -> Key -> Name -> Request String
 deleteSecret model engine type_ org key name =
-    delete model.velaAPI (Endpoint.Secret engine type_ org key name) Json.Decode.string
-        |> withAuth model.session
+    delete model.shared.velaAPI (Endpoint.Secret engine type_ org key name) Json.Decode.string
+        |> withAuth model.shared.session
 
 
 
@@ -729,40 +726,40 @@ deleteSecret model engine type_ org key name =
 -}
 getSchedules : PartialModel a -> Maybe Pagination.Page -> Maybe Pagination.PerPage -> Org -> Repo -> Request Schedules
 getSchedules model maybePage maybePerPage org repository =
-    get model.velaAPI (Endpoint.Schedule org repository Nothing maybePage maybePerPage) decodeSchedules
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Schedule org repository Nothing maybePage maybePerPage) decodeSchedules
+        |> withAuth model.shared.session
 
 
 {-| getSchedule : fetches vela schedules by repository and name
 -}
 getSchedule : PartialModel a -> Org -> Repo -> ScheduleName -> Request Schedule
 getSchedule model org repo id =
-    get model.velaAPI (Endpoint.Schedule org repo (Just id) Nothing Nothing) decodeSchedule
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.Schedule org repo (Just id) Nothing Nothing) decodeSchedule
+        |> withAuth model.shared.session
 
 
 {-| addSchedule : adds a schedule
 -}
 addSchedule : PartialModel a -> Org -> Repo -> Http.Body -> Request Schedule
 addSchedule model org repo body =
-    post model.velaAPI (Endpoint.Schedule org repo Nothing Nothing Nothing) body decodeSchedule
-        |> withAuth model.session
+    post model.shared.velaAPI (Endpoint.Schedule org repo Nothing Nothing Nothing) body decodeSchedule
+        |> withAuth model.shared.session
 
 
 {-| updateSchedule : updates a schedule
 -}
 updateSchedule : PartialModel a -> Org -> Repo -> ScheduleName -> Http.Body -> Request Schedule
 updateSchedule model org repo name body =
-    put model.velaAPI (Endpoint.Schedule org repo (Just name) Nothing Nothing) body decodeSchedule
-        |> withAuth model.session
+    put model.shared.velaAPI (Endpoint.Schedule org repo (Just name) Nothing Nothing) body decodeSchedule
+        |> withAuth model.shared.session
 
 
 {-| deleteSchedule : deletes a schedule
 -}
 deleteSchedule : PartialModel a -> Org -> Repo -> ScheduleName -> Request String
 deleteSchedule model org repo id =
-    delete model.velaAPI (Endpoint.Schedule org repo (Just id) Nothing Nothing) Json.Decode.string
-        |> withAuth model.session
+    delete model.shared.velaAPI (Endpoint.Schedule org repo (Just id) Nothing Nothing) Json.Decode.string
+        |> withAuth model.shared.session
 
 
 
@@ -773,5 +770,5 @@ deleteSchedule model org repo id =
 -}
 getBuildGraph : PartialModel a -> Org -> Repo -> BuildNumber -> Request BuildGraph
 getBuildGraph model org repository buildNumber =
-    get model.velaAPI (Endpoint.BuildGraph org repository buildNumber) decodeBuildGraph
-        |> withAuth model.session
+    get model.shared.velaAPI (Endpoint.BuildGraph org repository buildNumber) decodeBuildGraph
+        |> withAuth model.shared.session

--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -53,7 +53,6 @@ module Api exposing
     , updateSecret
     )
 
-import Shared
 import Api.Endpoint as Endpoint exposing (Endpoint)
 import Api.Pagination as Pagination
 import Auth.Jwt exposing (JwtAccessToken, decodeJwtAccessToken)
@@ -61,6 +60,7 @@ import Auth.Session exposing (Session(..))
 import Http
 import Http.Detailed
 import Json.Decode exposing (Decoder)
+import Shared
 import Task exposing (Task)
 import Vela
     exposing
@@ -155,6 +155,7 @@ type ListResponse a
 -}
 type alias PartialModel a =
     { a | shared : Shared.Model }
+
 
 
 -- HELPERS

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -266,7 +266,6 @@ type alias Model =
     { page : Page
     , navigationKey : Navigation.Key
     , shared : Shared.Model
-    , buildMenuOpen : List Int
     , pipeline : PipelineModel
     , templates : PipelineTemplates
     , schedulesModel : Pages.Schedules.Model.Model Msg
@@ -297,7 +296,6 @@ init flags url navKey =
         model =
             { page = Pages.Overview
             , navigationKey = navKey
-            , buildMenuOpen = []
             , schedulesModel = initSchedulesModel
             , secretsModel = initSecretsModel
             , deploymentModel = initDeploymentsModel
@@ -705,7 +703,7 @@ update msg model =
         ShowHideBuildMenu build show ->
             let
                 buildsOpen =
-                    model.buildMenuOpen
+                    model.shared.buildMenuOpen
 
                 replaceList : Int -> List Int -> List Int
                 replaceList id buildList =
@@ -727,7 +725,7 @@ update msg model =
                         build
             in
             ( { model
-                | buildMenuOpen = updatedOpen
+                | shared = { shared | buildMenuOpen = updatedOpen }
               }
             , Cmd.none
             )
@@ -1313,7 +1311,7 @@ update msg model =
         ApproveBuild org repo buildNumber ->
             let
                 newModel =
-                    { model | buildMenuOpen = [] }
+                    { model | shared = { shared | buildMenuOpen = [] } }
             in
             ( newModel
             , approveBuild model org repo buildNumber
@@ -1322,7 +1320,7 @@ update msg model =
         RestartBuild org repo buildNumber ->
             let
                 newModel =
-                    { model | buildMenuOpen = [] }
+                    { model | shared = { shared | buildMenuOpen = [] } }
             in
             ( newModel
             , restartBuild model org repo buildNumber
@@ -1331,7 +1329,7 @@ update msg model =
         CancelBuild org repo buildNumber ->
             let
                 newModel =
-                    { model | buildMenuOpen = [] }
+                    { model | shared = { shared | buildMenuOpen = [] } }
             in
             ( newModel
             , cancelBuild model org repo buildNumber
@@ -2884,7 +2882,7 @@ onMouseDown targetId model triggerMsg =
     else if model.shared.showIdentity then
         Browser.Events.onMouseDown (outsideTarget targetId <| triggerMsg <| Just False)
 
-    else if List.length model.buildMenuOpen > 0 then
+    else if List.length model.shared.buildMenuOpen > 0 then
         Browser.Events.onMouseDown (outsideTarget targetId <| triggerMsg <| Just False)
 
     else
@@ -3125,7 +3123,7 @@ viewContent model =
                     , viewTimeToggle shouldRenderFilter model.shared.repo.builds.showTimestamp
                     ]
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
-                , lazy7 Pages.Organization.viewBuilds model.shared.repo.builds buildMsgs model.buildMenuOpen model.shared.time model.shared.zone org maybeEvent
+                , lazy7 Pages.Organization.viewBuilds model.shared.repo.builds buildMsgs model.shared.buildMenuOpen model.shared.time model.shared.zone org maybeEvent
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
                 ]
             )
@@ -3154,7 +3152,7 @@ viewContent model =
                     , viewTimeToggle shouldRenderFilter model.shared.repo.builds.showTimestamp
                     ]
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
-                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.buildMenuOpen model.shared.time model.shared.zone org repo maybeEvent
+                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.shared.buildMenuOpen model.shared.time model.shared.zone org repo maybeEvent
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
                 ]
             )
@@ -3183,7 +3181,7 @@ viewContent model =
                     , viewTimeToggle shouldRenderFilter model.shared.repo.builds.showTimestamp
                     ]
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
-                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.buildMenuOpen model.shared.time model.shared.zone org repo (Just "pull_request")
+                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.shared.buildMenuOpen model.shared.time model.shared.zone org repo (Just "pull_request")
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
                 ]
             )
@@ -3212,7 +3210,7 @@ viewContent model =
                     , viewTimeToggle shouldRenderFilter model.shared.repo.builds.showTimestamp
                     ]
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
-                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.buildMenuOpen model.shared.time model.shared.zone org repo (Just "tag")
+                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.shared.buildMenuOpen model.shared.time model.shared.zone org repo (Just "tag")
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
                 ]
             )

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -266,7 +266,6 @@ type alias Model =
     { page : Page
     , navigationKey : Navigation.Key
     , shared : Shared.Model
-    , entryURL : Url
     , visibility : Visibility
     , buildMenuOpen : List Int
     , pipeline : PipelineModel
@@ -299,7 +298,6 @@ init flags url navKey =
         model =
             { page = Pages.Overview
             , navigationKey = navKey
-            , entryURL = url
             , visibility = Visible
             , buildMenuOpen = []
             , schedulesModel = initSchedulesModel
@@ -1484,7 +1482,7 @@ update msg model =
                                         redirectTo =
                                             case model.shared.velaRedirect of
                                                 "" ->
-                                                    Url.toString model.entryURL
+                                                    Url.toString model.shared.entryURL
 
                                                 _ ->
                                                     model.shared.velaRedirect
@@ -3000,7 +2998,7 @@ viewContent model =
 
         Pages.RepoSettings org repo ->
             ( String.join "/" [ org, repo ] ++ " settings"
-            , lazy5 Pages.RepoSettings.view model.shared.repo.repo repoSettingsMsgs model.shared.velaAPI (Url.toString model.entryURL) model.shared.velaMaxBuildLimit
+            , lazy5 Pages.RepoSettings.view model.shared.repo.repo repoSettingsMsgs model.shared.velaAPI (Url.toString model.shared.entryURL) model.shared.velaMaxBuildLimit
             )
 
         Pages.RepoSecrets engine org repo _ _ ->
@@ -3604,7 +3602,7 @@ setNewPage route model =
                     else
                         Pages.Login
               }
-            , Interop.setRedirect <| Encode.string <| Url.toString model.entryURL
+            , Interop.setRedirect <| Encode.string <| Url.toString model.shared.entryURL
             )
 
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -109,6 +109,7 @@ import Pages.Settings
 import Pages.SourceRepos
 import RemoteData exposing (RemoteData(..), WebData)
 import Routes
+import Shared
 import String.Extra
 import SvgBuilder exposing (velaLogo)
 import Task
@@ -241,7 +242,6 @@ import Vela
         , updateRepoModels
         , updateRepoTimeout
         )
-import Shared
 import Visualization.DOT as DOT
 
 
@@ -488,7 +488,7 @@ update msg model =
     let
         shared =
             model.shared
-        
+
         rm =
             model.repo
 
@@ -522,10 +522,10 @@ update msg model =
                 filters =
                     Dict.update org (\_ -> Just searchBy) model.shared.filters
             in
-            ( { model | shared = { shared | filters = filters} }, Cmd.none )
+            ( { model | shared = { shared | filters = filters } }, Cmd.none )
 
         SearchFavorites searchBy ->
-            ( { model | shared = { shared | favoritesFilter = searchBy} }, Cmd.none )
+            ( { model | shared = { shared | favoritesFilter = searchBy } }, Cmd.none )
 
         ChangeRepoLimit limit ->
             let
@@ -621,7 +621,7 @@ update msg model =
                 ( model, Cmd.none )
 
             else
-                ( { model | shared = {shared | theme = theme} }, Interop.setTheme <| encodeTheme theme )
+                ( { model | shared = { shared | theme = theme } }, Interop.setTheme <| encodeTheme theme )
 
         GotoPage pageNumber ->
             case model.page of
@@ -696,13 +696,16 @@ update msg model =
 
         ShowHideHelp show ->
             ( { model
-                | shared = { shared | showHelp =
-                    case show of
-                        Just s ->
-                            s
+                | shared =
+                    { shared
+                        | showHelp =
+                            case show of
+                                Just s ->
+                                    s
 
-                        Nothing ->
-                            not model.shared.showHelp}
+                                Nothing ->
+                                    not model.shared.showHelp
+                    }
               }
             , Cmd.none
             )
@@ -739,13 +742,16 @@ update msg model =
 
         ShowHideIdentity show ->
             ( { model
-                | shared = { shared | showIdentity =
-                    case show of
-                        Just s ->
-                            s
+                | shared =
+                    { shared
+                        | showIdentity =
+                            case show of
+                                Just s ->
+                                    s
 
-                        Nothing ->
-                            not model.shared.showIdentity}
+                                Nothing ->
+                                    not model.shared.showIdentity
+                    }
               }
             , Cmd.none
             )
@@ -1419,7 +1425,7 @@ update msg model =
 
         LogoutResponse _ ->
             -- ignoring outcome of request and proceeding to logout
-            ( { model | shared = {shared | session = Unauthenticated} }
+            ( { model | shared = { shared | session = Unauthenticated } }
             , Navigation.pushUrl model.navigationKey <| Routes.routeToUrl Routes.Login
             )
 
@@ -1460,7 +1466,7 @@ update msg model =
                                 Authenticated _ ->
                                     []
                     in
-                    ( { model | shared = {shared | session = Authenticated newSessionDetails, fetchingToken = False} }
+                    ( { model | shared = { shared | session = Authenticated newSessionDetails, fetchingToken = False } }
                     , Cmd.batch <| actions ++ [ refreshAccessToken RefreshAccessToken newSessionDetails ]
                     )
 
@@ -1491,12 +1497,12 @@ update msg model =
                                                     , redirectPage
                                                     ]
                                     in
-                                    ( { model | shared = {shared | session = Unauthenticated, fetchingToken = False }}
+                                    ( { model | shared = { shared | session = Unauthenticated, fetchingToken = False } }
                                     , Cmd.batch actions
                                     )
 
                                 _ ->
-                                    ( { model | shared = {shared | session = Unauthenticated, fetchingToken = False }}
+                                    ( { model | shared = { shared | session = Unauthenticated, fetchingToken = False } }
                                     , Cmd.batch
                                         [ addError error
                                         , redirectPage
@@ -1504,7 +1510,7 @@ update msg model =
                                     )
 
                         _ ->
-                            ( { model | shared = {shared | session = Unauthenticated, fetchingToken = False }}
+                            ( { model | shared = { shared | session = Unauthenticated, fetchingToken = False } }
                             , Cmd.batch
                                 [ addError error
                                 , redirectPage
@@ -1780,7 +1786,7 @@ update msg model =
                             rm
                                 |> updateOrgRepo org repo
                                 |> updateBuild (RemoteData.succeed build)
-                        , shared = {shared | favicon = statusToFavicon build.status}
+                        , shared = { shared | favicon = statusToFavicon build.status }
                       }
                     , Interop.setFavicon <| Encode.string <| statusToFavicon build.status
                     )
@@ -1810,7 +1816,7 @@ update msg model =
                             rm
                                 |> updateOrgRepo org repo
                                 |> updateBuild (RemoteData.succeed build)
-                        , shared = {shared | favicon = statusToFavicon build.status}
+                        , shared = { shared | favicon = statusToFavicon build.status }
                       }
                     , Cmd.batch
                         [ Interop.setFavicon <| Encode.string <| statusToFavicon build.status
@@ -2189,7 +2195,7 @@ update msg model =
 
         -- Time
         AdjustTimeZone newZone ->
-            ( { model | shared = { shared | zone = newZone} }
+            ( { model | shared = { shared | zone = newZone } }
             , Cmd.none
             )
 
@@ -2205,7 +2211,7 @@ update msg model =
                         ( favicon, updateFavicon ) =
                             refreshFavicon model.page model.shared.favicon rm.build.build
                     in
-                    ( { model | time = time, shared = {shared | favicon = favicon} }
+                    ( { model | time = time, shared = { shared | favicon = favicon } }
                     , Cmd.batch
                         [ updateFavicon
                         , refreshRenderBuildGraph model
@@ -2220,7 +2226,7 @@ update msg model =
                         ( favicon, cmd ) =
                             refreshFavicon model.page model.shared.favicon rm.build.build
                     in
-                    ( { model | time = time, shared = {shared | favicon = favicon} }, cmd )
+                    ( { model | time = time, shared = { shared | favicon = favicon } }, cmd )
 
                 FiveSecondHidden data ->
                     ( model, refreshPageHidden model data )
@@ -2261,7 +2267,7 @@ update msg model =
             let
                 m =
                     if key == "Shift" then
-                        { model | shared = {shared | shift = True} }
+                        { model | shared = { shared | shift = True } }
 
                     else
                         model
@@ -2272,7 +2278,7 @@ update msg model =
             let
                 m =
                     if key == "Shift" then
-                        { model | shared = {shared | shift = False} }
+                        { model | shared = { shared | shift = False } }
 
                     else
                         model
@@ -2289,7 +2295,7 @@ update msg model =
                         Hidden ->
                             Cmd.none
             in
-            ( { model | visibility = visibility, shared = {shared | shift = False} }, cmd )
+            ( { model | visibility = visibility, shared = { shared | shift = False } }, cmd )
 
         PushUrl url ->
             ( model
@@ -3347,7 +3353,10 @@ viewThemeToggle theme =
 
 setNewPage : Routes.Route -> Model -> ( Model, Cmd Msg )
 setNewPage route model =
-    let shared = model.shared in
+    let
+        shared =
+            model.shared
+    in
     case ( route, model.shared.session ) of
         -- Logged in and on auth flow pages - what are you doing here?
         ( Routes.Login, Authenticated _ ) ->

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -266,7 +266,6 @@ type alias Model =
     { page : Page
     , navigationKey : Navigation.Key
     , shared : Shared.Model
-    , visibility : Visibility
     , buildMenuOpen : List Int
     , pipeline : PipelineModel
     , templates : PipelineTemplates
@@ -298,7 +297,6 @@ init flags url navKey =
         model =
             { page = Pages.Overview
             , navigationKey = navKey
-            , visibility = Visible
             , buildMenuOpen = []
             , schedulesModel = initSchedulesModel
             , secretsModel = initSecretsModel
@@ -2413,7 +2411,7 @@ update msg model =
                         Hidden ->
                             Cmd.none
             in
-            ( { model | visibility = visibility, shared = { shared | shift = False } }, cmd )
+            ( { model | shared = { shared | visibility = visibility, shift = False } }, cmd )
 
         PushUrl url ->
             ( model
@@ -2550,7 +2548,7 @@ decodeOnGraphInteraction interaction =
 refreshSubscriptions : Model -> Sub Msg
 refreshSubscriptions model =
     Sub.batch <|
-        case model.visibility of
+        case model.shared.visibility of
             Visible ->
                 [ every Util.oneSecondMillis <| Tick OneSecond
                 , every Util.fiveSecondsMillis <| Tick FiveSecond

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -266,7 +266,6 @@ type alias Model =
     { page : Page
     , navigationKey : Navigation.Key
     , shared : Shared.Model
-    , time : Posix
     , entryURL : Url
     , visibility : Visibility
     , buildMenuOpen : List Int
@@ -300,7 +299,6 @@ init flags url navKey =
         model =
             { page = Pages.Overview
             , navigationKey = navKey
-            , time = millisToPosix 0
             , entryURL = url
             , visibility = Visible
             , buildMenuOpen = []
@@ -2315,7 +2313,7 @@ update msg model =
             )
 
         AdjustTime newTime ->
-            ( { model | time = newTime }
+            ( { model | shared = { shared | time = newTime } }
             , Cmd.none
             )
 
@@ -2326,7 +2324,7 @@ update msg model =
                         ( favicon, updateFavicon ) =
                             refreshFavicon model.page model.shared.favicon rm.build.build
                     in
-                    ( { model | time = time, shared = { shared | favicon = favicon } }
+                    ( { model | shared = { shared | time = time, favicon = favicon } }
                     , Cmd.batch
                         [ updateFavicon
                         , refreshRenderBuildGraph model
@@ -2341,7 +2339,7 @@ update msg model =
                         ( favicon, cmd ) =
                             refreshFavicon model.page model.shared.favicon rm.build.build
                     in
-                    ( { model | time = time, shared = { shared | favicon = favicon } }, cmd )
+                    ( { model | shared = { shared | time = time, favicon = favicon } }, cmd )
 
                 FiveSecondHidden data ->
                     ( model, refreshPageHidden model data )
@@ -2991,7 +2989,7 @@ viewContent model =
                 [ Pager.view model.shared.repo.hooks.pager Pager.defaultLabels GotoPage
                 , lazy2 Pages.Hooks.view
                     { hooks = model.shared.repo.hooks
-                    , time = model.time
+                    , time = model.shared.time
                     , org = model.shared.repo.org
                     , repo = model.shared.repo.name
                     }
@@ -3131,7 +3129,7 @@ viewContent model =
                     , viewTimeToggle shouldRenderFilter model.shared.repo.builds.showTimestamp
                     ]
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
-                , lazy7 Pages.Organization.viewBuilds model.shared.repo.builds buildMsgs model.buildMenuOpen model.time model.shared.zone org maybeEvent
+                , lazy7 Pages.Organization.viewBuilds model.shared.repo.builds buildMsgs model.buildMenuOpen model.shared.time model.shared.zone org maybeEvent
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
                 ]
             )
@@ -3160,7 +3158,7 @@ viewContent model =
                     , viewTimeToggle shouldRenderFilter model.shared.repo.builds.showTimestamp
                     ]
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
-                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.buildMenuOpen model.time model.shared.zone org repo maybeEvent
+                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.buildMenuOpen model.shared.time model.shared.zone org repo maybeEvent
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
                 ]
             )
@@ -3189,7 +3187,7 @@ viewContent model =
                     , viewTimeToggle shouldRenderFilter model.shared.repo.builds.showTimestamp
                     ]
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
-                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.buildMenuOpen model.time model.shared.zone org repo (Just "pull_request")
+                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.buildMenuOpen model.shared.time model.shared.zone org repo (Just "pull_request")
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
                 ]
             )
@@ -3218,7 +3216,7 @@ viewContent model =
                     , viewTimeToggle shouldRenderFilter model.shared.repo.builds.showTimestamp
                     ]
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
-                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.buildMenuOpen model.time model.shared.zone org repo (Just "tag")
+                , lazy8 Pages.Builds.view model.shared.repo.builds buildMsgs model.buildMenuOpen model.shared.time model.shared.zone org repo (Just "tag")
                 , Pager.view model.shared.repo.builds.pager Pager.defaultLabels GotoPage
                 ]
             )
@@ -3268,7 +3266,7 @@ viewContent model =
 
         Pages.Settings ->
             ( "Settings"
-            , Pages.Settings.view model.shared.session model.time (Pages.Settings.Msgs Copy)
+            , Pages.Settings.view model.shared.session model.shared.time (Pages.Settings.Msgs Copy)
             )
 
         Pages.Login ->

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -149,7 +149,6 @@ import Vela
         , Name
         , Org
         , PipelineConfig
-        , PipelineTemplates
         , Ref
         , Repo
         , RepoResourceIdentifier
@@ -240,19 +239,6 @@ import Visualization.DOT as DOT
 -- TYPES
 
 
-type alias Flags =
-    { isDev : Bool
-    , velaAPI : String
-    , velaFeedbackURL : String
-    , velaDocsURL : String
-    , velaTheme : String
-    , velaRedirect : String
-    , velaLogBytesLimit : Int
-    , velaMaxBuildLimit : Int
-    , velaScheduleAllowlist : String
-    }
-
-
 type alias Model =
     { page : Page
     , navigationKey : Navigation.Key
@@ -280,7 +266,7 @@ type alias RefreshData =
     }
 
 
-init : Flags -> Url -> Navigation.Key -> ( Model, Cmd Msg )
+init : Shared.Flags -> Url -> Navigation.Key -> ( Model, Cmd Msg )
 init flags url navKey =
     let
         model : Model
@@ -5339,7 +5325,7 @@ getPipelineTemplates model org repo ref lineFocus refresh =
 -- MAIN
 
 
-main : Program Flags Model Msg
+main : Program Shared.Flags Model Msg
 main =
     Browser.application
         { init = init

--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -53,7 +53,6 @@ type alias PartialModel a =
         , page : Page
         , user : WebData CurrentUser
         , sourceRepos : WebData SourceRepositories
-        , repo : RepoModel
         , time : Posix
         , pipeline : PipelineModel
     }
@@ -150,29 +149,29 @@ navButtons model { fetchSourceRepos, toggleFavorite, approveBuild, restartBuild,
 
         Pages.Build org repo _ _ ->
             div [ class "buttons" ]
-                [ approveBuildButton org repo model.repo.build.build approveBuild
-                , cancelBuildButton org repo model.repo.build.build cancelBuild
-                , restartBuildButton org repo model.repo.build.build restartBuild
+                [ approveBuildButton org repo model.shared.repo.build.build approveBuild
+                , cancelBuildButton org repo model.shared.repo.build.build cancelBuild
+                , restartBuildButton org repo model.shared.repo.build.build restartBuild
                 ]
 
         Pages.BuildServices org repo _ _ ->
             div [ class "buttons" ]
-                [ approveBuildButton org repo model.repo.build.build approveBuild
-                , cancelBuildButton org repo model.repo.build.build cancelBuild
-                , restartBuildButton org repo model.repo.build.build restartBuild
+                [ approveBuildButton org repo model.shared.repo.build.build approveBuild
+                , cancelBuildButton org repo model.shared.repo.build.build cancelBuild
+                , restartBuildButton org repo model.shared.repo.build.build restartBuild
                 ]
 
         Pages.BuildPipeline org repo _ _ _ ->
             div [ class "buttons" ]
-                [ approveBuildButton org repo model.repo.build.build approveBuild
-                , cancelBuildButton org repo model.repo.build.build cancelBuild
-                , restartBuildButton org repo model.repo.build.build restartBuild
+                [ approveBuildButton org repo model.shared.repo.build.build approveBuild
+                , cancelBuildButton org repo model.shared.repo.build.build cancelBuild
+                , restartBuildButton org repo model.shared.repo.build.build restartBuild
                 ]
 
         Pages.BuildGraph org repo _ ->
             div [ class "buttons" ]
-                [ cancelBuildButton org repo model.repo.build.build cancelBuild
-                , restartBuildButton org repo model.repo.build.build restartBuild
+                [ cancelBuildButton org repo model.shared.repo.build.build cancelBuild
+                , restartBuildButton org repo model.shared.repo.build.build restartBuild
                 ]
 
         Pages.Hooks org repo _ _ ->
@@ -239,7 +238,7 @@ viewUtil : PartialModel a -> Html msg
 viewUtil model =
     let
         rm =
-            model.repo
+            model.shared.repo
     in
     div [ class "util" ]
         [ case model.page of
@@ -271,16 +270,16 @@ viewUtil model =
                 viewRepoTabs rm org repo model.page model.shared.velaScheduleAllowlist
 
             Pages.Build _ _ _ _ ->
-                Pages.Build.History.view model.time model.shared.zone model.page 10 model.repo
+                Pages.Build.History.view model.time model.shared.zone model.page 10 model.shared.repo
 
             Pages.BuildServices _ _ _ _ ->
-                Pages.Build.History.view model.time model.shared.zone model.page 10 model.repo
+                Pages.Build.History.view model.time model.shared.zone model.page 10 model.shared.repo
 
             Pages.BuildPipeline _ _ _ _ _ ->
-                Pages.Build.History.view model.time model.shared.zone model.page 10 model.repo
+                Pages.Build.History.view model.time model.shared.zone model.page 10 model.shared.repo
 
             Pages.BuildGraph _ _ _ ->
-                Pages.Build.History.view model.time model.shared.zone model.page 10 model.repo
+                Pages.Build.History.view model.time model.shared.zone model.page 10 model.shared.repo
 
             Pages.AddDeployment _ _ ->
                 text ""
@@ -474,7 +473,7 @@ viewBuildTabs : PartialModel a -> Org -> Repo -> BuildNumber -> Page -> Html msg
 viewBuildTabs model org repo buildNumber currentPage =
     let
         bm =
-            model.repo.build
+            model.shared.repo.build
 
         pipeline =
             model.pipeline

--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -51,7 +51,6 @@ type alias PartialModel a =
     { a
         | shared : Shared.Model
         , page : Page
-        , sourceRepos : WebData SourceRepositories
         , time : Posix
         , pipeline : PipelineModel
     }
@@ -120,10 +119,10 @@ navButtons model { fetchSourceRepos, toggleFavorite, approveBuild, restartBuild,
                     , ( "-outline", True )
                     ]
                 , onClick fetchSourceRepos
-                , disabled (model.sourceRepos == Loading)
+                , disabled (model.shared.sourceRepos == Loading)
                 , Util.testAttribute "refresh-source-repos"
                 ]
-                [ case model.sourceRepos of
+                [ case model.shared.sourceRepos of
                     Loading ->
                         text "Loading…"
 

--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -30,20 +30,16 @@ import Pages.Build.History
 import RemoteData exposing (RemoteData(..), WebData)
 import Routes
 import Shared
-import Time exposing (Posix, Zone)
 import Util
 import Vela
     exposing
         ( Build
         , BuildNumber
-        , CurrentUser
         , Engine
         , Org
-        , PipelineModel
         , Repo
         , RepoModel
         , SecretType
-        , SourceRepositories
         )
 
 
@@ -51,7 +47,6 @@ type alias PartialModel a =
     { a
         | shared : Shared.Model
         , page : Page
-        , pipeline : PipelineModel
     }
 
 
@@ -473,7 +468,7 @@ viewBuildTabs model org repo buildNumber currentPage =
             model.shared.repo.build
 
         pipeline =
-            model.pipeline
+            model.shared.pipeline
 
         tabs =
             [ Tab "Build" currentPage (Pages.Build org repo buildNumber bm.steps.focusFragment) False True

--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -5,7 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 
 module Nav exposing (Msgs, viewBuildTabs, viewNav, viewUtil)
 
-import Shared
 import Crumbs
 import Favorites exposing (ToggleFavorite, isFavorited, starToggle)
 import Html
@@ -30,6 +29,7 @@ import Pages exposing (Page)
 import Pages.Build.History
 import RemoteData exposing (RemoteData(..), WebData)
 import Routes
+import Shared
 import Time exposing (Posix, Zone)
 import Util
 import Vela
@@ -49,7 +49,7 @@ import Vela
 
 type alias PartialModel a =
     { a
-        | shared: Shared.Model
+        | shared : Shared.Model
         , page : Page
         , user : WebData CurrentUser
         , sourceRepos : WebData SourceRepositories

--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 module Nav exposing (Msgs, viewBuildTabs, viewNav, viewUtil)
 
+import Shared
 import Crumbs
 import Favorites exposing (ToggleFavorite, isFavorited, starToggle)
 import Html
@@ -48,13 +49,12 @@ import Vela
 
 type alias PartialModel a =
     { a
-        | velaScheduleAllowlist : List ( Org, Repo )
+        | shared: Shared.Model
         , page : Page
         , user : WebData CurrentUser
         , sourceRepos : WebData SourceRepositories
         , repo : RepoModel
         , time : Posix
-        , zone : Zone
         , pipeline : PipelineModel
     }
 
@@ -253,34 +253,34 @@ viewUtil model =
                 viewOrgTabs rm org model.page
 
             Pages.RepositoryBuilds org repo _ _ _ ->
-                viewRepoTabs rm org repo model.page model.velaScheduleAllowlist
+                viewRepoTabs rm org repo model.page model.shared.velaScheduleAllowlist
 
             Pages.RepositoryDeployments org repo _ _ ->
-                viewRepoTabs rm org repo model.page model.velaScheduleAllowlist
+                viewRepoTabs rm org repo model.page model.shared.velaScheduleAllowlist
 
             Pages.RepoSecrets _ org repo _ _ ->
-                viewRepoTabs rm org repo model.page model.velaScheduleAllowlist
+                viewRepoTabs rm org repo model.page model.shared.velaScheduleAllowlist
 
             Pages.Schedules org repo _ _ ->
-                viewRepoTabs rm org repo model.page model.velaScheduleAllowlist
+                viewRepoTabs rm org repo model.page model.shared.velaScheduleAllowlist
 
             Pages.Hooks org repo _ _ ->
-                viewRepoTabs rm org repo model.page model.velaScheduleAllowlist
+                viewRepoTabs rm org repo model.page model.shared.velaScheduleAllowlist
 
             Pages.RepoSettings org repo ->
-                viewRepoTabs rm org repo model.page model.velaScheduleAllowlist
+                viewRepoTabs rm org repo model.page model.shared.velaScheduleAllowlist
 
             Pages.Build _ _ _ _ ->
-                Pages.Build.History.view model.time model.zone model.page 10 model.repo
+                Pages.Build.History.view model.time model.shared.zone model.page 10 model.repo
 
             Pages.BuildServices _ _ _ _ ->
-                Pages.Build.History.view model.time model.zone model.page 10 model.repo
+                Pages.Build.History.view model.time model.shared.zone model.page 10 model.repo
 
             Pages.BuildPipeline _ _ _ _ _ ->
-                Pages.Build.History.view model.time model.zone model.page 10 model.repo
+                Pages.Build.History.view model.time model.shared.zone model.page 10 model.repo
 
             Pages.BuildGraph _ _ _ ->
-                Pages.Build.History.view model.time model.zone model.page 10 model.repo
+                Pages.Build.History.view model.time model.shared.zone model.page 10 model.repo
 
             Pages.AddDeployment _ _ ->
                 text ""

--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -51,7 +51,6 @@ type alias PartialModel a =
     { a
         | shared : Shared.Model
         , page : Page
-        , user : WebData CurrentUser
         , sourceRepos : WebData SourceRepositories
         , time : Posix
         , pipeline : PipelineModel
@@ -133,19 +132,19 @@ navButtons model { fetchSourceRepos, toggleFavorite, approveBuild, restartBuild,
                 ]
 
         Pages.RepositoryBuilds org repo _ _ _ ->
-            starToggle org repo toggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo
+            starToggle org repo toggleFavorite <| isFavorited model.shared.user <| org ++ "/" ++ repo
 
         Pages.RepositoryDeployments org repo _ _ ->
-            starToggle org repo toggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo
+            starToggle org repo toggleFavorite <| isFavorited model.shared.user <| org ++ "/" ++ repo
 
         Pages.Schedules org repo _ _ ->
-            starToggle org repo toggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo
+            starToggle org repo toggleFavorite <| isFavorited model.shared.user <| org ++ "/" ++ repo
 
         Pages.RepoSettings org repo ->
-            starToggle org repo toggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo
+            starToggle org repo toggleFavorite <| isFavorited model.shared.user <| org ++ "/" ++ repo
 
         Pages.RepoSecrets _ org repo _ _ ->
-            starToggle org repo toggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo
+            starToggle org repo toggleFavorite <| isFavorited model.shared.user <| org ++ "/" ++ repo
 
         Pages.Build org repo _ _ ->
             div [ class "buttons" ]
@@ -175,7 +174,7 @@ navButtons model { fetchSourceRepos, toggleFavorite, approveBuild, restartBuild,
                 ]
 
         Pages.Hooks org repo _ _ ->
-            starToggle org repo toggleFavorite <| isFavorited model.user <| org ++ "/" ++ repo
+            starToggle org repo toggleFavorite <| isFavorited model.shared.user <| org ++ "/" ++ repo
 
         Pages.OrgSecrets _ _ _ _ ->
             text ""

--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -51,7 +51,6 @@ type alias PartialModel a =
     { a
         | shared : Shared.Model
         , page : Page
-        , time : Posix
         , pipeline : PipelineModel
     }
 
@@ -268,16 +267,16 @@ viewUtil model =
                 viewRepoTabs rm org repo model.page model.shared.velaScheduleAllowlist
 
             Pages.Build _ _ _ _ ->
-                Pages.Build.History.view model.time model.shared.zone model.page 10 model.shared.repo
+                Pages.Build.History.view model.shared.time model.shared.zone model.page 10 model.shared.repo
 
             Pages.BuildServices _ _ _ _ ->
-                Pages.Build.History.view model.time model.shared.zone model.page 10 model.shared.repo
+                Pages.Build.History.view model.shared.time model.shared.zone model.page 10 model.shared.repo
 
             Pages.BuildPipeline _ _ _ _ _ ->
-                Pages.Build.History.view model.time model.shared.zone model.page 10 model.shared.repo
+                Pages.Build.History.view model.shared.time model.shared.zone model.page 10 model.shared.repo
 
             Pages.BuildGraph _ _ _ ->
-                Pages.Build.History.view model.time model.shared.zone model.page 10 model.shared.repo
+                Pages.Build.History.view model.shared.time model.shared.zone model.page 10 model.shared.repo
 
             Pages.AddDeployment _ _ ->
                 text ""

--- a/src/elm/Pages/Build/Graph/DOT.elm
+++ b/src/elm/Pages/Build/Graph/DOT.elm
@@ -187,7 +187,7 @@ nodeLabel model buildGraph node showSteps =
                 ++ "</table>"
 
         runtime =
-            Util.formatRunTime model.time node.startedAt node.finishedAt
+            Util.formatRunTime model.shared.time node.startedAt node.finishedAt
 
         header =
             "<tr>"

--- a/src/elm/Pages/Build/Graph/DOT.elm
+++ b/src/elm/Pages/Build/Graph/DOT.elm
@@ -44,7 +44,7 @@ renderDOT model buildGraph =
         isNodeFocused : String -> BuildGraphNode -> Bool
         isNodeFocused filter n =
             n.id
-                == model.repo.build.graph.focusedNode
+                == model.shared.repo.build.graph.focusedNode
                 || (String.length filter > 2)
                 && (String.contains filter n.name
                         || List.any (\s -> String.contains filter s.name) n.steps
@@ -61,14 +61,14 @@ renderDOT model buildGraph =
                 |> List.map
                     (\( _, n ) ->
                         Node n.id
-                            (BuildGraphNode n.cluster n.id n.name n.status n.startedAt n.finishedAt n.steps (isNodeFocused model.repo.build.graph.filter n))
+                            (BuildGraphNode n.cluster n.id n.name n.status n.startedAt n.finishedAt n.steps (isNodeFocused model.shared.repo.build.graph.filter n))
                     )
 
         -- convert BuildGraphEdge to Graph.Edge
         inEdges =
             buildGraph.edges
                 |> List.map
-                    (\e -> Edge e.source e.destination (BuildGraphEdge e.cluster e.source e.destination e.status (isEdgeFocused model.repo.build.graph.focusedNode e)))
+                    (\e -> Edge e.source e.destination (BuildGraphEdge e.cluster e.source e.destination e.status (isEdgeFocused model.shared.repo.build.graph.focusedNode e)))
 
         -- construct a Graph to extract nodes and edges
         ( nodes, edges ) =
@@ -134,7 +134,7 @@ renderDOT model buildGraph =
             clusterSubgraph builtInClusterID builtInSubgraphStyles builtInNodesString builtInEdgesString
 
         serviceSubgraph =
-            if model.repo.build.graph.showServices then
+            if model.shared.repo.build.graph.showServices then
                 clusterSubgraph serviceClusterID serviceSubgraphStyles serviceNodesString serviceEdgesString
 
             else
@@ -142,7 +142,7 @@ renderDOT model buildGraph =
 
         -- reverse the subgraphs for top-bottom rankdir to consistently group services and built-ins
         rotation =
-            case model.repo.build.graph.rankdir of
+            case model.shared.repo.build.graph.rankdir of
                 TB ->
                     List.reverse
 
@@ -162,7 +162,7 @@ renderDOT model buildGraph =
             , serviceSubgraph
             ]
     in
-    digraph (baseGraphStyles model.repo.build.graph.rankdir)
+    digraph (baseGraphStyles model.shared.repo.build.graph.rankdir)
         (rotation subgraphs)
 
 
@@ -437,7 +437,7 @@ nodeAttributes model buildGraph node =
 
         -- track step expansion using the model and OnGraphInteraction
         showSteps =
-            model.repo.build.graph.showSteps
+            model.shared.repo.build.graph.showSteps
     in
     Dict.fromList <|
         -- node attributes

--- a/src/elm/Pages/Build/Graph/Interop.elm
+++ b/src/elm/Pages/Build/Graph/Interop.elm
@@ -18,16 +18,16 @@ import Vela exposing (encodeBuildGraphRenderData)
 renderBuildGraph : BuildModel.PartialModel a -> Bool -> Cmd msg
 renderBuildGraph model freshDraw =
     -- rendering the full graph requires repo, build and graph
-    case model.repo.build.graph.graph of
+    case model.shared.repo.build.graph.graph of
         Success g ->
             Interop.renderBuildGraph <|
                 encodeBuildGraphRenderData
                     { dot = renderDOT model g
                     , buildID = g.buildID
-                    , filter = model.repo.build.graph.filter
-                    , showServices = model.repo.build.graph.showServices
-                    , showSteps = model.repo.build.graph.showSteps
-                    , focusedNode = model.repo.build.graph.focusedNode
+                    , filter = model.shared.repo.build.graph.filter
+                    , showServices = model.shared.repo.build.graph.showServices
+                    , showSteps = model.shared.repo.build.graph.showSteps
+                    , focusedNode = model.shared.repo.build.graph.focusedNode
                     , freshDraw = freshDraw
                     }
 

--- a/src/elm/Pages/Build/Graph/View.elm
+++ b/src/elm/Pages/Build/Graph/View.elm
@@ -59,7 +59,7 @@ view model msgs org repo buildNumber =
                         , class "-icon"
                         , class "build-graph-action-rotate"
                         , class <|
-                            case model.repo.build.graph.rankdir of
+                            case model.shared.repo.build.graph.rankdir of
                                 DOT.TB ->
                                     "-vertical"
 
@@ -80,7 +80,7 @@ view model msgs org repo buildNumber =
                     [ div []
                         [ Html.input
                             [ Html.Attributes.type_ "checkbox"
-                            , Html.Attributes.checked model.repo.build.graph.showServices
+                            , Html.Attributes.checked model.shared.repo.build.graph.showServices
                             , onCheck msgs.buildGraphMsgs.showServices
                             , id "checkbox-services-toggle"
                             , Util.testAttribute "build-graph-action-toggle-services"
@@ -95,7 +95,7 @@ view model msgs org repo buildNumber =
                     [ div []
                         [ Html.input
                             [ Html.Attributes.type_ "checkbox"
-                            , Html.Attributes.checked model.repo.build.graph.showSteps
+                            , Html.Attributes.checked model.shared.repo.build.graph.showSteps
                             , onCheck msgs.buildGraphMsgs.showSteps
                             , id "checkbox-steps-toggle"
                             , Util.testAttribute "build-graph-action-toggle-steps"
@@ -114,7 +114,7 @@ view model msgs org repo buildNumber =
                             , Html.Events.onInput msgs.buildGraphMsgs.updateFilter
                             , id "build-graph-action-filter"
                             , Util.testAttribute "build-graph-action-filter"
-                            , Html.Attributes.value model.repo.build.graph.filter
+                            , Html.Attributes.value model.shared.repo.build.graph.filter
                             ]
                             []
                         , Html.label [ class "elm-build-graph-search-filter-form-label", Html.Attributes.for "build-graph-action-filter" ]
@@ -177,7 +177,7 @@ view model msgs org repo buildNumber =
                     , text "complete"
                     ]
                 ]
-            , case model.repo.build.graph.graph of
+            , case model.shared.repo.build.graph.graph of
                 RemoteData.Success _ ->
                     -- dont render anything when the build graph draw command has been dispatched
                     text ""

--- a/src/elm/Pages/Build/Model.elm
+++ b/src/elm/Pages/Build/Model.elm
@@ -16,11 +16,11 @@ module Pages.Build.Model exposing
     , PartialModel
     )
 
-import Shared
 import Browser.Navigation as Navigation
 import Html exposing (Html)
 import Pages exposing (Page)
 import RemoteData exposing (WebData)
+import Shared
 import Time exposing (Posix, Zone)
 import Vela exposing (BuildNumber, CurrentUser, Org, PipelineModel, Repo, RepoModel, SourceRepositories)
 

--- a/src/elm/Pages/Build/Model.elm
+++ b/src/elm/Pages/Build/Model.elm
@@ -36,7 +36,6 @@ type alias PartialModel a =
         | shared : Shared.Model
         , navigationKey : Navigation.Key
         , page : Page
-        , pipeline : PipelineModel
     }
 
 

--- a/src/elm/Pages/Build/Model.elm
+++ b/src/elm/Pages/Build/Model.elm
@@ -35,7 +35,6 @@ type alias PartialModel a =
     { a
         | shared : Shared.Model
         , navigationKey : Navigation.Key
-        , sourceRepos : WebData SourceRepositories
         , page : Page
         , time : Posix
         , buildMenuOpen : List Int

--- a/src/elm/Pages/Build/Model.elm
+++ b/src/elm/Pages/Build/Model.elm
@@ -36,7 +36,6 @@ type alias PartialModel a =
         | shared : Shared.Model
         , navigationKey : Navigation.Key
         , page : Page
-        , buildMenuOpen : List Int
         , pipeline : PipelineModel
     }
 

--- a/src/elm/Pages/Build/Model.elm
+++ b/src/elm/Pages/Build/Model.elm
@@ -36,7 +36,6 @@ type alias PartialModel a =
         | shared : Shared.Model
         , navigationKey : Navigation.Key
         , page : Page
-        , time : Posix
         , buildMenuOpen : List Int
         , pipeline : PipelineModel
     }

--- a/src/elm/Pages/Build/Model.elm
+++ b/src/elm/Pages/Build/Model.elm
@@ -35,7 +35,6 @@ type alias PartialModel a =
     { a
         | shared : Shared.Model
         , navigationKey : Navigation.Key
-        , user : WebData CurrentUser
         , sourceRepos : WebData SourceRepositories
         , page : Page
         , time : Posix

--- a/src/elm/Pages/Build/Model.elm
+++ b/src/elm/Pages/Build/Model.elm
@@ -16,6 +16,7 @@ module Pages.Build.Model exposing
     , PartialModel
     )
 
+import Shared
 import Browser.Navigation as Navigation
 import Html exposing (Html)
 import Pages exposing (Page)
@@ -32,15 +33,13 @@ import Vela exposing (BuildNumber, CurrentUser, Org, PipelineModel, Repo, RepoMo
 -}
 type alias PartialModel a =
     { a
-        | velaScheduleAllowlist : List ( Org, Repo )
+        | shared : Shared.Model
         , navigationKey : Navigation.Key
         , user : WebData CurrentUser
         , sourceRepos : WebData SourceRepositories
         , page : Page
         , time : Posix
-        , zone : Zone
         , repo : RepoModel
-        , shift : Bool
         , buildMenuOpen : List Int
         , pipeline : PipelineModel
     }

--- a/src/elm/Pages/Build/Model.elm
+++ b/src/elm/Pages/Build/Model.elm
@@ -39,7 +39,6 @@ type alias PartialModel a =
         , sourceRepos : WebData SourceRepositories
         , page : Page
         , time : Posix
-        , repo : RepoModel
         , buildMenuOpen : List Int
         , pipeline : PipelineModel
     }

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -94,11 +94,11 @@ import Vela
 viewBuild : PartialModel a -> Msgs msg -> Org -> Repo -> BuildNumber -> Html msg
 viewBuild model msgs org repo buildNumber =
     wrapWithBuildPreview model msgs org repo buildNumber <|
-        case model.repo.build.steps.steps of
+        case model.shared.repo.build.steps.steps of
             RemoteData.Success steps_ ->
                 viewBuildSteps model
                     msgs
-                    model.repo
+                    model.shared.repo
                     steps_
 
             RemoteData.Failure _ ->
@@ -106,7 +106,7 @@ viewBuild model msgs org repo buildNumber =
 
             _ ->
                 -- Don't show two loaders
-                if Util.isLoading model.repo.build.build then
+                if Util.isLoading model.shared.repo.build.build then
                     text ""
 
                 else
@@ -119,7 +119,7 @@ wrapWithBuildPreview : PartialModel a -> Msgs msgs -> Org -> Repo -> BuildNumber
 wrapWithBuildPreview model msgs org repo buildNumber content =
     let
         rm =
-            model.repo
+            model.shared.repo
 
         build =
             rm.build
@@ -610,7 +610,7 @@ viewStepLogs msgs shift rm step =
 viewBuildServices : PartialModel a -> Msgs msg -> Org -> Repo -> BuildNumber -> Html msg
 viewBuildServices model msgs org repo buildNumber =
     wrapWithBuildPreview model msgs org repo buildNumber <|
-        case model.repo.build.services.services of
+        case model.shared.repo.build.services.services of
             RemoteData.Success services ->
                 if List.isEmpty services then
                     div [ class "no-services" ] [ small [] [ code [] [ text "No services found for this pipeline." ] ] ]
@@ -624,14 +624,14 @@ viewBuildServices model msgs org repo buildNumber =
                                 , Util.testAttribute "log-actions"
                                 ]
                                 [ collapseAllButton msgs.collapseAllServices
-                                , expandAllButton msgs.expandAllServices model.repo.org model.repo.name model.repo.build.buildNumber
+                                , expandAllButton msgs.expandAllServices model.shared.repo.org model.shared.repo.name model.shared.repo.build.buildNumber
                                 ]
                     in
                     div []
                         [ logActions
                         , div [ class "steps" ]
                             [ div [ class "-items", Util.testAttribute "services" ] <|
-                                List.map (\service -> viewService model msgs model.repo service) <|
+                                List.map (\service -> viewService model msgs model.shared.repo service) <|
                                     services
                             ]
                         ]
@@ -641,7 +641,7 @@ viewBuildServices model msgs org repo buildNumber =
 
             _ ->
                 -- Don't show two loaders
-                if Util.isLoading model.repo.build.build then
+                if Util.isLoading model.shared.repo.build.build then
                     text ""
 
                 else

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -129,14 +129,14 @@ wrapWithBuildPreview model msgs org repo buildNumber content =
                 RemoteData.Success bld ->
                     case bld.status of
                         PendingApproval ->
-                            [ viewPreview msgs model.buildMenuOpen False model.time model.shared.zone org repo rm.builds.showTimestamp bld
+                            [ viewPreview msgs model.buildMenuOpen False model.shared.time model.shared.zone org repo rm.builds.showTimestamp bld
                             , p [ class "notice", Util.testAttribute "approve-build-notice" ] [ text "An admin of this repository must approve the build to run" ]
                             , viewBuildTabs model org repo buildNumber model.page
                             , content
                             ]
 
                         _ ->
-                            [ viewPreview msgs model.buildMenuOpen False model.time model.shared.zone org repo rm.builds.showTimestamp bld
+                            [ viewPreview msgs model.buildMenuOpen False model.shared.time model.shared.zone org repo rm.builds.showTimestamp bld
                             , viewBuildTabs model org repo buildNumber model.page
                             , content
                             ]
@@ -502,7 +502,7 @@ viewStepDetails model msgs rm step =
                 [ div
                     [ class "-info" ]
                     [ div [ class "-name" ] [ text step.name ]
-                    , div [ class "-duration" ] [ text <| Util.formatRunTime model.time step.started step.finished ]
+                    , div [ class "-duration" ] [ text <| Util.formatRunTime model.shared.time step.started step.finished ]
                     ]
                 , FeatherIcons.chevronDown |> FeatherIcons.withSize 20 |> FeatherIcons.withClass "details-icon-expand" |> FeatherIcons.toHtml [ attribute "aria-label" "show build actions" ]
                 ]
@@ -680,7 +680,7 @@ viewServiceDetails model msgs rm service =
                 [ div
                     [ class "-info" ]
                     [ div [ class "-name" ] [ text service.name ]
-                    , div [ class "-duration" ] [ text <| Util.formatRunTime model.time service.started service.finished ]
+                    , div [ class "-duration" ] [ text <| Util.formatRunTime model.shared.time service.started service.finished ]
                     ]
                 , FeatherIcons.chevronDown |> FeatherIcons.withSize 20 |> FeatherIcons.withClass "details-icon-expand" |> FeatherIcons.toHtml []
                 ]

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -129,14 +129,14 @@ wrapWithBuildPreview model msgs org repo buildNumber content =
                 RemoteData.Success bld ->
                     case bld.status of
                         PendingApproval ->
-                            [ viewPreview msgs model.buildMenuOpen False model.time model.zone org repo rm.builds.showTimestamp bld
+                            [ viewPreview msgs model.buildMenuOpen False model.time model.shared.zone org repo rm.builds.showTimestamp bld
                             , p [ class "notice", Util.testAttribute "approve-build-notice" ] [ text "An admin of this repository must approve the build to run" ]
                             , viewBuildTabs model org repo buildNumber model.page
                             , content
                             ]
 
                         _ ->
-                            [ viewPreview msgs model.buildMenuOpen False model.time model.zone org repo rm.builds.showTimestamp bld
+                            [ viewPreview msgs model.buildMenuOpen False model.time model.shared.zone org repo rm.builds.showTimestamp bld
                             , viewBuildTabs model org repo buildNumber model.page
                             , content
                             ]
@@ -506,7 +506,7 @@ viewStepDetails model msgs rm step =
                     ]
                 , FeatherIcons.chevronDown |> FeatherIcons.withSize 20 |> FeatherIcons.withClass "details-icon-expand" |> FeatherIcons.toHtml [ attribute "aria-label" "show build actions" ]
                 ]
-            , div [ class "logs-container" ] [ viewStepLogs msgs.logsMsgs model.shift rm step ]
+            , div [ class "logs-container" ] [ viewStepLogs msgs.logsMsgs model.shared.shift rm step ]
             ]
     in
     details
@@ -684,7 +684,7 @@ viewServiceDetails model msgs rm service =
                     ]
                 , FeatherIcons.chevronDown |> FeatherIcons.withSize 20 |> FeatherIcons.withClass "details-icon-expand" |> FeatherIcons.toHtml []
                 ]
-            , div [ class "logs-container" ] [ viewServiceLogs msgs.logsMsgs model.shift rm service ]
+            , div [ class "logs-container" ] [ viewServiceLogs msgs.logsMsgs model.shared.shift rm service ]
             ]
     in
     details

--- a/src/elm/Pages/Build/View.elm
+++ b/src/elm/Pages/Build/View.elm
@@ -129,14 +129,14 @@ wrapWithBuildPreview model msgs org repo buildNumber content =
                 RemoteData.Success bld ->
                     case bld.status of
                         PendingApproval ->
-                            [ viewPreview msgs model.buildMenuOpen False model.shared.time model.shared.zone org repo rm.builds.showTimestamp bld
+                            [ viewPreview msgs model.shared.buildMenuOpen False model.shared.time model.shared.zone org repo rm.builds.showTimestamp bld
                             , p [ class "notice", Util.testAttribute "approve-build-notice" ] [ text "An admin of this repository must approve the build to run" ]
                             , viewBuildTabs model org repo buildNumber model.page
                             , content
                             ]
 
                         _ ->
-                            [ viewPreview msgs model.buildMenuOpen False model.shared.time model.shared.zone org repo rm.builds.showTimestamp bld
+                            [ viewPreview msgs model.shared.buildMenuOpen False model.shared.time model.shared.zone org repo rm.builds.showTimestamp bld
                             , viewBuildTabs model org repo buildNumber model.page
                             , content
                             ]

--- a/src/elm/Pages/Deployments/Model.elm
+++ b/src/elm/Pages/Deployments/Model.elm
@@ -12,12 +12,12 @@ module Pages.Deployments.Model exposing
     , defaultDeploymentForm
     )
 
-import Shared
 import Auth.Session exposing (Session)
 import Http
 import Http.Detailed
 import Pages exposing (Page)
 import RemoteData exposing (WebData)
+import Shared
 import Vela exposing (Deployment, KeyValuePair, Org, Repo, Repository, Team)
 
 
@@ -29,7 +29,7 @@ import Vela exposing (Deployment, KeyValuePair, Org, Repo, Repository, Team)
 -}
 type alias PartialModel a msg =
     { a
-        | shared: Shared.Model
+        | shared : Shared.Model
         , page : Page
         , deploymentModel : Model msg
     }

--- a/src/elm/Pages/Deployments/Model.elm
+++ b/src/elm/Pages/Deployments/Model.elm
@@ -12,6 +12,7 @@ module Pages.Deployments.Model exposing
     , defaultDeploymentForm
     )
 
+import Shared
 import Auth.Session exposing (Session)
 import Http
 import Http.Detailed
@@ -28,8 +29,7 @@ import Vela exposing (Deployment, KeyValuePair, Org, Repo, Repository, Team)
 -}
 type alias PartialModel a msg =
     { a
-        | velaAPI : String
-        , session : Session
+        | shared: Shared.Model
         , page : Page
         , deploymentModel : Model msg
     }

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -5,12 +5,12 @@ SPDX-License-Identifier: Apache-2.0
 
 module Pages.Pipeline.Model exposing (Download, Expand, Get, Msgs, PartialModel)
 
-import Shared
 import Alerts exposing (Alert)
 import Auth.Session exposing (Session)
 import Browser.Navigation as Navigation
 import Pages exposing (Page)
 import RemoteData exposing (WebData)
+import Shared
 import Time exposing (Posix)
 import Toasty exposing (Stack)
 import Vela

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -41,7 +41,6 @@ type alias PartialModel a =
         , sourceRepos : WebData SourceRepositories
         , navigationKey : Navigation.Key
         , time : Posix
-        , repo : RepoModel
         , templates : PipelineTemplates
         , pipeline : PipelineModel
         , page : Page

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -38,7 +38,6 @@ type alias PartialModel a =
     { a
         | shared : Shared.Model
         , navigationKey : Navigation.Key
-        , time : Posix
         , templates : PipelineTemplates
         , pipeline : PipelineModel
         , page : Page

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -30,7 +30,6 @@ type alias PartialModel a =
     { a
         | shared : Shared.Model
         , navigationKey : Navigation.Key
-        , templates : PipelineTemplates
         , page : Page
     }
 

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 module Pages.Pipeline.Model exposing (Download, Expand, Get, Msgs, PartialModel)
 
+import Shared
 import Alerts exposing (Alert)
 import Auth.Session exposing (Session)
 import Browser.Navigation as Navigation
@@ -35,14 +36,12 @@ import Vela
 -}
 type alias PartialModel a =
     { a
-        | velaAPI : String
-        , session : Session
+        | shared : Shared.Model
         , user : WebData CurrentUser
         , sourceRepos : WebData SourceRepositories
         , navigationKey : Navigation.Key
         , time : Posix
         , repo : RepoModel
-        , shift : Bool
         , templates : PipelineTemplates
         , pipeline : PipelineModel
         , page : Page

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -45,7 +45,6 @@ type alias PartialModel a =
         , templates : PipelineTemplates
         , pipeline : PipelineModel
         , page : Page
-        , toasties : Stack Alert
     }
 
 

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -5,26 +5,18 @@ SPDX-License-Identifier: Apache-2.0
 
 module Pages.Pipeline.Model exposing (Download, Expand, Get, Msgs, PartialModel)
 
-import Alerts exposing (Alert)
-import Auth.Session exposing (Session)
 import Browser.Navigation as Navigation
 import Pages exposing (Page)
-import RemoteData exposing (WebData)
 import Shared
-import Time exposing (Posix)
-import Toasty exposing (Stack)
 import Vela
     exposing
         ( BuildNumber
-        , CurrentUser
         , FocusFragment
         , Org
         , PipelineModel
         , PipelineTemplates
         , Ref
         , Repo
-        , RepoModel
-        , SourceRepositories
         )
 
 
@@ -39,7 +31,6 @@ type alias PartialModel a =
         | shared : Shared.Model
         , navigationKey : Navigation.Key
         , templates : PipelineTemplates
-        , pipeline : PipelineModel
         , page : Page
     }
 

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -37,7 +37,6 @@ import Vela
 type alias PartialModel a =
     { a
         | shared : Shared.Model
-        , sourceRepos : WebData SourceRepositories
         , navigationKey : Navigation.Key
         , time : Posix
         , templates : PipelineTemplates

--- a/src/elm/Pages/Pipeline/Model.elm
+++ b/src/elm/Pages/Pipeline/Model.elm
@@ -37,7 +37,6 @@ import Vela
 type alias PartialModel a =
     { a
         | shared : Shared.Model
-        , user : WebData CurrentUser
         , sourceRepos : WebData SourceRepositories
         , navigationKey : Navigation.Key
         , time : Posix

--- a/src/elm/Pages/Pipeline/View.elm
+++ b/src/elm/Pages/Pipeline/View.elm
@@ -141,7 +141,7 @@ viewTemplate ( _, t ) =
 -}
 viewPipelineConfiguration : PartialModel a -> Msgs msg -> Html msg
 viewPipelineConfiguration model msgs =
-    case model.pipeline.config of
+    case model.shared.pipeline.config of
         ( Loading, _ ) ->
             Util.smallLoaderWithText "loading pipeline configuration"
 
@@ -157,7 +157,7 @@ viewPipelineConfiguration model msgs =
 viewPipelineConfigurationResponse : PartialModel a -> Msgs msg -> Html msg
 viewPipelineConfigurationResponse model msgs =
     div [ class "logs-container", class "-pipeline" ]
-        [ case model.pipeline.config of
+        [ case model.shared.pipeline.config of
             ( Success config, _ ) ->
                 viewPipelineConfigurationData model config msgs
 
@@ -175,7 +175,7 @@ viewPipelineConfigurationData : PartialModel a -> PipelineConfig -> Msgs msg -> 
 viewPipelineConfigurationData model config msgs =
     wrapPipelineConfigurationContent model msgs (class "") <|
         div [ class "logs", Util.testAttribute "pipeline-configuration-data" ] <|
-            viewLines config model.pipeline.lineFocus msgs.focusLineNumber
+            viewLines config model.shared.pipeline.lineFocus msgs.focusLineNumber
 
 
 {-| viewPipelineConfigurationData : takes model and string and renders a pipeline configuration error.
@@ -215,7 +215,7 @@ viewPipelineActions : PartialModel a -> Get msg -> Expand msg -> Download msg ->
 viewPipelineActions model get expand download =
     let
         pipeline =
-            model.pipeline
+            model.shared.pipeline
 
         toggle =
             case model.shared.repo.build.build of
@@ -294,7 +294,7 @@ expandPipelineToggleButton : PartialModel a -> String -> Get msg -> Expand msg -
 expandPipelineToggleButton model ref get expand =
     let
         pipeline =
-            model.pipeline
+            model.shared.pipeline
 
         { org, name, build } =
             model.shared.repo

--- a/src/elm/Pages/Pipeline/View.elm
+++ b/src/elm/Pages/Pipeline/View.elm
@@ -51,7 +51,7 @@ import Vela
 viewPipeline : PartialModel a -> Msgs msg -> Html msg
 viewPipeline model msgs =
     div [ class "pipeline" ]
-        [ viewPipelineTemplates model.templates msgs.showHideTemplates
+        [ viewPipelineTemplates model.shared.templates msgs.showHideTemplates
         , viewPipelineConfiguration model msgs
         ]
 

--- a/src/elm/Pages/Pipeline/View.elm
+++ b/src/elm/Pages/Pipeline/View.elm
@@ -218,7 +218,7 @@ viewPipelineActions model get expand download =
             model.pipeline
 
         toggle =
-            case model.repo.build.build of
+            case model.shared.repo.build.build of
                 Success build ->
                     div [ class "action", class "expand-pipeline", Util.testAttribute "pipeline-expand" ]
                         [ expandPipelineToggleButton model build.commit get expand
@@ -297,7 +297,7 @@ expandPipelineToggleButton model ref get expand =
             model.pipeline
 
         { org, name, build } =
-            model.repo
+            model.shared.repo
 
         action =
             if pipeline.expanded then

--- a/src/elm/Pages/Schedules/Form.elm
+++ b/src/elm/Pages/Schedules/Form.elm
@@ -52,7 +52,7 @@ viewAddForm model =
     in
     div [ class "schedule-form" ]
         [ viewNameInput sm.form.name False
-        , viewValueInput sm.form.entry "0 0 * * * (runs at 12:00 AM in UTC)" (Util.toUtcString model.time)
+        , viewValueInput sm.form.entry "0 0 * * * (runs at 12:00 AM in UTC)" (Util.toUtcString model.shared.time)
         , viewEnabledCheckbox sm.form
         , viewBranchNameInput sm.form.branch False
         , viewHelp
@@ -70,7 +70,7 @@ viewEditForm model =
     in
     div [ class "schedule-form", class "edit-form" ]
         [ viewNameInput sm.form.name True
-        , viewValueInput sm.form.entry "0 0 * * * (runs at 12:00 AM in UTC)" (Util.toUtcString model.time)
+        , viewValueInput sm.form.entry "0 0 * * * (runs at 12:00 AM in UTC)" (Util.toUtcString model.shared.time)
         , viewEnabledCheckbox sm.form
         , viewBranchNameInput sm.form.branch False
         , viewHelp

--- a/src/elm/Pages/Schedules/Model.elm
+++ b/src/elm/Pages/Schedules/Model.elm
@@ -39,7 +39,6 @@ type alias PartialModel a msg =
     { a
         | shared : Shared.Model
         , page : Page
-        , time : Posix
         , schedulesModel : Model msg
     }
 

--- a/src/elm/Pages/Schedules/Model.elm
+++ b/src/elm/Pages/Schedules/Model.elm
@@ -17,6 +17,7 @@ module Pages.Schedules.Model exposing
     , defaultScheduleUpdate
     )
 
+import Shared
 import Api.Pagination as Pagination
 import Auth.Session exposing (Session)
 import Http
@@ -36,12 +37,9 @@ import Vela exposing (Org, Repo, Schedule, Schedules)
 -}
 type alias PartialModel a msg =
     { a
-        | velaAPI : String
-        , velaScheduleAllowlist : List ( Org, Repo )
-        , session : Session
+        | shared: Shared.Model
         , page : Page
         , time : Posix
-        , zone : Zone
         , schedulesModel : Model msg
     }
 

--- a/src/elm/Pages/Schedules/Model.elm
+++ b/src/elm/Pages/Schedules/Model.elm
@@ -17,7 +17,6 @@ module Pages.Schedules.Model exposing
     , defaultScheduleUpdate
     )
 
-import Shared
 import Api.Pagination as Pagination
 import Auth.Session exposing (Session)
 import Http
@@ -25,6 +24,7 @@ import Http.Detailed
 import LinkHeader exposing (WebLink)
 import Pages exposing (Page)
 import RemoteData exposing (WebData)
+import Shared
 import Time exposing (Posix, Zone)
 import Vela exposing (Org, Repo, Schedule, Schedules)
 
@@ -37,7 +37,7 @@ import Vela exposing (Org, Repo, Schedule, Schedules)
 -}
 type alias PartialModel a msg =
     { a
-        | shared: Shared.Model
+        | shared : Shared.Model
         , page : Page
         , time : Posix
         , schedulesModel : Model msg

--- a/src/elm/Pages/Schedules/Model.elm
+++ b/src/elm/Pages/Schedules/Model.elm
@@ -18,14 +18,12 @@ module Pages.Schedules.Model exposing
     )
 
 import Api.Pagination as Pagination
-import Auth.Session exposing (Session)
 import Http
 import Http.Detailed
 import LinkHeader exposing (WebLink)
 import Pages exposing (Page)
 import RemoteData exposing (WebData)
 import Shared
-import Time exposing (Posix, Zone)
 import Vela exposing (Org, Repo, Schedule, Schedules)
 
 

--- a/src/elm/Pages/Schedules/View.elm
+++ b/src/elm/Pages/Schedules/View.elm
@@ -51,7 +51,7 @@ viewRepoSchedules : PartialModel a msg -> Org -> Repo -> Html msg
 viewRepoSchedules model org repo =
     let
         schedulesAllowed =
-            Util.checkScheduleAllowlist org repo model.velaScheduleAllowlist
+            Util.checkScheduleAllowlist org repo model.shared.velaScheduleAllowlist
 
         actions =
             if schedulesAllowed then
@@ -80,7 +80,7 @@ viewRepoSchedules model org repo =
                 case model.schedulesModel.schedules of
                     Success s ->
                         ( text "No schedules found for this repo"
-                        , schedulesToRows model.zone org repo s
+                        , schedulesToRows model.shared.zone org repo s
                         )
 
                     Failure error ->
@@ -226,7 +226,7 @@ viewAddSchedule model =
     div [ class "manage-schedule", Util.testAttribute "manage-schedule" ]
         [ div []
             [ h2 [] [ text "Add Schedule" ]
-            , if Util.checkScheduleAllowlist model.schedulesModel.org model.schedulesModel.repo model.velaScheduleAllowlist then
+            , if Util.checkScheduleAllowlist model.schedulesModel.org model.schedulesModel.repo model.shared.velaScheduleAllowlist then
                 viewAddForm model
 
               else
@@ -242,7 +242,7 @@ viewEditSchedule model =
     div [ class "manage-schedule", Util.testAttribute "manage-schedule" ]
         [ div []
             [ h2 [] [ text "View/Edit Schedule" ]
-            , if Util.checkScheduleAllowlist model.schedulesModel.org model.schedulesModel.repo model.velaScheduleAllowlist then
+            , if Util.checkScheduleAllowlist model.schedulesModel.org model.schedulesModel.repo model.shared.velaScheduleAllowlist then
                 case model.schedulesModel.schedule of
                     Success _ ->
                         viewEditForm model

--- a/src/elm/Pages/Secrets/Form.elm
+++ b/src/elm/Pages/Secrets/Form.elm
@@ -169,7 +169,7 @@ viewEventsSelect : SecretForm -> PartialModel a msg -> Html Msg
 viewEventsSelect secretUpdate model =
     let
         schedulesAllowed =
-            Util.checkScheduleAllowlist model.secretsModel.org model.secretsModel.repo model.velaScheduleAllowlist
+            Util.checkScheduleAllowlist model.secretsModel.org model.secretsModel.repo model.shared.velaScheduleAllowlist
 
         scheduleOption =
             if schedulesAllowed then

--- a/src/elm/Pages/Secrets/Model.elm
+++ b/src/elm/Pages/Secrets/Model.elm
@@ -17,6 +17,7 @@ module Pages.Secrets.Model exposing
     , defaultSecretUpdate
     )
 
+import Shared
 import Auth.Session exposing (Session)
 import Http
 import Http.Detailed
@@ -34,9 +35,7 @@ import Vela exposing (Copy, Engine, Key, Org, Repo, Secret, SecretType, Secrets,
 -}
 type alias PartialModel a msg =
     { a
-        | velaAPI : String
-        , velaScheduleAllowlist : List ( Org, Repo )
-        , session : Session
+        | shared : Shared.Model
         , page : Page
         , secretsModel : Model msg
     }

--- a/src/elm/Pages/Secrets/Model.elm
+++ b/src/elm/Pages/Secrets/Model.elm
@@ -17,13 +17,13 @@ module Pages.Secrets.Model exposing
     , defaultSecretUpdate
     )
 
-import Shared
 import Auth.Session exposing (Session)
 import Http
 import Http.Detailed
 import LinkHeader exposing (WebLink)
 import Pages exposing (Page)
 import RemoteData exposing (WebData)
+import Shared
 import Vela exposing (Copy, Engine, Key, Org, Repo, Secret, SecretType, Secrets, Team)
 
 

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -14,6 +14,8 @@ import Url exposing (..)
 import Util exposing (..)
 import Vela exposing (..)
 
+
+
 -- INIT
 
 
@@ -21,11 +23,13 @@ type alias Model =
     Shared.Model.Model
 
 
+
 --init : Result Json.Decode.Error Flags -> Route () -> ( Model, Effect Msg )
 --init flagsResult route =
 --    ( {}
 --    , Effect.none
 --    )
+
 
 type alias Flags =
     { isDev : Bool
@@ -38,7 +42,6 @@ type alias Flags =
     , velaMaxBuildLimit : Int
     , velaScheduleAllowlist : String
     }
-
 
 
 init : Flags -> Url -> Model

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -1,5 +1,7 @@
 module Shared exposing (..)
 
+-- todo: these need to be refined, only expose what is needed
+
 import Alerts exposing (..)
 import Auth.Session exposing (..)
 import Browser.Dom exposing (..)
@@ -23,6 +25,10 @@ type alias Model =
     Shared.Model.Model
 
 
+
+-- todo: comments, what goes in here, why
+
+
 type alias Flags =
     { isDev : Bool
     , velaAPI : String
@@ -36,8 +42,13 @@ type alias Flags =
     }
 
 
+
+-- todo: comments
+
+
 init : Flags -> Url -> Model
 init flags url =
+    -- todo: these need to be logically ordered (flags, session, user, data models, etc)
     { session = Unauthenticated
     , fetchingToken = String.length flags.velaRedirect == 0
     , user = NotAsked
@@ -63,10 +74,11 @@ init flags url =
     , showIdentity = False
     , buildMenuOpen = []
     , favicon = defaultFavicon
+    , pipeline = defaultPipeline
+    , templates = defaultPipelineTemplates
 
+    -- todo: these need to be refactored with Msg
     -- , schedulesModel = initSchedulesModel
     -- , secretsModel = initSecretsModel
     -- , deploymentModel = initDeploymentsModel
-    , pipeline = defaultPipeline
-    , templates = defaultPipelineTemplates
     }

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -1,0 +1,77 @@
+module Shared exposing (..)
+
+import Alerts exposing (..)
+import Auth.Session exposing (..)
+import Browser.Dom exposing (..)
+import Browser.Events exposing (Visibility(..))
+import Dict exposing (..)
+import Pages exposing (..)
+import RemoteData exposing (..)
+import Shared.Model
+import Time exposing (..)
+import Toasty as Alerting
+import Url exposing (..)
+import Util exposing (..)
+import Vela exposing (..)
+
+-- INIT
+
+
+type alias Model =
+    Shared.Model.Model
+
+
+--init : Result Json.Decode.Error Flags -> Route () -> ( Model, Effect Msg )
+--init flagsResult route =
+--    ( {}
+--    , Effect.none
+--    )
+
+type alias Flags =
+    { isDev : Bool
+    , velaAPI : String
+    , velaFeedbackURL : String
+    , velaDocsURL : String
+    , velaTheme : String
+    , velaRedirect : String
+    , velaLogBytesLimit : Int
+    , velaMaxBuildLimit : Int
+    , velaScheduleAllowlist : String
+    }
+
+
+
+init : Flags -> Url -> Model
+init flags url =
+    { session = Unauthenticated
+    , fetchingToken = String.length flags.velaRedirect == 0
+    , user = NotAsked
+    , sourceRepos = NotAsked
+    , velaAPI = flags.velaAPI
+    , velaFeedbackURL = flags.velaFeedbackURL
+    , velaDocsURL = flags.velaDocsURL
+    , velaRedirect = flags.velaRedirect
+    , velaLogBytesLimit = flags.velaLogBytesLimit
+    , velaMaxBuildLimit = flags.velaMaxBuildLimit
+    , velaScheduleAllowlist = Util.stringToAllowlist flags.velaScheduleAllowlist
+    , toasties = Alerting.initialState
+    , zone = utc
+    , time = millisToPosix 0
+    , filters = Dict.empty
+    , favoritesFilter = ""
+    , repo = defaultRepoModel
+    , entryURL = url
+    , theme = stringToTheme flags.velaTheme
+    , shift = False
+    , visibility = Visible
+    , showHelp = False
+    , showIdentity = False
+    , buildMenuOpen = []
+    , favicon = defaultFavicon
+
+    -- , schedulesModel = initSchedulesModel
+    -- , secretsModel = initSecretsModel
+    -- , deploymentModel = initDeploymentsModel
+    , pipeline = defaultPipeline
+    , templates = defaultPipelineTemplates
+    }

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -23,14 +23,6 @@ type alias Model =
     Shared.Model.Model
 
 
-
---init : Result Json.Decode.Error Flags -> Route () -> ( Model, Effect Msg )
---init flagsResult route =
---    ( {}
---    , Effect.none
---    )
-
-
 type alias Flags =
     { isDev : Bool
     , velaAPI : String

--- a/src/elm/Shared/Model.elm
+++ b/src/elm/Shared/Model.elm
@@ -3,8 +3,6 @@ module Shared.Model exposing (..)
 import Alerts exposing (Alert)
 import Auth.Session exposing (Session(..))
 import Browser.Events exposing (Visibility(..))
-import Browser.Navigation as Navigation
-import Pages exposing (Page)
 import RemoteData exposing (RemoteData(..), WebData)
 import Time
     exposing
@@ -53,11 +51,12 @@ type alias Model =
     , showHelp : Bool
     , showIdentity : Bool
     , favicon : Favicon
-
-    -- , schedulesModel : Pages.Schedules.Model.Model Msg
-    -- , secretsModel : Pages.Secrets.Model.Model Msg
-    -- , deploymentModel : Pages.Deployments.Model.Model Msg
     , pipeline : PipelineModel
     , templates : PipelineTemplates
     , buildMenuOpen : List Int
+
+    -- todo: these need to be refactored with Msg
+    -- , schedulesModel : Pages.Schedules.Model.Model Msg
+    -- , secretsModel : Pages.Secrets.Model.Model Msg
+    -- , deploymentModel : Pages.Deployments.Model.Model Msg
     }

--- a/src/elm/Shared/Model.elm
+++ b/src/elm/Shared/Model.elm
@@ -11,6 +11,7 @@ import Time
         ( Posix
         , Zone
         )
+import Toasty exposing (Stack)
 import Url exposing (Url)
 import Vela
     exposing
@@ -25,7 +26,7 @@ import Vela
         , SourceRepositories
         , Theme(..)
         )
-import Toasty exposing (Stack)
+
 
 type alias Model =
     { session : Session
@@ -52,6 +53,7 @@ type alias Model =
     , showHelp : Bool
     , showIdentity : Bool
     , favicon : Favicon
+
     -- , schedulesModel : Pages.Schedules.Model.Model Msg
     -- , secretsModel : Pages.Secrets.Model.Model Msg
     -- , deploymentModel : Pages.Deployments.Model.Model Msg

--- a/src/elm/Shared/Model.elm
+++ b/src/elm/Shared/Model.elm
@@ -1,4 +1,4 @@
-module Shared.Model exposing (..)
+module Shared.Model exposing (Model)
 
 import Alerts exposing (Alert)
 import Auth.Session exposing (Session(..))

--- a/src/elm/Shared/Model.elm
+++ b/src/elm/Shared/Model.elm
@@ -26,6 +26,10 @@ import Vela
         )
 
 
+
+-- todo: comments
+
+
 type alias Model =
     { session : Session
     , fetchingToken : Bool

--- a/src/elm/Shared/Model.elm
+++ b/src/elm/Shared/Model.elm
@@ -1,0 +1,61 @@
+module Shared.Model exposing (..)
+
+import Alerts exposing (Alert)
+import Auth.Session exposing (Session(..))
+import Browser.Events exposing (Visibility(..))
+import Browser.Navigation as Navigation
+import Pages exposing (Page)
+import RemoteData exposing (RemoteData(..), WebData)
+import Time
+    exposing
+        ( Posix
+        , Zone
+        )
+import Url exposing (Url)
+import Vela
+    exposing
+        ( CurrentUser
+        , Favicon
+        , Org
+        , PipelineModel
+        , PipelineTemplates
+        , Repo
+        , RepoModel
+        , RepoSearchFilters
+        , SourceRepositories
+        , Theme(..)
+        )
+import Toasty exposing (Stack)
+
+type alias Model =
+    { session : Session
+    , fetchingToken : Bool
+    , user : WebData CurrentUser
+    , toasties : Stack Alert
+    , sourceRepos : WebData SourceRepositories
+    , repo : RepoModel
+    , velaAPI : String
+    , velaFeedbackURL : String
+    , velaDocsURL : String
+    , velaRedirect : String
+    , velaLogBytesLimit : Int
+    , velaMaxBuildLimit : Int
+    , velaScheduleAllowlist : List ( Org, Repo )
+    , zone : Zone
+    , time : Posix
+    , filters : RepoSearchFilters
+    , favoritesFilter : String
+    , entryURL : Url
+    , theme : Theme
+    , shift : Bool
+    , visibility : Visibility
+    , showHelp : Bool
+    , showIdentity : Bool
+    , favicon : Favicon
+    -- , schedulesModel : Pages.Schedules.Model.Model Msg
+    -- , secretsModel : Pages.Secrets.Model.Model Msg
+    -- , deploymentModel : Pages.Deployments.Model.Model Msg
+    , pipeline : PipelineModel
+    , templates : PipelineTemplates
+    , buildMenuOpen : List Int
+    }


### PR DESCRIPTION
refactoring the code to follow established patterns better, inspired by [elm-land](https://elm.land/concepts/) and [NextJS](https://nextjs.org/)

the main idea is to build the app around the core components
- **Shared**
- View
- Components
- Pages
- Auth (later)
- Layouts (later)

this pull request focuses on the **Shared** module, which mainly refactors `Model` and `Msg` which will open us up to making `Main.elm` smaller and more consumable. 

yes, we gained lines in Main.elm, but i promise we will make it smaller once we have everything using Shared, and we can remove Msg also.
