### PR TITLE
fix: reset favicon in nested layouts

### DIFF
--- a/src/elm/Layouts/Default.elm
+++ b/src/elm/Layouts/Default.elm
@@ -19,7 +19,6 @@ import Layout exposing (Layout)
 import Route exposing (Route)
 import Shared
 import Toasty as Alerting
-import Utils.Favicons as Favicons
 import Utils.Helpers as Util
 import Utils.Theme as Theme
 import View exposing (View)
@@ -55,7 +54,7 @@ init shared _ =
     ( { showIdentity = False
       , showHelp = False
       }
-    , Effect.updateFavicon { favicon = Favicons.defaultFavicon }
+    , Effect.none
     )
 
 

--- a/src/elm/Layouts/Default.elm
+++ b/src/elm/Layouts/Default.elm
@@ -19,6 +19,7 @@ import Layout exposing (Layout)
 import Route exposing (Route)
 import Shared
 import Toasty as Alerting
+import Utils.Favicons as Favicons
 import Utils.Helpers as Util
 import Utils.Theme as Theme
 import View exposing (View)
@@ -54,7 +55,7 @@ init shared _ =
     ( { showIdentity = False
       , showHelp = False
       }
-    , Effect.none
+    , Effect.updateFavicon { favicon = Favicons.defaultFavicon }
     )
 
 

--- a/src/elm/Layouts/Default/Org.elm
+++ b/src/elm/Layouts/Default/Org.elm
@@ -20,6 +20,7 @@ import Route exposing (Route)
 import Route.Path
 import Shared
 import Url exposing (Url)
+import Utils.Favicons as Favicons
 import Utils.Helpers as Util
 import View exposing (View)
 
@@ -69,7 +70,10 @@ init : Shared.Model -> Route () -> () -> ( Model, Effect Msg )
 init shared route _ =
     ( { tabHistory = Dict.empty
       }
-    , Effect.getCurrentUser {}
+    , Effect.batch
+        [ Effect.updateFavicon { favicon = Favicons.defaultFavicon }
+        , Effect.getCurrentUser {}
+        ]
     )
 
 

--- a/src/elm/Layouts/Default/Repo.elm
+++ b/src/elm/Layouts/Default/Repo.elm
@@ -22,6 +22,7 @@ import Route.Path
 import Shared
 import Time
 import Url exposing (Url)
+import Utils.Favicons as Favicons
 import Utils.Favorites as Favorites
 import Utils.Interval as Interval
 import View exposing (View)
@@ -75,7 +76,8 @@ init props shared route _ =
     ( { tabHistory = Dict.empty
       }
     , Effect.batch
-        [ Effect.getCurrentUser {}
+        [ Effect.updateFavicon { favicon = Favicons.defaultFavicon }
+        , Effect.getCurrentUser {}
         , Effect.getRepoBuildsShared
             { pageNumber = Nothing
             , perPage = Nothing


### PR DESCRIPTION
we need to reset the favicon in all layouts.
fixes situations where default init is not called and the favicon doesnt reset.