### PR TITLE
fix(org): hide pagination when there are no org repos

### DIFF
--- a/src/elm/Pages/Org_.elm
+++ b/src/elm/Pages/Org_.elm
@@ -190,7 +190,7 @@ view shared route model =
             ]
             [ span [] []
             , Components.Pager.view
-                { show = True
+                { show = RemoteData.unwrap 0 List.length model.repos > 0
                 , links = model.pager
                 , labels = Components.Pager.prevNextLabels
                 , msg = GotoPage
@@ -239,7 +239,7 @@ view shared route model =
                         ]
                     ]
         , Components.Pager.view
-            { show = True
+            { show = RemoteData.unwrap 0 List.length model.repos > 0
             , links = model.pager
             , labels = Components.Pager.prevNextLabels
             , msg = GotoPage


### PR DESCRIPTION
fixes this ux regression with floating disabled pagination

## before
<img width="1728" alt="Screenshot 2024-04-02 at 8 40 52 AM" src="https://github.com/go-vela/ui/assets/48764154/d552aba5-bd17-4d68-a175-8c8c7c56aa05">


## after
<img width="1706" alt="Screenshot 2024-04-02 at 8 48 27 AM" src="https://github.com/go-vela/ui/assets/48764154/02d2bfa0-b7af-41da-8b37-6281fdddd99c">

