### PR TITLE
fix(tabs): remove red alert from audit on skipped hooks

### DIFF
--- a/src/elm/Nav.elm
+++ b/src/elm/Nav.elm
@@ -443,6 +443,9 @@ viewRepoTabs rm org repo currentPage scheduleAllowlist =
                         "success" ->
                             False
 
+                        "skipped" ->
+                            False
+
                         _ ->
                             hook.created > build.created
 


### PR DESCRIPTION
Trying to make less red appear on the page when it's business as usual. Would be open to maybe a white dot as an alert? 