### PR TITLE
chore: remove allow_ fields from repo and events from secrets

### DIFF
--- a/cypress/fixtures/enable_repo_response.json
+++ b/cypress/fixtures/enable_repo_response.json
@@ -15,10 +15,5 @@
   "private": false,
   "trusted": true,
   "active": true,
-  "allow_pull": false,
-  "allow_push": true,
-  "allow_deploy": false,
-  "allow_tag": false,
-  "allow_comment": false,
   "pipeline_type": "yaml"
 }

--- a/cypress/fixtures/overview_page.json
+++ b/cypress/fixtures/overview_page.json
@@ -15,11 +15,7 @@
     "visibility": "public",
     "private": false,
     "trusted": true,
-    "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false
+    "active": true
   },
   {
     "id": 18,
@@ -37,11 +33,7 @@
     "visibility": "public",
     "private": false,
     "trusted": true,
-    "active": false,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false
+    "active": false
   },
   {
     "id": 17,
@@ -59,11 +51,7 @@
     "visibility": "public",
     "private": false,
     "trusted": true,
-    "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false
+    "active": true
   },
   {
     "id": 16,
@@ -81,10 +69,6 @@
     "visibility": "public",
     "private": false,
     "trusted": true,
-    "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false
+    "active": true
   }
 ]

--- a/cypress/fixtures/repositories.json
+++ b/cypress/fixtures/repositories.json
@@ -16,11 +16,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -66,11 +61,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -116,11 +106,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "allow_events": {
       "push": {
         "branch": true,
@@ -165,11 +150,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {

--- a/cypress/fixtures/repositories_100.json
+++ b/cypress/fixtures/repositories_100.json
@@ -16,11 +16,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -66,11 +61,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -116,11 +106,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -166,11 +151,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -216,11 +196,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -266,11 +241,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -316,11 +286,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -366,11 +331,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -416,11 +376,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -466,11 +421,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -516,11 +466,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -566,11 +511,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -616,11 +556,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -666,11 +601,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -716,11 +646,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -766,11 +691,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -816,11 +736,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -866,11 +781,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -916,11 +826,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -966,11 +871,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1016,11 +916,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1066,11 +961,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1116,11 +1006,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1166,11 +1051,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1216,11 +1096,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1266,11 +1141,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1316,11 +1186,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1366,11 +1231,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1416,11 +1276,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1466,11 +1321,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1516,11 +1366,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1566,11 +1411,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1616,11 +1456,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1666,11 +1501,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1716,11 +1546,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1766,11 +1591,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1816,11 +1636,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1866,11 +1681,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1916,11 +1726,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -1966,11 +1771,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2016,11 +1816,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2066,11 +1861,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2116,11 +1906,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2166,11 +1951,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2216,11 +1996,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2266,11 +2041,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2316,11 +2086,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2366,11 +2131,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2416,11 +2176,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2466,11 +2221,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2516,11 +2266,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2566,11 +2311,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2616,11 +2356,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2666,11 +2401,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2716,11 +2446,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2766,11 +2491,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2816,11 +2536,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2866,11 +2581,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2916,11 +2626,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -2966,11 +2671,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3016,11 +2716,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3066,11 +2761,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3116,11 +2806,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3166,11 +2851,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3216,11 +2896,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3266,11 +2941,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3316,11 +2986,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3366,11 +3031,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3416,11 +3076,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3466,11 +3121,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3516,11 +3166,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3566,11 +3211,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3616,11 +3256,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3666,11 +3301,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3716,11 +3346,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3766,11 +3391,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3816,11 +3436,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3866,11 +3481,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3916,11 +3526,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -3966,11 +3571,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4016,11 +3616,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4066,11 +3661,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4116,11 +3706,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4166,11 +3751,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4216,11 +3796,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4266,11 +3841,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4316,11 +3886,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4366,11 +3931,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4416,11 +3976,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4466,11 +4021,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4516,11 +4066,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4566,11 +4111,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4616,11 +4156,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4666,11 +4201,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4716,11 +4246,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4766,11 +4291,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4816,11 +4336,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4866,11 +4381,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4916,11 +4426,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -4966,11 +4471,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {

--- a/cypress/fixtures/repositories_10a.json
+++ b/cypress/fixtures/repositories_10a.json
@@ -16,11 +16,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -66,11 +61,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -116,11 +106,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -166,11 +151,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -216,11 +196,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -266,11 +241,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -316,11 +286,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -366,11 +331,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -416,11 +376,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -466,11 +421,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {

--- a/cypress/fixtures/repositories_10b.json
+++ b/cypress/fixtures/repositories_10b.json
@@ -16,11 +16,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -66,11 +61,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -116,11 +106,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -166,11 +151,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -216,11 +196,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -266,11 +241,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -316,11 +286,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -366,11 +331,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -416,11 +376,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {
@@ -466,11 +421,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "pipeline_type": "yaml",
     "allow_events": {
       "push": {

--- a/cypress/fixtures/repositories_5.json
+++ b/cypress/fixtures/repositories_5.json
@@ -16,11 +16,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "allow_events": {
       "push": {
         "branch": true,
@@ -68,11 +63,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "allow_events": {
       "push": {
         "branch": true,
@@ -120,11 +110,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "allow_events": {
       "push": {
         "branch": true,
@@ -172,11 +157,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "allow_events": {
       "push": {
         "branch": true,
@@ -224,11 +204,6 @@
     "private": false,
     "trusted": true,
     "active": true,
-    "allow_pull": false,
-    "allow_push": true,
-    "allow_deploy": false,
-    "allow_tag": false,
-    "allow_comment": false,
     "allow_events": {
       "push": {
         "branch": true,

--- a/cypress/fixtures/repository.json
+++ b/cypress/fixtures/repository.json
@@ -15,11 +15,6 @@
   "private": false,
   "trusted": true,
   "active": true,
-  "allow_pull": true,
-  "allow_push": true,
-  "allow_deploy": false,
-  "allow_tag": false,
-  "allow_comment": false,
   "allow_events": {
     "push": {
       "branch": true,

--- a/cypress/fixtures/repository_inactive.json
+++ b/cypress/fixtures/repository_inactive.json
@@ -15,11 +15,6 @@
   "private": false,
   "trusted": true,
   "active": false,
-  "allow_pull": true,
-  "allow_push": true,
-  "allow_deploy": false,
-  "allow_tag": false,
-  "allow_comment": false,
   "allow_events": {
     "push": {
       "branch": true,

--- a/cypress/fixtures/repository_updated.json
+++ b/cypress/fixtures/repository_updated.json
@@ -15,11 +15,6 @@
   "private": false,
   "trusted": true,
   "active": true,
-  "allow_pull": false,
-  "allow_push": false,
-  "allow_deploy": true,
-  "allow_tag": true,
-  "allow_comment": false,
   "allow_events": {
     "push": {
       "branch": false,

--- a/cypress/fixtures/schedule.json
+++ b/cypress/fixtures/schedule.json
@@ -26,11 +26,6 @@
     "private": false,
     "trusted": false,
     "active": true,
-    "allow_pull": true,
-    "allow_push": true,
-    "allow_deploy": true,
-    "allow_tag": true,
-    "allow_comment": true,
     "pipeline_type": "yaml",
     "previous_name": ""
   }

--- a/cypress/fixtures/schedules.json
+++ b/cypress/fixtures/schedules.json
@@ -26,11 +26,6 @@
       "private": false,
       "trusted": false,
       "active": true,
-      "allow_pull": true,
-      "allow_push": true,
-      "allow_deploy": true,
-      "allow_tag": true,
-      "allow_comment": true,
       "pipeline_type": "yaml",
       "previous_name": ""
     }
@@ -62,11 +57,6 @@
       "private": false,
       "trusted": false,
       "active": true,
-      "allow_pull": true,
-      "allow_push": true,
-      "allow_deploy": true,
-      "allow_tag": true,
-      "allow_comment": true,
       "pipeline_type": "yaml",
       "previous_name": ""
     }

--- a/cypress/fixtures/source_repos.json
+++ b/cypress/fixtures/source_repos.json
@@ -15,12 +15,7 @@
       "visibility": "public",
       "private": false,
       "trusted": true,
-      "active": false,
-      
-      
-      
-      
-      
+      "active": false
     },
     {
       "id": 22,
@@ -37,12 +32,7 @@
       "visibility": "public",
       "private": false,
       "trusted": true,
-      "active": false,
-      
-      
-      
-      
-      
+      "active": false
     },
     {
       "id": 21,
@@ -59,12 +49,7 @@
       "visibility": "public",
       "private": false,
       "trusted": true,
-      "active": true,
-      
-      
-      
-      
-      
+      "active": true
     },
     {
       "id": 20,
@@ -81,12 +66,7 @@
       "visibility": "public",
       "private": false,
       "trusted": true,
-      "active": false,
-      
-      
-      
-      
-      
+      "active": false
     }
   ],
   "CookieCat": [
@@ -105,12 +85,7 @@
       "visibility": "public",
       "private": false,
       "trusted": true,
-      "active": false,
-      
-      
-      
-      
-      
+      "active": false
     }
   ]
 }

--- a/cypress/fixtures/source_repos.json
+++ b/cypress/fixtures/source_repos.json
@@ -16,11 +16,11 @@
       "private": false,
       "trusted": true,
       "active": false,
-      "allow_pull": false,
-      "allow_push": true,
-      "allow_deploy": false,
-      "allow_tag": false,
-      "allow_comment": false
+      
+      
+      
+      
+      
     },
     {
       "id": 22,
@@ -38,11 +38,11 @@
       "private": false,
       "trusted": true,
       "active": false,
-      "allow_pull": false,
-      "allow_push": true,
-      "allow_deploy": false,
-      "allow_tag": false,
-      "allow_comment": false
+      
+      
+      
+      
+      
     },
     {
       "id": 21,
@@ -60,11 +60,11 @@
       "private": false,
       "trusted": true,
       "active": true,
-      "allow_pull": false,
-      "allow_push": true,
-      "allow_deploy": false,
-      "allow_tag": false,
-      "allow_comment": false
+      
+      
+      
+      
+      
     },
     {
       "id": 20,
@@ -82,11 +82,11 @@
       "private": false,
       "trusted": true,
       "active": false,
-      "allow_pull": false,
-      "allow_push": true,
-      "allow_deploy": false,
-      "allow_tag": false,
-      "allow_comment": false
+      
+      
+      
+      
+      
     }
   ],
   "CookieCat": [
@@ -106,11 +106,11 @@
       "private": false,
       "trusted": true,
       "active": false,
-      "allow_pull": false,
-      "allow_push": true,
-      "allow_deploy": false,
-      "allow_tag": false,
-      "allow_comment": false
+      
+      
+      
+      
+      
     }
   ]
 }

--- a/src/elm/Pages/Org_/Repo_/Deployments/Add.elm
+++ b/src/elm/Pages/Org_/Repo_/Deployments/Add.elm
@@ -318,7 +318,7 @@ view shared route model =
                     , div [ class "deployment-form" ]
                         [ case model.repo of
                             RemoteData.Success repo ->
-                                if not repo.allow_deploy then
+                                if not repo.allowEvents.deploy.created then
                                     p [ class "notice" ]
                                         [ strong []
                                             [ text "Deploy webhook for this repo must be enabled in settings"

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -220,11 +220,6 @@ buildRepoPayload repo =
         repo.private
         repo.trusted
         repo.active
-        repo.allow_pull
-        repo.allow_push
-        repo.allow_deploy
-        repo.allow_tag
-        repo.allow_comment
         repo.allowEvents
 
 
@@ -239,11 +234,6 @@ encodeEnableRepository repo =
         , ( "private", Json.Encode.bool <| repo.private )
         , ( "trusted", Json.Encode.bool <| repo.trusted )
         , ( "active", Json.Encode.bool <| repo.active )
-        , ( "allow_pull", Json.Encode.bool <| repo.allow_pull )
-        , ( "allow_push", Json.Encode.bool <| repo.allow_push )
-        , ( "allow_deploy", Json.Encode.bool <| repo.allow_deploy )
-        , ( "allow_tag", Json.Encode.bool <| repo.allow_tag )
-        , ( "allow_comment", Json.Encode.bool <| repo.allow_comment )
         , ( "allow_events", encodeAllowEvents repo.allowEvents )
         ]
 
@@ -307,11 +297,6 @@ type alias EnableRepoPayload =
     , private : Bool
     , trusted : Bool
     , active : Bool
-    , allow_pull : Bool
-    , allow_push : Bool
-    , allow_deploy : Bool
-    , allow_tag : Bool
-    , allow_comment : Bool
     , allowEvents : AllowEvents
     }
 
@@ -360,11 +345,6 @@ type alias Repository =
     , private : Bool
     , trusted : Bool
     , active : Bool
-    , allow_pull : Bool
-    , allow_push : Bool
-    , allow_deploy : Bool
-    , allow_tag : Bool
-    , allow_comment : Bool
     , allowEvents : AllowEvents
     , enabled : Enabled
     , pipeline_type : String
@@ -390,11 +370,6 @@ decodeRepository =
         |> optional "private" bool False
         |> optional "trusted" bool False
         |> optional "active" bool False
-        |> optional "allow_pull" bool False
-        |> optional "allow_push" bool False
-        |> optional "allow_deploy" bool False
-        |> optional "allow_tag" bool False
-        |> optional "allow_comment" bool False
         |> optional "allow_events" decodeAllowEvents defaultAllowEvents
         -- "enabled"
         |> optional "active" enabledDecoder Disabled
@@ -414,11 +389,6 @@ type alias RepoPayload =
     { private : Maybe Bool
     , trusted : Maybe Bool
     , active : Maybe Bool
-    , allow_pull : Maybe Bool
-    , allow_push : Maybe Bool
-    , allow_deploy : Maybe Bool
-    , allow_tag : Maybe Bool
-    , allow_comment : Maybe Bool
     , allowEvents : Maybe AllowEvents
     , visibility : Maybe String
     , approve_build : Maybe String
@@ -435,11 +405,6 @@ encodeRepoPayload repo =
         [ ( "active", encodeOptional Json.Encode.bool repo.active )
         , ( "private", encodeOptional Json.Encode.bool repo.private )
         , ( "trusted", encodeOptional Json.Encode.bool repo.trusted )
-        , ( "allow_pull", encodeOptional Json.Encode.bool repo.allow_pull )
-        , ( "allow_push", encodeOptional Json.Encode.bool repo.allow_push )
-        , ( "allow_deploy", encodeOptional Json.Encode.bool repo.allow_deploy )
-        , ( "allow_tag", encodeOptional Json.Encode.bool repo.allow_tag )
-        , ( "allow_comment", encodeOptional Json.Encode.bool repo.allow_comment )
         , ( "allow_events", encodeOptional encodeAllowEvents repo.allowEvents )
         , ( "visibility", encodeOptional Json.Encode.string repo.visibility )
         , ( "approve_build", encodeOptional Json.Encode.string repo.approve_build )
@@ -455,11 +420,6 @@ defaultRepoPayload =
     { private = Nothing
     , trusted = Nothing
     , active = Nothing
-    , allow_pull = Nothing
-    , allow_push = Nothing
-    , allow_deploy = Nothing
-    , allow_tag = Nothing
-    , allow_comment = Nothing
     , allowEvents = Nothing
     , visibility = Nothing
     , approve_build = Nothing
@@ -1735,7 +1695,6 @@ type alias SecretPayload =
     , team : Maybe Team
     , name : Maybe Name
     , value : Maybe String
-    , events : Maybe (List String)
     , images : Maybe (List String)
     , allowCommand : Maybe Bool
     , allowSubstitution : Maybe Bool
@@ -1751,7 +1710,6 @@ defaultSecretPayload =
     , team = Nothing
     , name = Nothing
     , value = Nothing
-    , events = Nothing
     , images = Nothing
     , allowCommand = Nothing
     , allowSubstitution = Nothing


### PR DESCRIPTION
Follow up from https://github.com/go-vela/types/pull/362 and https://github.com/go-vela/server/pull/1098