### PR TITLE
chore: use more elm-land generated patterns

### DIFF
--- a/src/elm/Main/Pages/Model.elm
+++ b/src/elm/Main/Pages/Model.elm
@@ -5,7 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 module Main.Pages.Model exposing (Model(..))
 
+import Pages.Account.Authenticate
 import Pages.Account.Login
+import Pages.Account.Logout
 import Pages.Account.Settings
 import Pages.Account.SourceRepos
 import Pages.Dash.Secrets.Engine_.Org.Org_
@@ -29,16 +31,20 @@ import Pages.Org_.Repo_.Build_.Services
 import Pages.Org_.Repo_.Deployments
 import Pages.Org_.Repo_.Deployments.Add
 import Pages.Org_.Repo_.Hooks
+import Pages.Org_.Repo_.Pulls
 import Pages.Org_.Repo_.Schedules
 import Pages.Org_.Repo_.Schedules.Add
 import Pages.Org_.Repo_.Schedules.Name_
 import Pages.Org_.Repo_.Settings
+import Pages.Org_.Repo_.Tags
 import View exposing (View)
 
 
 type Model
     = Home_ Pages.Home_.Model
+    | Account_Authenticate Pages.Account.Authenticate.Model
     | Account_Login Pages.Account.Login.Model
+    | Account_Logout Pages.Account.Logout.Model
     | Account_Settings Pages.Account.Settings.Model
     | Account_SourceRepos Pages.Account.SourceRepos.Model
     | Dash_Secrets_Engine__Org_Org_ { engine : String, org : String } Pages.Dash.Secrets.Engine_.Org.Org_.Model
@@ -56,10 +62,12 @@ type Model
     | Org__Repo__Deployments { org : String, repo : String } Pages.Org_.Repo_.Deployments.Model
     | Org__Repo__Deployments_Add { org : String, repo : String } Pages.Org_.Repo_.Deployments.Add.Model
     | Org__Repo__Hooks { org : String, repo : String } Pages.Org_.Repo_.Hooks.Model
+    | Org__Repo__Pulls { org : String, repo : String } Pages.Org_.Repo_.Pulls.Model
     | Org__Repo__Schedules { org : String, repo : String } Pages.Org_.Repo_.Schedules.Model
     | Org__Repo__Schedules_Add { org : String, repo : String } Pages.Org_.Repo_.Schedules.Add.Model
     | Org__Repo__Schedules_Name_ { org : String, repo : String, name : String } Pages.Org_.Repo_.Schedules.Name_.Model
     | Org__Repo__Settings { org : String, repo : String } Pages.Org_.Repo_.Settings.Model
+    | Org__Repo__Tags { org : String, repo : String } Pages.Org_.Repo_.Tags.Model
     | Org__Repo__Build_ { org : String, repo : String, build : String } Pages.Org_.Repo_.Build_.Model
     | Org__Repo__Build__Graph { org : String, repo : String, build : String } Pages.Org_.Repo_.Build_.Graph.Model
     | Org__Repo__Build__Pipeline { org : String, repo : String, build : String } Pages.Org_.Repo_.Build_.Pipeline.Model

--- a/src/elm/Main/Pages/Msg.elm
+++ b/src/elm/Main/Pages/Msg.elm
@@ -5,7 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 module Main.Pages.Msg exposing (Msg(..))
 
+import Pages.Account.Authenticate
 import Pages.Account.Login
+import Pages.Account.Logout
 import Pages.Account.Settings
 import Pages.Account.SourceRepos
 import Pages.Dash.Secrets.Engine_.Org.Org_
@@ -29,15 +31,19 @@ import Pages.Org_.Repo_.Build_.Services
 import Pages.Org_.Repo_.Deployments
 import Pages.Org_.Repo_.Deployments.Add
 import Pages.Org_.Repo_.Hooks
+import Pages.Org_.Repo_.Pulls
 import Pages.Org_.Repo_.Schedules
 import Pages.Org_.Repo_.Schedules.Add
 import Pages.Org_.Repo_.Schedules.Name_
 import Pages.Org_.Repo_.Settings
+import Pages.Org_.Repo_.Tags
 
 
 type Msg
     = Home_ Pages.Home_.Msg
+    | Account_Authenticate Pages.Account.Authenticate.Msg
     | Account_Login Pages.Account.Login.Msg
+    | Account_Logout Pages.Account.Logout.Msg
     | Account_Settings Pages.Account.Settings.Msg
     | Account_SourceRepos Pages.Account.SourceRepos.Msg
     | Dash_Secrets_Engine__Org_Org_ Pages.Dash.Secrets.Engine_.Org.Org_.Msg
@@ -55,10 +61,12 @@ type Msg
     | Org__Repo__Deployments Pages.Org_.Repo_.Deployments.Msg
     | Org__Repo__Deployments_Add Pages.Org_.Repo_.Deployments.Add.Msg
     | Org__Repo__Hooks Pages.Org_.Repo_.Hooks.Msg
+    | Org__Repo__Pulls Pages.Org_.Repo_.Pulls.Msg
     | Org__Repo__Schedules Pages.Org_.Repo_.Schedules.Msg
     | Org__Repo__Schedules_Add Pages.Org_.Repo_.Schedules.Add.Msg
     | Org__Repo__Schedules_Name_ Pages.Org_.Repo_.Schedules.Name_.Msg
     | Org__Repo__Settings Pages.Org_.Repo_.Settings.Msg
+    | Org__Repo__Tags Pages.Org_.Repo_.Tags.Msg
     | Org__Repo__Build_ Pages.Org_.Repo_.Build_.Msg
     | Org__Repo__Build__Graph Pages.Org_.Repo_.Build_.Graph.Msg
     | Org__Repo__Build__Pipeline Pages.Org_.Repo_.Build_.Pipeline.Msg

--- a/src/elm/Pages/Account/Authenticate.elm
+++ b/src/elm/Pages/Account/Authenticate.elm
@@ -1,0 +1,73 @@
+{--
+SPDX-License-Identifier: Apache-2.0
+--}
+
+
+module Pages.Account.Authenticate exposing (Model, Msg, page)
+
+import Effect exposing (Effect)
+import Html
+import Page exposing (Page)
+import Route exposing (Route)
+import Shared
+import View exposing (View)
+
+
+page : Shared.Model -> Route () -> Page Model Msg
+page shared route =
+    Page.new
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        }
+
+
+
+-- INIT
+
+
+type alias Model =
+    {}
+
+
+init : () -> ( Model, Effect Msg )
+init () =
+    ( {}
+    , Effect.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = NoOp
+
+
+update : Msg -> Model -> ( Model, Effect Msg )
+update msg model =
+    case msg of
+        NoOp ->
+            ( model
+            , Effect.none
+            )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+
+
+-- VIEW
+
+
+view : Model -> View Msg
+view model =
+    View.none

--- a/src/elm/Pages/Account/Logout.elm
+++ b/src/elm/Pages/Account/Logout.elm
@@ -1,0 +1,73 @@
+{--
+SPDX-License-Identifier: Apache-2.0
+--}
+
+
+module Pages.Account.Logout exposing (Model, Msg, page)
+
+import Effect exposing (Effect)
+import Html
+import Page exposing (Page)
+import Route exposing (Route)
+import Shared
+import View exposing (View)
+
+
+page : Shared.Model -> Route () -> Page Model Msg
+page shared route =
+    Page.new
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        }
+
+
+
+-- INIT
+
+
+type alias Model =
+    {}
+
+
+init : () -> ( Model, Effect Msg )
+init () =
+    ( {}
+    , Effect.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = NoOp
+
+
+update : Msg -> Model -> ( Model, Effect Msg )
+update msg model =
+    case msg of
+        NoOp ->
+            ( model
+            , Effect.none
+            )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+
+
+-- VIEW
+
+
+view : Model -> View Msg
+view model =
+    View.none

--- a/src/elm/Pages/Org_/Repo_/Pulls.elm
+++ b/src/elm/Pages/Org_/Repo_/Pulls.elm
@@ -1,0 +1,75 @@
+{--
+SPDX-License-Identifier: Apache-2.0
+--}
+
+
+module Pages.Org_.Repo_.Pulls exposing (Model, Msg, page)
+
+import Effect exposing (Effect)
+import Html
+import Page exposing (Page)
+import Route exposing (Route)
+import Shared
+import View exposing (View)
+
+
+page : Shared.Model -> Route { org : String, repo : String } -> Page Model Msg
+page shared route =
+    Page.new
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        }
+
+
+
+-- INIT
+
+
+type alias Model =
+    {}
+
+
+init : () -> ( Model, Effect Msg )
+init () =
+    ( {}
+    , Effect.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = NoOp
+
+
+update : Msg -> Model -> ( Model, Effect Msg )
+update msg model =
+    case msg of
+        NoOp ->
+            ( model
+            , Effect.none
+            )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+
+
+-- VIEW
+
+
+view : Model -> View Msg
+view model =
+    { title = "Pages.Org_.Repo_.Pulls"
+    , body = [ Html.text "/:org/:repo/pulls" ]
+    }

--- a/src/elm/Pages/Org_/Repo_/Pulls.elm
+++ b/src/elm/Pages/Org_/Repo_/Pulls.elm
@@ -70,6 +70,4 @@ subscriptions model =
 
 view : Model -> View Msg
 view model =
-    { title = "Pages.Org_.Repo_.Pulls"
-    , body = [ Html.text "/:org/:repo/pulls" ]
-    }
+    View.none

--- a/src/elm/Pages/Org_/Repo_/Tags.elm
+++ b/src/elm/Pages/Org_/Repo_/Tags.elm
@@ -70,6 +70,4 @@ subscriptions model =
 
 view : Model -> View Msg
 view model =
-    { title = "Pages.Org_.Repo_.Tags"
-    , body = [ Html.text "/:org/:repo/tags" ]
-    }
+    View.none

--- a/src/elm/Pages/Org_/Repo_/Tags.elm
+++ b/src/elm/Pages/Org_/Repo_/Tags.elm
@@ -1,0 +1,75 @@
+{--
+SPDX-License-Identifier: Apache-2.0
+--}
+
+
+module Pages.Org_.Repo_.Tags exposing (Model, Msg, page)
+
+import Effect exposing (Effect)
+import Html
+import Page exposing (Page)
+import Route exposing (Route)
+import Shared
+import View exposing (View)
+
+
+page : Shared.Model -> Route { org : String, repo : String } -> Page Model Msg
+page shared route =
+    Page.new
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        }
+
+
+
+-- INIT
+
+
+type alias Model =
+    {}
+
+
+init : () -> ( Model, Effect Msg )
+init () =
+    ( {}
+    , Effect.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = NoOp
+
+
+update : Msg -> Model -> ( Model, Effect Msg )
+update msg model =
+    case msg of
+        NoOp ->
+            ( model
+            , Effect.none
+            )
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+
+
+-- VIEW
+
+
+view : Model -> View Msg
+view model =
+    { title = "Pages.Org_.Repo_.Tags"
+    , body = [ Html.text "/:org/:repo/tags" ]
+    }

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0
 --}
 
 
-module Route exposing (Route, fromUrl, href, parsePath, strip, toString)
+module Route exposing (Route, fromUrl, href, toString)
 
 import Dict exposing (Dict)
 import Html
@@ -47,38 +47,3 @@ toString route =
             |> Maybe.map (String.append "#")
             |> Maybe.withDefault ""
         ]
-
-
-strip : Route params -> { path : Route.Path.Path, query : Dict String String, hash : Maybe String }
-strip route =
-    { path = route.path
-    , query = route.query
-    , hash = route.hash
-    }
-
-
-parsePath :
-    String
-    ->
-        { path : String
-        , query : Maybe String
-        , hash : Maybe String
-        }
-parsePath urlString =
-    let
-        pathsAndHash =
-            String.split "#" urlString
-
-        maybeHash =
-            List.head <| List.drop 1 pathsAndHash
-
-        pathsAndQuery =
-            String.split "?" <| Maybe.withDefault "" <| List.head pathsAndHash
-
-        pathSegments =
-            String.split "/" <| Maybe.withDefault "" <| List.head pathsAndQuery
-
-        maybeQuery =
-            List.head <| List.drop 1 pathsAndQuery
-    in
-    { path = String.join "/" pathSegments, query = maybeQuery, hash = maybeHash }

--- a/src/elm/Route/Path.elm
+++ b/src/elm/Route/Path.elm
@@ -80,190 +80,176 @@ fromString urlPath =
         "account" :: "source-repos" :: [] ->
             Just Account_SourceRepos
 
-        "-" :: "secrets" :: engine :: "org" :: org :: [] ->
+        "-" :: "secrets" :: engine_ :: "org" :: org_ :: [] ->
             Dash_Secrets_Engine__Org_Org_
-                { org = org
-                , engine = engine
+                { engine = engine_
+                , org = org_
                 }
                 |> Just
 
-        "-" :: "secrets" :: engine :: "org" :: org :: "add" :: [] ->
+        "-" :: "secrets" :: engine_ :: "org" :: org_ :: "add" :: [] ->
             Dash_Secrets_Engine__Org_Org__Add
-                { org = org
-                , engine = engine
+                { engine = engine_
+                , org = org_
                 }
                 |> Just
 
-        "-" :: "secrets" :: engine :: "org" :: org :: name :: [] ->
+        "-" :: "secrets" :: engine_ :: "org" :: org_ :: name_ :: [] ->
             Dash_Secrets_Engine__Org_Org__Name_
-                { org = org
-                , name = name
-                , engine = engine
+                { engine = engine_
+                , org = org_
+                , name = name_
                 }
                 |> Just
 
-        "-" :: "secrets" :: engine :: "repo" :: org :: repo :: [] ->
+        "-" :: "secrets" :: engine_ :: "repo" :: org_ :: repo_ :: [] ->
             Dash_Secrets_Engine__Repo_Org__Repo_
-                { org = org
-                , repo = repo
-                , engine = engine
+                { engine = engine_
+                , org = org_
+                , repo = repo_
                 }
                 |> Just
 
-        "-" :: "secrets" :: engine :: "repo" :: org :: repo :: "add" :: [] ->
+        "-" :: "secrets" :: engine_ :: "repo" :: org_ :: repo_ :: "add" :: [] ->
             Dash_Secrets_Engine__Repo_Org__Repo__Add
-                { org = org
-                , repo = repo
-                , engine = engine
+                { engine = engine_
+                , org = org_
+                , repo = repo_
                 }
                 |> Just
 
-        "-" :: "secrets" :: engine :: "repo" :: org :: repo :: name :: [] ->
+        "-" :: "secrets" :: engine_ :: "repo" :: org_ :: repo_ :: name_ :: [] ->
             Dash_Secrets_Engine__Repo_Org__Repo__Name_
-                { org = org
-                , repo = repo
-                , name = name
-                , engine = engine
+                { engine = engine_
+                , org = org_
+                , repo = repo_
+                , name = name_
                 }
                 |> Just
 
-        "-" :: "secrets" :: engine :: "shared" :: org :: team :: [] ->
+        "-" :: "secrets" :: engine_ :: "shared" :: org_ :: team_ :: [] ->
             Dash_Secrets_Engine__Shared_Org__Team_
-                { org = org
-                , team = team
-                , engine = engine
+                { engine = engine_
+                , org = org_
+                , team = team_
                 }
                 |> Just
 
-        "-" :: "secrets" :: engine :: "shared" :: org :: team :: "add" :: [] ->
+        "-" :: "secrets" :: engine_ :: "shared" :: org_ :: team_ :: "add" :: [] ->
             Dash_Secrets_Engine__Shared_Org__Team__Add
-                { org = org
-                , team = team
-                , engine = engine
+                { engine = engine_
+                , org = org_
+                , team = team_
                 }
                 |> Just
 
-        "-" :: "secrets" :: engine :: "shared" :: org :: team :: name :: [] ->
+        "-" :: "secrets" :: engine_ :: "shared" :: org_ :: team_ :: name_ :: [] ->
             Dash_Secrets_Engine__Shared_Org__Team__Name_
-                { org = org
-                , team = team
-                , name = name
-                , engine = engine
+                { engine = engine_
+                , org = org_
+                , team = team_
+                , name = name_
                 }
                 |> Just
 
-        org :: [] ->
+        org_ :: [] ->
             Org_
-                { org = org
+                { org = org_
                 }
                 |> Just
 
-        org :: "builds" :: [] ->
+        org_ :: "builds" :: [] ->
             Org__Builds
-                { org = org
+                { org = org_
                 }
                 |> Just
 
-        org :: repo :: [] ->
+        org_ :: repo_ :: [] ->
             Org__Repo_
-                { org = org
-                , repo = repo
+                { org = org_
+                , repo = repo_
                 }
                 |> Just
 
-        org :: repo :: "deployments" :: "add" :: [] ->
-            Org__Repo__Deployments_Add
-                { org = org
-                , repo = repo
-                }
-                |> Just
-
-        org :: repo :: "deployments" :: [] ->
+        org_ :: repo_ :: "deployments" :: [] ->
             Org__Repo__Deployments
-                { org = org
-                , repo = repo
+                { org = org_
+                , repo = repo_
                 }
                 |> Just
 
-        org :: repo :: "schedules" :: [] ->
-            Org__Repo__Schedules
-                { org = org
-                , repo = repo
+        org_ :: repo_ :: "deployments" :: "add" :: [] ->
+            Org__Repo__Deployments_Add
+                { org = org_
+                , repo = repo_
                 }
                 |> Just
 
-        org :: repo :: "schedules" :: "add" :: [] ->
-            Org__Repo__Schedules_Add
-                { org = org
-                , repo = repo
-                }
-                |> Just
-
-        org :: repo :: "schedules" :: name :: [] ->
-            Org__Repo__Schedules_Name_
-                { org = org
-                , repo = repo
-                , name = name
-                }
-                |> Just
-
-        org :: repo :: "hooks" :: [] ->
+        org_ :: repo_ :: "hooks" :: [] ->
             Org__Repo__Hooks
-                { org = org
-                , repo = repo
+                { org = org_
+                , repo = repo_
                 }
                 |> Just
 
-        org :: repo :: "settings" :: [] ->
+        org_ :: repo_ :: "schedules" :: [] ->
+            Org__Repo__Schedules
+                { org = org_
+                , repo = repo_
+                }
+                |> Just
+
+        org_ :: repo_ :: "schedules" :: "add" :: [] ->
+            Org__Repo__Schedules_Add
+                { org = org_
+                , repo = repo_
+                }
+                |> Just
+
+        org_ :: repo_ :: "schedules" :: name_ :: [] ->
+            Org__Repo__Schedules_Name_
+                { org = org_
+                , repo = repo_
+                , name = name_
+                }
+                |> Just
+
+        org_ :: repo_ :: "settings" :: [] ->
             Org__Repo__Settings
-                { org = org
-                , repo = repo
+                { org = org_
+                , repo = repo_
                 }
                 |> Just
 
-        org :: repo :: "pulls" :: [] ->
-            Org__Repo__Pulls
-                { org = org
-                , repo = repo
-                }
-                |> Just
-
-        org :: repo :: "tags" :: [] ->
-            Org__Repo__Tags
-                { org = org
-                , repo = repo
-                }
-                |> Just
-
-        org :: repo :: build :: [] ->
+        org_ :: repo_ :: build_ :: [] ->
             Org__Repo__Build_
-                { org = org
-                , repo = repo
-                , build = build
+                { org = org_
+                , repo = repo_
+                , build = build_
                 }
                 |> Just
 
-        org :: repo :: build :: "services" :: [] ->
-            Org__Repo__Build__Services
-                { org = org
-                , repo = repo
-                , build = build
-                }
-                |> Just
-
-        org :: repo :: build :: "pipeline" :: [] ->
-            Org__Repo__Build__Pipeline
-                { org = org
-                , repo = repo
-                , build = build
-                }
-                |> Just
-
-        org :: repo :: build :: "graph" :: [] ->
+        org_ :: repo_ :: build_ :: "graph" :: [] ->
             Org__Repo__Build__Graph
-                { org = org
-                , repo = repo
-                , build = build
+                { org = org_
+                , repo = repo_
+                , build = build_
+                }
+                |> Just
+
+        org_ :: repo_ :: build_ :: "pipeline" :: [] ->
+            Org__Repo__Build__Pipeline
+                { org = org_
+                , repo = repo_
+                , build = build_
+                }
+                |> Just
+
+        org_ :: repo_ :: build_ :: "services" :: [] ->
+            Org__Repo__Build__Services
+                { org = org_
+                , repo = repo_
+                , build = build_
                 }
                 |> Just
 
@@ -367,14 +353,14 @@ toString path =
                 Org__Repo__Build_ params ->
                     [ params.org, params.repo, params.build ]
 
-                Org__Repo__Build__Services params ->
-                    [ params.org, params.repo, params.build, "services" ]
+                Org__Repo__Build__Graph params ->
+                    [ params.org, params.repo, params.build, "graph" ]
 
                 Org__Repo__Build__Pipeline params ->
                     [ params.org, params.repo, params.build, "pipeline" ]
 
-                Org__Repo__Build__Graph params ->
-                    [ params.org, params.repo, params.build, "graph" ]
+                Org__Repo__Build__Services params ->
+                    [ params.org, params.repo, params.build, "services" ]
 
                 NotFound_ ->
                     [ "not-found" ]

--- a/src/elm/Route/Path.elm
+++ b/src/elm/Route/Path.elm
@@ -221,6 +221,20 @@ fromString urlPath =
                 }
                 |> Just
 
+        org_ :: repo_ :: "pulls" :: [] ->
+            Org__Repo__Pulls
+                { org = org_
+                , repo = repo_
+                }
+                |> Just
+
+        org_ :: repo_ :: "tags" :: [] ->
+            Org__Repo__Tags
+                { org = org_
+                , repo = repo_
+                }
+                |> Just
+
         org_ :: repo_ :: build_ :: [] ->
             Org__Repo__Build_
                 { org = org_

--- a/src/elm/Route/Path.elm
+++ b/src/elm/Route/Path.elm
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 module Route.Path exposing (Path(..), fromString, fromUrl, href, toString)
 
 import Html
-import Html.Attributes exposing (name)
+import Html.Attributes
 import Url exposing (Url)
 import Url.Parser exposing ((</>))
 
@@ -14,8 +14,8 @@ import Url.Parser exposing ((</>))
 type Path
     = Home_
     | Account_Login
-    | Account_Logout
     | Account_Authenticate
+    | Account_Logout
     | Account_Settings
     | Account_SourceRepos
     | Dash_Secrets_Engine__Org_Org_ { engine : String, org : String }
@@ -37,13 +37,13 @@ type Path
     | Org__Repo__Schedules_Add { org : String, repo : String }
     | Org__Repo__Schedules_Name_ { org : String, repo : String, name : String }
     | Org__Repo__Settings { org : String, repo : String }
+    | Org__Repo__Pulls { org : String, repo : String }
+    | Org__Repo__Tags { org : String, repo : String }
     | Org__Repo__Build_ { org : String, repo : String, build : String }
     | Org__Repo__Build__Graph { org : String, repo : String, build : String }
     | Org__Repo__Build__Pipeline { org : String, repo : String, build : String }
     | Org__Repo__Build__Services { org : String, repo : String, build : String }
     | NotFound_
-    | Org__Repo__Pulls { org : String, repo : String }
-    | Org__Repo__Tags { org : String, repo : String }
 
 
 fromUrl : Url -> Path
@@ -65,20 +65,92 @@ fromString urlPath =
         [] ->
             Just Home_
 
-        [ "account", "login" ] ->
+        "account" :: "login" :: [] ->
             Just Account_Login
 
-        [ "account", "logout" ] ->
-            Just Account_Logout
-
-        [ "account", "authenticate" ] ->
+        "account" :: "authenticate" :: [] ->
             Just Account_Authenticate
 
-        [ "account", "settings" ] ->
+        "account" :: "logout" :: [] ->
+            Just Account_Logout
+
+        "account" :: "settings" :: [] ->
             Just Account_Settings
 
-        [ "account", "source-repos" ] ->
+        "account" :: "source-repos" :: [] ->
             Just Account_SourceRepos
+
+        "-" :: "secrets" :: engine :: "org" :: org :: [] ->
+            Dash_Secrets_Engine__Org_Org_
+                { org = org
+                , engine = engine
+                }
+                |> Just
+
+        "-" :: "secrets" :: engine :: "org" :: org :: "add" :: [] ->
+            Dash_Secrets_Engine__Org_Org__Add
+                { org = org
+                , engine = engine
+                }
+                |> Just
+
+        "-" :: "secrets" :: engine :: "org" :: org :: name :: [] ->
+            Dash_Secrets_Engine__Org_Org__Name_
+                { org = org
+                , name = name
+                , engine = engine
+                }
+                |> Just
+
+        "-" :: "secrets" :: engine :: "repo" :: org :: repo :: [] ->
+            Dash_Secrets_Engine__Repo_Org__Repo_
+                { org = org
+                , repo = repo
+                , engine = engine
+                }
+                |> Just
+
+        "-" :: "secrets" :: engine :: "repo" :: org :: repo :: "add" :: [] ->
+            Dash_Secrets_Engine__Repo_Org__Repo__Add
+                { org = org
+                , repo = repo
+                , engine = engine
+                }
+                |> Just
+
+        "-" :: "secrets" :: engine :: "repo" :: org :: repo :: name :: [] ->
+            Dash_Secrets_Engine__Repo_Org__Repo__Name_
+                { org = org
+                , repo = repo
+                , name = name
+                , engine = engine
+                }
+                |> Just
+
+        "-" :: "secrets" :: engine :: "shared" :: org :: team :: [] ->
+            Dash_Secrets_Engine__Shared_Org__Team_
+                { org = org
+                , team = team
+                , engine = engine
+                }
+                |> Just
+
+        "-" :: "secrets" :: engine :: "shared" :: org :: team :: "add" :: [] ->
+            Dash_Secrets_Engine__Shared_Org__Team__Add
+                { org = org
+                , team = team
+                , engine = engine
+                }
+                |> Just
+
+        "-" :: "secrets" :: engine :: "shared" :: org :: team :: name :: [] ->
+            Dash_Secrets_Engine__Shared_Org__Team__Name_
+                { org = org
+                , team = team
+                , name = name
+                , engine = engine
+                }
+                |> Just
 
         org :: [] ->
             Org_
@@ -195,78 +267,6 @@ fromString urlPath =
                 }
                 |> Just
 
-        "-" :: "secrets" :: engine :: "org" :: org :: [] ->
-            Dash_Secrets_Engine__Org_Org_
-                { org = org
-                , engine = engine
-                }
-                |> Just
-
-        "-" :: "secrets" :: engine :: "org" :: org :: "add" :: [] ->
-            Dash_Secrets_Engine__Org_Org__Add
-                { org = org
-                , engine = engine
-                }
-                |> Just
-
-        "-" :: "secrets" :: engine :: "org" :: org :: name :: [] ->
-            Dash_Secrets_Engine__Org_Org__Name_
-                { org = org
-                , name = name
-                , engine = engine
-                }
-                |> Just
-
-        "-" :: "secrets" :: engine :: "repo" :: org :: repo :: [] ->
-            Dash_Secrets_Engine__Repo_Org__Repo_
-                { org = org
-                , repo = repo
-                , engine = engine
-                }
-                |> Just
-
-        "-" :: "secrets" :: engine :: "repo" :: org :: repo :: "add" :: [] ->
-            Dash_Secrets_Engine__Repo_Org__Repo__Add
-                { org = org
-                , repo = repo
-                , engine = engine
-                }
-                |> Just
-
-        "-" :: "secrets" :: engine :: "repo" :: org :: repo :: name :: [] ->
-            Dash_Secrets_Engine__Repo_Org__Repo__Name_
-                { org = org
-                , repo = repo
-                , name = name
-                , engine = engine
-                }
-                |> Just
-
-        "-" :: "secrets" :: engine :: "shared" :: org :: team :: [] ->
-            Dash_Secrets_Engine__Shared_Org__Team_
-                { org = org
-                , team = team
-                , engine = engine
-                }
-                |> Just
-
-        "-" :: "secrets" :: engine :: "shared" :: org :: team :: "add" :: [] ->
-            Dash_Secrets_Engine__Shared_Org__Team__Add
-                { org = org
-                , team = team
-                , engine = engine
-                }
-                |> Just
-
-        "-" :: "secrets" :: engine :: "shared" :: org :: team :: name :: [] ->
-            Dash_Secrets_Engine__Shared_Org__Team__Name_
-                { org = org
-                , team = team
-                , name = name
-                , engine = engine
-                }
-                |> Just
-
         _ ->
             Nothing
 
@@ -288,65 +288,17 @@ toString path =
                 Account_Login ->
                     [ "account", "login" ]
 
-                Account_Logout ->
-                    [ "account", "logout" ]
-
                 Account_Authenticate ->
                     [ "account", "authenticate" ]
+
+                Account_Logout ->
+                    [ "account", "logout" ]
 
                 Account_Settings ->
                     [ "account", "settings" ]
 
                 Account_SourceRepos ->
                     [ "account", "source-repos" ]
-
-                Org_ params ->
-                    [ params.org ]
-
-                Org__Builds params ->
-                    [ params.org, "builds" ]
-
-                Org__Repo_ params ->
-                    [ params.org, params.repo ]
-
-                Org__Repo__Pulls params ->
-                    [ params.org, params.repo, "?event=pull_request" ]
-
-                Org__Repo__Tags params ->
-                    [ params.org, params.repo, "?event=tag" ]
-
-                Org__Repo__Deployments params ->
-                    [ params.org, params.repo, "deployments" ]
-
-                Org__Repo__Deployments_Add params ->
-                    [ params.org, params.repo, "deployments", "add" ]
-
-                Org__Repo__Schedules params ->
-                    [ params.org, params.repo, "schedules" ]
-
-                Org__Repo__Schedules_Add params ->
-                    [ params.org, params.repo, "schedules", "add" ]
-
-                Org__Repo__Schedules_Name_ params ->
-                    [ params.org, params.repo, "schedules", params.name ]
-
-                Org__Repo__Hooks params ->
-                    [ params.org, params.repo, "hooks" ]
-
-                Org__Repo__Settings params ->
-                    [ params.org, params.repo, "settings" ]
-
-                Org__Repo__Build_ params ->
-                    [ params.org, params.repo, params.build ]
-
-                Org__Repo__Build__Services params ->
-                    [ params.org, params.repo, params.build, "services" ]
-
-                Org__Repo__Build__Pipeline params ->
-                    [ params.org, params.repo, params.build, "pipeline" ]
-
-                Org__Repo__Build__Graph params ->
-                    [ params.org, params.repo, params.build, "graph" ]
 
                 Dash_Secrets_Engine__Org_Org_ params ->
                     [ "-", "secrets", params.engine, "org", params.org ]
@@ -374,6 +326,55 @@ toString path =
 
                 Dash_Secrets_Engine__Shared_Org__Team__Name_ params ->
                     [ "-", "secrets", params.engine, "shared", params.org, params.team, params.name ]
+
+                Org_ params ->
+                    [ params.org ]
+
+                Org__Builds params ->
+                    [ params.org, "builds" ]
+
+                Org__Repo_ params ->
+                    [ params.org, params.repo ]
+
+                Org__Repo__Deployments params ->
+                    [ params.org, params.repo, "deployments" ]
+
+                Org__Repo__Deployments_Add params ->
+                    [ params.org, params.repo, "deployments", "add" ]
+
+                Org__Repo__Hooks params ->
+                    [ params.org, params.repo, "hooks" ]
+
+                Org__Repo__Schedules params ->
+                    [ params.org, params.repo, "schedules" ]
+
+                Org__Repo__Schedules_Add params ->
+                    [ params.org, params.repo, "schedules", "add" ]
+
+                Org__Repo__Schedules_Name_ params ->
+                    [ params.org, params.repo, "schedules", params.name ]
+
+                Org__Repo__Settings params ->
+                    [ params.org, params.repo, "settings" ]
+
+                -- ALIASES
+                Org__Repo__Pulls params ->
+                    [ params.org, params.repo, "?event=pull_request" ]
+
+                Org__Repo__Tags params ->
+                    [ params.org, params.repo, "?event=tag" ]
+
+                Org__Repo__Build_ params ->
+                    [ params.org, params.repo, params.build ]
+
+                Org__Repo__Build__Services params ->
+                    [ params.org, params.repo, params.build, "services" ]
+
+                Org__Repo__Build__Pipeline params ->
+                    [ params.org, params.repo, params.build, "pipeline" ]
+
+                Org__Repo__Build__Graph params ->
+                    [ params.org, params.repo, params.build, "graph" ]
 
                 NotFound_ ->
                     [ "not-found" ]

--- a/src/elm/Route/Path.elm
+++ b/src/elm/Route/Path.elm
@@ -13,8 +13,8 @@ import Url.Parser exposing ((</>))
 
 type Path
     = Home_
-    | Account_Login
     | Account_Authenticate
+    | Account_Login
     | Account_Logout
     | Account_Settings
     | Account_SourceRepos
@@ -33,11 +33,11 @@ type Path
     | Org__Repo__Deployments { org : String, repo : String }
     | Org__Repo__Deployments_Add { org : String, repo : String }
     | Org__Repo__Hooks { org : String, repo : String }
+    | Org__Repo__Pulls { org : String, repo : String }
     | Org__Repo__Schedules { org : String, repo : String }
     | Org__Repo__Schedules_Add { org : String, repo : String }
     | Org__Repo__Schedules_Name_ { org : String, repo : String, name : String }
     | Org__Repo__Settings { org : String, repo : String }
-    | Org__Repo__Pulls { org : String, repo : String }
     | Org__Repo__Tags { org : String, repo : String }
     | Org__Repo__Build_ { org : String, repo : String, build : String }
     | Org__Repo__Build__Graph { org : String, repo : String, build : String }
@@ -65,11 +65,11 @@ fromString urlPath =
         [] ->
             Just Home_
 
-        "account" :: "login" :: [] ->
-            Just Account_Login
-
         "account" :: "authenticate" :: [] ->
             Just Account_Authenticate
+
+        "account" :: "login" :: [] ->
+            Just Account_Login
 
         "account" :: "logout" :: [] ->
             Just Account_Logout
@@ -192,6 +192,13 @@ fromString urlPath =
                 }
                 |> Just
 
+        org_ :: repo_ :: "pulls" :: [] ->
+            Org__Repo__Pulls
+                { org = org_
+                , repo = repo_
+                }
+                |> Just
+
         org_ :: repo_ :: "schedules" :: [] ->
             Org__Repo__Schedules
                 { org = org_
@@ -216,13 +223,6 @@ fromString urlPath =
 
         org_ :: repo_ :: "settings" :: [] ->
             Org__Repo__Settings
-                { org = org_
-                , repo = repo_
-                }
-                |> Just
-
-        org_ :: repo_ :: "pulls" :: [] ->
-            Org__Repo__Pulls
                 { org = org_
                 , repo = repo_
                 }
@@ -285,11 +285,11 @@ toString path =
                 Home_ ->
                     []
 
-                Account_Login ->
-                    [ "account", "login" ]
-
                 Account_Authenticate ->
                     [ "account", "authenticate" ]
+
+                Account_Login ->
+                    [ "account", "login" ]
 
                 Account_Logout ->
                     [ "account", "logout" ]
@@ -345,6 +345,9 @@ toString path =
                 Org__Repo__Hooks params ->
                     [ params.org, params.repo, "hooks" ]
 
+                Org__Repo__Pulls params ->
+                    [ params.org, params.repo, "?event=pull_request" ]
+
                 Org__Repo__Schedules params ->
                     [ params.org, params.repo, "schedules" ]
 
@@ -356,10 +359,6 @@ toString path =
 
                 Org__Repo__Settings params ->
                     [ params.org, params.repo, "settings" ]
-
-                -- ALIASES
-                Org__Repo__Pulls params ->
-                    [ params.org, params.repo, "?event=pull_request" ]
 
                 Org__Repo__Tags params ->
                     [ params.org, params.repo, "?event=tag" ]

--- a/src/elm/Route/Query.elm
+++ b/src/elm/Route/Query.elm
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0
 --}
 
 
-module Route.Query exposing (fromString, fromUrl, toString)
+module Route.Query exposing (fromUrl, toString)
 
 import Dict exposing (Dict)
 import Url exposing (Url)
@@ -26,18 +26,6 @@ fromUrl url =
                     |> String.split "&"
                     |> List.filterMap (String.split "=" >> queryPiecesToTuple)
                     |> Dict.fromList
-
-
-fromString : String -> Dict String String
-fromString query =
-    if String.isEmpty query then
-        Dict.empty
-
-    else
-        query
-            |> String.split "&"
-            |> List.filterMap (String.split "=" >> queryPiecesToTuple)
-            |> Dict.fromList
 
 
 queryPiecesToTuple : List String -> Maybe ( String, String )

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -289,11 +289,20 @@ update route msg model =
                         _ ->
                             model.velaRedirect
 
+                queryURL query =
+                    { protocol = Url.Http
+                    , host = ""
+                    , port_ = Nothing
+                    , path = ""
+                    , query = query
+                    , fragment = Nothing
+                    }
+
                 redirectRoute =
                     Route.parsePath velaRedirect
                         |> (\parsed ->
                                 { path = Maybe.withDefault Route.Path.Home_ <| Route.Path.fromString parsed.path
-                                , query = Route.Query.fromString <| Maybe.withDefault "" parsed.query
+                                , query = Route.Query.fromUrl <| queryURL parsed.query
                                 , hash = parsed.hash
                                 }
                            )

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -300,7 +300,7 @@ update route msg model =
                     }
 
                 redirectRoute =
-                    Routes.parsePath velaRedirect
+                    Routes.pathFromString velaRedirect
                         |> (\parsed ->
                                 { path = Maybe.withDefault Route.Path.Home_ <| Route.Path.fromString parsed.path
                                 , query = Route.Query.fromUrl <| queryURL parsed.query

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -35,6 +35,7 @@ import Utils.Favicons as Favicons
 import Utils.Favorites as Favorites
 import Utils.Helpers as Util
 import Utils.Interval as Interval
+import Utils.Routes as Routes
 import Utils.Theme as Theme
 import Vela exposing (defaultUpdateUserPayload)
 
@@ -299,7 +300,7 @@ update route msg model =
                     }
 
                 redirectRoute =
-                    Route.parsePath velaRedirect
+                    Routes.parsePath velaRedirect
                         |> (\parsed ->
                                 { path = Maybe.withDefault Route.Path.Home_ <| Route.Path.fromString parsed.path
                                 , query = Route.Query.fromUrl <| queryURL parsed.query

--- a/src/elm/Utils/Routes.elm
+++ b/src/elm/Utils/Routes.elm
@@ -1,14 +1,14 @@
-module Utils.Routes exposing (parsePath)
+module Utils.Routes exposing (pathFromString)
 
 
-parsePath :
+pathFromString :
     String
     ->
         { path : String
         , query : Maybe String
         , hash : Maybe String
         }
-parsePath urlString =
+pathFromString urlString =
     let
         pathsAndHash =
             String.split "#" urlString

--- a/src/elm/Utils/Routes.elm
+++ b/src/elm/Utils/Routes.elm
@@ -1,0 +1,28 @@
+module Utils.Routes exposing (parsePath)
+
+
+parsePath :
+    String
+    ->
+        { path : String
+        , query : Maybe String
+        , hash : Maybe String
+        }
+parsePath urlString =
+    let
+        pathsAndHash =
+            String.split "#" urlString
+
+        maybeHash =
+            List.head <| List.drop 1 pathsAndHash
+
+        pathsAndQuery =
+            String.split "?" <| Maybe.withDefault "" <| List.head pathsAndHash
+
+        pathSegments =
+            String.split "/" <| Maybe.withDefault "" <| List.head pathsAndQuery
+
+        maybeQuery =
+            List.head <| List.drop 1 pathsAndQuery
+    in
+    { path = String.join "/" pathSegments, query = maybeQuery, hash = maybeHash }


### PR DESCRIPTION
changes pulled from running `elm-land generate` then manually fixing anything wrong.
so, it basically just matches more style/pattern consistency from the `elm-land` CL.
- switch statement patterns `a :  b : []`
- switch branch ordering
- type ordering
- moved `parsePath` to `Utils.Routes` so `generate` wont cause conflicts with `Route.elm`

```sh
elm-land generate && elm-format --yes src
```