### PR TITLE
enhance(repo-settings): display repository owner in UI

### DIFF
--- a/src/elm/Pages/Org_/Repo_/Settings.elm
+++ b/src/elm/Pages/Org_/Repo_/Settings.elm
@@ -1151,6 +1151,8 @@ viewAdminActions repo disableRepoMsg enableRepoMsg chownRepoMsg repairRepoMsg =
                 [ text "Chown Repository"
                 , small []
                     [ em [] [ text "This will make you the owner of the webhook for this repository." ] ]
+                , small []
+                    [ em [] [ text <| "Current owner: " ++ repo.owner.name ] ]
                 ]
             , button
                 [ class "button"


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/69

Mock:
<img width="501" alt="Screenshot 2024-04-25 at 9 01 16 AM" src="https://github.com/go-vela/ui/assets/65553218/e221320d-858f-4478-9bfd-e5d12334a458">
