### PR TITLE
fix: set repo.owner.admin to optional

### DIFF
--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -180,7 +180,7 @@ decodeUser =
         |> required "name" string
         |> optional "favorites" (Json.Decode.list string) []
         |> required "active" bool
-        |> required "admin" bool
+        |> optional "admin" bool False
 
 
 emptyUser : User


### PR DESCRIPTION
fixes a regression introduced by scrubbing certain fields from the repo owner 

also please see: https://github.com/go-vela/server/pull/1113