### PR TITLE
fix(deployments): remove unnecessary class

### DIFF
--- a/src/elm/Pages/Deployments/View.elm
+++ b/src/elm/Pages/Deployments/View.elm
@@ -238,7 +238,6 @@ renderDeployment zone repo_ deployment =
             [ attribute "data-label" "builds"
             , scope "row"
             , class "break-word"
-            , class "build"
             ]
             [ linksView (pullBuildLinks deployment) ]
         , td


### PR DESCRIPTION
fixes a styling issue in light mode on the deployments page (see erroneous white lines).

before
![before](https://github.com/go-vela/ui/assets/1301201/ab9803f7-c951-4b9a-95e4-01e12edaa1af)

after
![after](https://github.com/go-vela/ui/assets/1301201/ba3f630a-259d-44f7-bd3a-954c476f65ab)

also tested when the column was populated with builds, fwiw
