### PR TITLE
feat(deployments): updating ui to show new changes to database

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -3894,6 +3894,9 @@ loadRepoSubPage model org repo toPage =
                     Pages.RepoSettings o r ->
                         ( model, getRepo model o r )
 
+                    Pages.RepositoryDeployments o r maybePage maybePerPage ->
+                        ( model, getDeployments model o r maybePage maybePerPage )
+
                     Pages.PromoteDeployment o r deploymentNumber ->
                         ( model, getDeployment model o r deploymentNumber )
 

--- a/src/elm/Pages/Deployments/View.elm
+++ b/src/elm/Pages/Deployments/View.elm
@@ -275,6 +275,7 @@ redeployLink org repo deployment =
         [ text "Redeploy"
         ]
 
+
 {-| pullBuildLinks : takes deployment and creates a list of links to every build in the builds field
 -}
 pullBuildLinks : Deployment -> List String
@@ -293,7 +294,7 @@ linksView : List String -> Html msg
 linksView links =
     links
         |> List.map (\link -> a [ href link ] [ text (String.append "#" (getHead (List.head (List.reverse (String.split "/" link))))) ])
-        |> List.intersperse ( text ", " )
+        |> List.intersperse (text ", ")
         |> div []
 
 
@@ -304,6 +305,6 @@ getHead link =
     case link of
         Nothing ->
             ""
-        
+
         Just val ->
             val

--- a/src/elm/Pages/Deployments/View.elm
+++ b/src/elm/Pages/Deployments/View.elm
@@ -275,6 +275,7 @@ redeployLink org repo deployment =
         [ text "Redeploy"
         ]
 
+
 {-| pullBuildLinks : takes deployment and creates a list of links to every build in the builds field
 -}
 pullBuildLinks : Deployment -> List String
@@ -284,7 +285,7 @@ pullBuildLinks deployment =
             []
 
         Just builds ->
-           (List.map .link builds)
+            List.map .link builds
 
 
 {-| linksView : takes list of links and creates an HTML msg that displays as a list of links
@@ -292,15 +293,19 @@ pullBuildLinks deployment =
 linksView : List String -> Html msg
 linksView links =
     links
-        |> List.map (\link -> a 
-                        [ href link ] 
-                        [ text (link
-                                    |> String.split "/"
-                                    |> List.reverse
-                                    |> List.head
-                                    |> Maybe.withDefault ""
-                                    |> String.append "#" )
-                        ]
-                    )
+        |> List.map
+            (\link ->
+                a
+                    [ href link ]
+                    [ text
+                        (link
+                            |> String.split "/"
+                            |> List.reverse
+                            |> List.head
+                            |> Maybe.withDefault ""
+                            |> String.append "#"
+                        )
+                    ]
+            )
         |> List.intersperse (text ", ")
         |> div []

--- a/src/elm/Pages/Deployments/View.elm
+++ b/src/elm/Pages/Deployments/View.elm
@@ -275,7 +275,6 @@ redeployLink org repo deployment =
         [ text "Redeploy"
         ]
 
-
 {-| pullBuildLinks : takes deployment and creates a list of links to every build in the builds field
 -}
 pullBuildLinks : Deployment -> List String
@@ -285,7 +284,7 @@ pullBuildLinks deployment =
             []
 
         Just builds ->
-            List.map (String.dropRight 1) (List.map (String.dropLeft 1) (List.map Debug.toString (List.map .link builds)))
+           (List.map .link builds)
 
 
 {-| linksView : takes list of links and creates an HTML msg that displays as a list of links
@@ -293,18 +292,15 @@ pullBuildLinks deployment =
 linksView : List String -> Html msg
 linksView links =
     links
-        |> List.map (\link -> a [ href link ] [ text (String.append "#" (getHead (List.head (List.reverse (String.split "/" link))))) ])
+        |> List.map (\link -> a 
+                        [ href link ] 
+                        [ text (link
+                                    |> String.split "/"
+                                    |> List.reverse
+                                    |> List.head
+                                    |> Maybe.withDefault ""
+                                    |> String.append "#" )
+                        ]
+                    )
         |> List.intersperse (text ", ")
         |> div []
-
-
-{-| getHead : takes Maybe String and returns either Nothing or the value to help with the linksView function
--}
-getHead : Maybe String -> String
-getHead link =
-    case link of
-        Nothing ->
-            ""
-
-        Just val ->
-            val

--- a/src/elm/Pages/Deployments/View.elm
+++ b/src/elm/Pages/Deployments/View.elm
@@ -171,12 +171,14 @@ deploymentsToRows repo_ deployments =
 tableHeaders : Table.Columns
 tableHeaders =
     [ ( Just "-icon", "" )
+    , ( Nothing, "id" )
     , ( Nothing, "number" )
     , ( Nothing, "target" )
     , ( Nothing, "commit" )
     , ( Nothing, "ref" )
     , ( Nothing, "description" )
-    , ( Nothing, "user" )
+    , ( Nothing, "builds" )
+    , ( Nothing, "created by" )
     , ( Nothing, "" )
     ]
 
@@ -200,6 +202,13 @@ renderDeployment repo_ deployment =
             , Util.testAttribute <| "deployments-row-id"
             ]
             [ text <| String.fromInt deployment.id ]
+        , td
+            [ attribute "data-label" "number"
+            , scope "row"
+            , class "break-word"
+            , Util.testAttribute <| "deployments-row-number"
+            ]
+            [ text <| String.fromInt deployment.number ]
         , td
             [ attribute "data-label" "target"
             , scope "row"
@@ -232,11 +241,18 @@ renderDeployment repo_ deployment =
             ]
             [ text deployment.description ]
         , td
-            [ attribute "data-label" "user"
+            [ attribute "data-label" "builds"
+            , scope "row"
+            , class "break-word"
+            , class "build"
+            ]
+            [ linksView (pullBuildLinks deployment) ]
+        , td
+            [ attribute "data-label" "created by"
             , scope "row"
             , class "break-word"
             ]
-            [ text deployment.user ]
+            [ text deployment.created_by ]
         , td
             [ attribute "data-label" ""
             , scope "row"
@@ -258,3 +274,36 @@ redeployLink org repo deployment =
         ]
         [ text "Redeploy"
         ]
+
+{-| pullBuildLinks : takes deployment and creates a list of links to every build in the builds field
+-}
+pullBuildLinks : Deployment -> List String
+pullBuildLinks deployment =
+    case deployment.builds of
+        Nothing ->
+            []
+
+        Just builds ->
+            List.map (String.dropRight 1) (List.map (String.dropLeft 1) (List.map Debug.toString (List.map .link builds)))
+
+
+{-| linksView : takes list of links and creates an HTML msg that displays as a list of links
+-}
+linksView : List String -> Html msg
+linksView links =
+    links
+        |> List.map (\link -> a [ href link ] [ text (String.append "#" (getHead (List.head (List.reverse (String.split "/" link))))) ])
+        |> List.intersperse ( text ", " )
+        |> div []
+
+
+{-| getHead : takes Maybe String and returns either Nothing or the value to help with the linksView function
+-}
+getHead : Maybe String -> String
+getHead link =
+    case link of
+        Nothing ->
+            ""
+        
+        Just val ->
+            val

--- a/src/elm/Pages/Schedules/Form.elm
+++ b/src/elm/Pages/Schedules/Form.elm
@@ -300,4 +300,4 @@ viewCancelButton schedulesModel =
 -}
 schedulesDocsURL : String
 schedulesDocsURL =
-    "https://go-vela.github.io/docs/usage/schedules/"
+    "https://go-vela.github.io/docs/usage/schedule_build/"

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -2340,7 +2340,7 @@ decodeDeploymentParameters =
     Decode.map decodeKeyValuePairs <| Decode.keyValuePairs Decode.string
 
 
-decodeDeployPairs : List ( Build ) -> Maybe (List Build)
+decodeDeployPairs : List Build -> Maybe (List Build)
 decodeDeployPairs o =
     if List.isEmpty o then
         Nothing

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -905,15 +905,17 @@ type alias KeyValuePair =
 
 type alias Deployment =
     { id : Int
+    , number : Int
     , repo_id : Int
     , url : String
-    , user : String
+    , created_by : String
     , commit : String
     , ref : String
     , task : String
     , target : String
     , description : String
     , payload : Maybe (List KeyValuePair)
+    , builds : Maybe (List Build)
     }
 
 
@@ -1336,6 +1338,7 @@ type alias Build =
     , started : Int
     , finished : Int
     , deploy : String
+    , deploy_number : Int
     , clone : String
     , source : String
     , title : String
@@ -1371,6 +1374,7 @@ decodeBuild =
         |> optional "started" int -1
         |> optional "finished" int -1
         |> optional "deploy" string ""
+        |> optional "deploy_number" int -1
         |> optional "clone" string ""
         |> optional "source" string ""
         |> optional "title" string ""
@@ -2280,15 +2284,17 @@ decodeDeployment : Decoder Deployment
 decodeDeployment =
     Decode.succeed Deployment
         |> optional "id" int -1
+        |> optional "number" int -1
         |> optional "repo_id" int -1
         |> optional "url" string ""
-        |> optional "user" string ""
+        |> optional "created_by" string ""
         |> optional "commit" string ""
         |> optional "ref" string ""
         |> optional "task" string ""
         |> optional "target" string ""
         |> optional "description" string ""
         |> optional "payload" decodeDeploymentParameters Nothing
+        |> optional "builds" decodeDeploymentBuilds Nothing
 
 
 decodeDeployments : Decoder (List Deployment)
@@ -2332,6 +2338,20 @@ decodeKeyValuePairs o =
 decodeDeploymentParameters : Decoder (Maybe (List KeyValuePair))
 decodeDeploymentParameters =
     Decode.map decodeKeyValuePairs <| Decode.keyValuePairs Decode.string
+
+
+decodeDeployPairs : List ( Build ) -> Maybe (List Build)
+decodeDeployPairs o =
+    if List.isEmpty o then
+        Nothing
+
+    else
+        Just o
+
+
+decodeDeploymentBuilds : Decoder (Maybe (List Build))
+decodeDeploymentBuilds =
+    Decode.map decodeDeployPairs <| Decode.list decodeBuild
 
 
 type alias DeploymentPayload =


### PR DESCRIPTION
This story is attached to this PR: [https://github.com/go-vela/server/pull/1031](https://github.com/go-vela/server/pull/1031)

In switching over from pulling in deployments information from the SCM to pulling in from our own database, a few changes were made in the ui to allow this to happen.

As well, an ID column and builds column were added to the deployments table to better help users comprehend and use deployments.