### PR TITLE
fix: removing id field and adding created at field to deployments table

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -64,7 +64,7 @@ import Html.Attributes
         , type_
         )
 import Html.Events exposing (onClick)
-import Html.Lazy exposing (lazy, lazy2, lazy3, lazy5, lazy7, lazy8)
+import Html.Lazy exposing (lazy, lazy2, lazy3, lazy4, lazy5, lazy7, lazy8)
 import Http
 import Http.Detailed
 import Interop
@@ -2974,7 +2974,7 @@ viewContent model =
         Pages.RepositoryDeployments org repo maybePage _ ->
             ( String.join "/" [ org, repo ] ++ " deployments" ++ Util.pageToString maybePage
             , div []
-                [ lazy3 Pages.Deployments.View.viewDeployments model.repo org repo
+                [ lazy4 Pages.Deployments.View.viewDeployments model.zone model.repo org repo
                 , Pager.view model.repo.deployments.pager Pager.defaultLabels GotoPage
                 ]
             )

--- a/src/elm/Pages/Deployments/View.elm
+++ b/src/elm/Pages/Deployments/View.elm
@@ -21,6 +21,7 @@ import Routes
 import Svg.Attributes
 import SvgBuilder exposing (hookSuccess)
 import Table
+import Time exposing (Zone)
 import Util exposing (largeLoader)
 import Vela exposing (Deployment, Org, Repo, RepoModel, Repository)
 
@@ -73,8 +74,8 @@ addForm deploymentModel =
 
 {-| viewDeployments : renders a list of deployments
 -}
-viewDeployments : RepoModel -> Org -> Repo -> Html msg
-viewDeployments repoModel org repo =
+viewDeployments : Zone -> RepoModel -> Org -> Repo -> Html msg
+viewDeployments zone repoModel org repo =
     let
         addButton =
             a
@@ -101,7 +102,7 @@ viewDeployments repoModel org repo =
             case ( repoModel.repo, repoModel.deployments.deployments ) of
                 ( RemoteData.Success repo_, RemoteData.Success s ) ->
                     ( text "No deployments found for this repo"
-                    , deploymentsToRows repo_ s
+                    , deploymentsToRows zone repo_ s
                     )
 
                 ( _, RemoteData.Failure error ) ->
@@ -161,9 +162,9 @@ viewDeployments repoModel org repo =
 
 {-| deploymentsToRows : takes list of deployments and produces list of Table rows
 -}
-deploymentsToRows : Repository -> List Deployment -> Table.Rows Deployment msg
-deploymentsToRows repo_ deployments =
-    List.map (\deployment -> Table.Row deployment (renderDeployment repo_)) deployments
+deploymentsToRows : Zone -> Repository -> List Deployment -> Table.Rows Deployment msg
+deploymentsToRows zone repo_ deployments =
+    List.map (\deployment -> Table.Row deployment (renderDeployment zone repo_)) deployments
 
 
 {-| tableHeaders : returns table headers for deployments table
@@ -171,7 +172,6 @@ deploymentsToRows repo_ deployments =
 tableHeaders : Table.Columns
 tableHeaders =
     [ ( Just "-icon", "" )
-    , ( Nothing, "id" )
     , ( Nothing, "number" )
     , ( Nothing, "target" )
     , ( Nothing, "commit" )
@@ -179,14 +179,15 @@ tableHeaders =
     , ( Nothing, "description" )
     , ( Nothing, "builds" )
     , ( Nothing, "created by" )
+    , ( Nothing, "created at" )
     , ( Nothing, "" )
     ]
 
 
 {-| renderDeployment : takes deployment and renders a table row
 -}
-renderDeployment : Repository -> Deployment -> Html msg
-renderDeployment repo_ deployment =
+renderDeployment : Zone -> Repository -> Deployment -> Html msg
+renderDeployment zone repo_ deployment =
     tr [ Util.testAttribute <| "deployments-row" ]
         [ td
             [ attribute "data-label" ""
@@ -195,13 +196,6 @@ renderDeployment repo_ deployment =
             , class "-icon"
             ]
             [ hookSuccess ]
-        , td
-            [ attribute "data-label" "id"
-            , scope "row"
-            , class "break-word"
-            , Util.testAttribute <| "deployments-row-id"
-            ]
-            [ text <| String.fromInt deployment.id ]
         , td
             [ attribute "data-label" "number"
             , scope "row"
@@ -253,6 +247,12 @@ renderDeployment repo_ deployment =
             , class "break-word"
             ]
             [ text deployment.created_by ]
+        , td
+            [ attribute "data-label" "created at"
+            , scope "row"
+            , class "break-word"
+            ]
+            [ text <| Util.humanReadableDateTimeWithDefault zone deployment.created_at ]
         , td
             [ attribute "data-label" ""
             , scope "row"

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -911,6 +911,7 @@ type alias Deployment =
     , repo_id : Int
     , url : String
     , created_by : String
+    , created_at : Int
     , commit : String
     , ref : String
     , task : String
@@ -2543,6 +2544,7 @@ decodeDeployment =
         |> optional "repo_id" int -1
         |> optional "url" string ""
         |> optional "created_by" string ""
+        |> optional "created_at" int 0
         |> optional "commit" string ""
         |> optional "ref" string ""
         |> optional "task" string ""


### PR DESCRIPTION
Removing the ID field because it doesn't really provide any useful data.
Adding the Created At field so that users can see when deployments were created.

Going from:
<img width="1668" alt="Screenshot 2024-01-24 at 10 19 19 AM" src="https://github.com/go-vela/ui/assets/55173466/3b4bf7e0-8bf6-46f8-98f1-1f9d0a344aa4">

to: 
<img width="1642" alt="Screenshot 2024-01-24 at 10 18 09 AM" src="https://github.com/go-vela/ui/assets/55173466/46f01087-6056-4a02-ad30-941b3741d492">
