### PR TITLE
feat(schedule)!: show schedule errors and nest object

### DIFF
--- a/cypress/fixtures/schedules.json
+++ b/cypress/fixtures/schedules.json
@@ -59,7 +59,7 @@
     "created_by": "CookieCat",
     "updated_at": 1685037152,
     "updated_by": "CookieCat",
-    "scheduled_at": 1685037152,
+    "scheduled_at": 0,
     "branch": "main",
     "error": ""
   },

--- a/cypress/fixtures/schedules.json
+++ b/cypress/fixtures/schedules.json
@@ -122,7 +122,7 @@
     "created_at": 1685037182,
     "created_by": "CookieCat",
     "updated_at": 1685037182,
-    "updated_by": "CookieCat",   
+    "updated_by": "CookieCat",
     "scheduled_at": 0,
     "branch": "main",
     "error": "unable to trigger build for schedule Hourly: unable to schedule build: unable to compile pipeline configuration for github/octocat: 1 error occurred: * no \"version:\" YAML property provided"

--- a/cypress/fixtures/schedules.json
+++ b/cypress/fixtures/schedules.json
@@ -1,6 +1,57 @@
 [
   {
     "id": 1,
+    "repo": {
+      "id": 1,
+      "owner": {
+        "id": 1,
+        "name": "CookieCat",
+        "active": true
+      },
+      "org": "CookieCat",
+      "name": "octocat",
+      "full_name": "github/octocat",
+      "link": "https://github.com/github/octocat",
+      "clone": "https://github.com/github/octocat.git",
+      "branch": "main",
+      "topics": [],
+      "build_limit": 10,
+      "timeout": 30,
+      "counter": 0,
+      "visibility": "public",
+      "private": false,
+      "trusted": false,
+      "active": true,
+      "allow_events": {
+        "push": {
+          "branch": true,
+          "tag": false,
+          "delete_branch": false,
+          "delete_tag": false
+        },
+        "pull_request": {
+          "opened": false,
+          "edited": false,
+          "synchronize": false,
+          "reopened": false,
+          "labeled": false,
+          "unlabeled": false
+        },
+        "deployment": {
+          "created": false
+        },
+        "comment": {
+          "created": false,
+          "edited": false
+        },
+        "schedule": {
+          "run": false
+        }
+      },
+      "pipeline_type": "yaml",
+      "previous_name": "",
+      "approve_build": "fork-always"
+    },
     "active": true,
     "name": "Daily",
     "entry": "0 0 * * *",
@@ -8,10 +59,19 @@
     "created_by": "CookieCat",
     "updated_at": 1685037152,
     "updated_by": "CookieCat",
-    "scheduled_at": 0,
+    "scheduled_at": 1685037152,
+    "branch": "main",
+    "error": ""
+  },
+  {
+    "id": 2,
     "repo": {
       "id": 1,
-      "user_id": 1,
+      "owner": {
+        "id": 1,
+        "name": "CookieCat",
+        "active": true
+      },
       "org": "CookieCat",
       "name": "octocat",
       "full_name": "github/octocat",
@@ -26,39 +86,45 @@
       "private": false,
       "trusted": false,
       "active": true,
+      "allow_events": {
+        "push": {
+          "branch": true,
+          "tag": false,
+          "delete_branch": false,
+          "delete_tag": false
+        },
+        "pull_request": {
+          "opened": false,
+          "edited": false,
+          "synchronize": false,
+          "reopened": false,
+          "labeled": false,
+          "unlabeled": false
+        },
+        "deployment": {
+          "created": false
+        },
+        "comment": {
+          "created": false,
+          "edited": false
+        },
+        "schedule": {
+          "run": false
+        }
+      },
       "pipeline_type": "yaml",
-      "previous_name": ""
-    }
-  },
-  {
-    "id": 2,
+      "previous_name": "",
+      "approve_build": "fork-always"
+    },
     "active": true,
     "name": "Hourly",
     "entry": "30 * * * *",
     "created_at": 1685037182,
     "created_by": "CookieCat",
     "updated_at": 1685037182,
-    "updated_by": "CookieCat",
+    "updated_by": "CookieCat",   
     "scheduled_at": 0,
-    "repo": {
-      "id": 1,
-      "user_id": 1,
-      "org": "CookieCat",
-      "name": "octocat",
-      "full_name": "github/octocat",
-      "link": "https://github.com/github/octocat",
-      "clone": "https://github.com/github/octocat.git",
-      "branch": "main",
-      "topics": [],
-      "build_limit": 10,
-      "timeout": 30,
-      "counter": 0,
-      "visibility": "public",
-      "private": false,
-      "trusted": false,
-      "active": true,
-      "pipeline_type": "yaml",
-      "previous_name": ""
-    }
+    "branch": "main",
+    "error": "unable to trigger build for schedule Hourly: unable to schedule build: unable to compile pipeline configuration for github/octocat: 1 error occurred: * no \"version:\" YAML property provided"
   }
 ]

--- a/cypress/integration/schedules.spec.js
+++ b/cypress/integration/schedules.spec.js
@@ -114,7 +114,7 @@ context('Schedules', () => {
         });
         it('should show last scheduled at', () => {
           cy.get('@dailySchedule').within(() => {
-            cy.get('[data-label=scheduled-at]').contains('-');
+            cy.get('[data-label=scheduled-at]').should('exist');
           });
         });
         it('should show updated by', () => {
@@ -124,9 +124,7 @@ context('Schedules', () => {
         });
         it('should show updated at', () => {
           cy.get('@dailySchedule').within(() => {
-            cy.get('[data-label=updated-at]').contains(
-              '05/25/2023 at 12:52 PM',
-            );
+            cy.get('[data-label=updated-at]').should('exist');
           });
         });
         context('failure', () => {

--- a/cypress/integration/schedules.spec.js
+++ b/cypress/integration/schedules.spec.js
@@ -81,5 +81,61 @@ context('Schedules', () => {
         });
       },
     );
+    context('schedule',
+      {
+        env: {
+          VELA_SCHEDULE_ALLOWLIST: '*',
+        },
+      },
+      () => {
+        beforeEach(() => {
+          cy.get('[data-test=schedules-row]').first().as('dailySchedule');
+        });
+        it('should show name', () => {
+          cy.get('@dailySchedule').within(() => {
+            cy.get('.name').contains('Daily');
+          });
+        });
+        it('should show entry', () => {
+          cy.get('@dailySchedule').within(() => {
+            cy.get('[data-label=cron-expression]').contains('0 0 * * *');
+          });
+        });
+        it('should show enabled', () => {
+          cy.get('@dailySchedule').within(() => {
+            cy.get('[data-label=enabled]').contains('yes');
+          });
+        });
+        it('should show branch', () => {
+          cy.get('@dailySchedule').within(() => {
+            cy.get('[data-label=branch]').contains('main');
+          });
+        });
+        it('should show last scheduled at', () => {
+          cy.get('@dailySchedule').within(() => {
+            cy.get('[data-label=scheduled-at]').contains('05/25/2023 at 12:52 PM');
+          });
+        });
+        it('should show updated by', () => {
+          cy.get('@dailySchedule').within(() => {
+            cy.get('[data-label=updated-by]').contains('CookieCat');
+          });
+        });
+        it('should show updated at', () => {
+          cy.get('@dailySchedule').within(() => {
+            cy.get('[data-label=updated-at]').contains('05/25/2023 at 12:52 PM');
+          });
+        });
+        context('failure', () => {
+          beforeEach(() => {
+            cy.get('[data-test=schedules-error]').as('error');
+          });
+          it('should show error', () => {
+            cy.get('@error').contains(
+              'unable to trigger build for schedule Hourly: unable to schedule build: unable to compile pipeline configuration for github/octocat: 1 error occurred: * no \"version:\" YAML property provided'
+            );
+          });
+        });
+      })
   });
 });

--- a/cypress/integration/schedules.spec.js
+++ b/cypress/integration/schedules.spec.js
@@ -114,9 +114,7 @@ context('Schedules', () => {
         });
         it('should show last scheduled at', () => {
           cy.get('@dailySchedule').within(() => {
-            cy.get('[data-label=scheduled-at]').contains(
-              '05/25/2023 at 12:52 PM',
-            );
+            cy.get('[data-label=scheduled-at]').contains('-');
           });
         });
         it('should show updated by', () => {

--- a/cypress/integration/schedules.spec.js
+++ b/cypress/integration/schedules.spec.js
@@ -81,7 +81,8 @@ context('Schedules', () => {
         });
       },
     );
-    context('schedule',
+    context(
+      'schedule',
       {
         env: {
           VELA_SCHEDULE_ALLOWLIST: '*',
@@ -113,7 +114,9 @@ context('Schedules', () => {
         });
         it('should show last scheduled at', () => {
           cy.get('@dailySchedule').within(() => {
-            cy.get('[data-label=scheduled-at]').contains('05/25/2023 at 12:52 PM');
+            cy.get('[data-label=scheduled-at]').contains(
+              '05/25/2023 at 12:52 PM',
+            );
           });
         });
         it('should show updated by', () => {
@@ -123,7 +126,9 @@ context('Schedules', () => {
         });
         it('should show updated at', () => {
           cy.get('@dailySchedule').within(() => {
-            cy.get('[data-label=updated-at]').contains('05/25/2023 at 12:52 PM');
+            cy.get('[data-label=updated-at]').contains(
+              '05/25/2023 at 12:52 PM',
+            );
           });
         });
         context('failure', () => {
@@ -132,10 +137,11 @@ context('Schedules', () => {
           });
           it('should show error', () => {
             cy.get('@error').contains(
-              'unable to trigger build for schedule Hourly: unable to schedule build: unable to compile pipeline configuration for github/octocat: 1 error occurred: * no \"version:\" YAML property provided'
+              'unable to trigger build for schedule Hourly: unable to schedule build: unable to compile pipeline configuration for github/octocat: 1 error occurred: * no "version:" YAML property provided',
             );
           });
         });
-      })
+      },
+    );
   });
 });

--- a/src/elm/Pages/Org_/Repo_/Hooks.elm
+++ b/src/elm/Pages/Org_/Repo_/Hooks.elm
@@ -5,9 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 module Pages.Org_.Repo_.Hooks exposing (..)
 
-import Ansi.Log
 import Api.Pagination
-import Array
 import Auth
 import Components.Loading
 import Components.Pager
@@ -19,7 +17,6 @@ import Html
     exposing
         ( Html
         , a
-        , code
         , div
         , span
         , td
@@ -44,7 +41,6 @@ import Route exposing (Route)
 import Route.Path
 import Shared
 import Time
-import Utils.Ansi
 import Utils.Errors as Errors
 import Utils.Helpers as Util
 import Utils.Interval as Interval
@@ -424,31 +420,23 @@ hookErrorRow hook =
 viewHookError : Vela.Hook -> Html msg
 viewHookError hook =
     let
-        lines =
-            Utils.Ansi.decodeAnsi hook.error
-                |> Array.map
-                    (\line ->
-                        Just <|
-                            Ansi.Log.viewLine line
-                    )
-                |> Array.toList
-                |> List.filterMap identity
-
         msgRow =
             case hook.status of
                 "skipped" ->
                     tr [ class "skipped-data", Util.testAttribute "hooks-skipped" ]
                         [ td [ attribute "colspan" "6" ]
-                            [ code [ class "skipped-content" ]
-                                lines
+                            [ span
+                                [ class "skipped-content" ]
+                                [ text hook.error ]
                             ]
                         ]
 
                 _ ->
                     tr [ class "error-data", Util.testAttribute "hooks-error" ]
                         [ td [ attribute "colspan" "6" ]
-                            [ code [ class "error-content" ]
-                                lines
+                            [ span
+                                [ class "error-content" ]
+                                [ text hook.error ]
                             ]
                         ]
     in

--- a/src/elm/Pages/Org_/Repo_/Schedules.elm
+++ b/src/elm/Pages/Org_/Repo_/Schedules.elm
@@ -16,8 +16,8 @@ import Components.Table
 import Dict
 import Effect exposing (Effect)
 import FeatherIcons
-import Html exposing (Html, a, code, div, span, text, td, tr)
-import Html.Attributes exposing (class, attribute)
+import Html exposing (Html, a, code, div, span, td, text, tr)
+import Html.Attributes exposing (attribute, class)
 import Http
 import Http.Detailed
 import Layouts
@@ -296,6 +296,7 @@ schedulesToRows zone org repo schedules =
         |> List.concatMap (\s -> [ Just <| Components.Table.Row (addKey s) (viewSchedule zone org repo), scheduleErrorRow s ])
         |> List.filterMap identity
 
+
 {-| tableHeaders : returns table headers for schedules table
 -}
 tableHeaders : Components.Table.Columns
@@ -403,14 +404,15 @@ viewScheduleError schedule =
                 |> List.filterMap identity
 
         msgRow =
-                tr [ class "error-data", Util.testAttribute "schedules-error" ]
-                    [ td [ attribute "colspan" "6" ]
-                        [ code [ class "error-content" ]
-                            lines
-                        ]
+            tr [ class "error-data", Util.testAttribute "schedules-error" ]
+                [ td [ attribute "colspan" "6" ]
+                    [ code [ class "error-content" ]
+                        lines
                     ]
+                ]
     in
     msgRow
+
 
 {-| addKey : helper to create Vela.Schedule key
 -}

--- a/src/elm/Pages/Org_/Repo_/Schedules.elm
+++ b/src/elm/Pages/Org_/Repo_/Schedules.elm
@@ -293,7 +293,7 @@ viewRepoSchedules shared model org repo =
 schedulesToRows : Time.Zone -> String -> String -> List Vela.Schedule -> Components.Table.Rows Vela.Schedule msg
 schedulesToRows zone org repo schedules =
     schedules
-        |> List.concatMap (\s -> [ Just <| Components.Table.Row (addKey s) (viewSchedule zone org repo), scheduleErrorRow s ])
+        |> List.concatMap (\s -> [ Just <| Components.Table.Row s (viewSchedule zone org repo), scheduleErrorRow s ])
         |> List.filterMap identity
 
 
@@ -412,10 +412,3 @@ viewScheduleError schedule =
                 ]
     in
     msgRow
-
-
-{-| addKey : helper to create Vela.Schedule key
--}
-addKey : Vela.Schedule -> Vela.Schedule
-addKey schedule =
-    { schedule | org = schedule.org ++ "/" ++ schedule.repo ++ "/" ++ schedule.name }

--- a/src/elm/Pages/Org_/Repo_/Schedules.elm
+++ b/src/elm/Pages/Org_/Repo_/Schedules.elm
@@ -5,9 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 module Pages.Org_.Repo_.Schedules exposing (Model, Msg, page, view)
 
-import Ansi.Log
 import Api.Pagination
-import Array
 import Auth
 import Components.Loading
 import Components.Pager
@@ -16,7 +14,7 @@ import Components.Table
 import Dict
 import Effect exposing (Effect)
 import FeatherIcons
-import Html exposing (Html, a, code, div, span, td, text, tr)
+import Html exposing (Html, a, div, span, td, text, tr)
 import Html.Attributes exposing (attribute, class)
 import Http
 import Http.Detailed
@@ -29,7 +27,6 @@ import Route.Path
 import Shared
 import Svg.Attributes
 import Time
-import Utils.Ansi
 import Utils.Errors as Errors
 import Utils.Helpers as Util
 import Utils.Interval as Interval
@@ -393,21 +390,12 @@ scheduleErrorRow schedule =
 viewScheduleError : Vela.Schedule -> Html msg
 viewScheduleError schedule =
     let
-        lines =
-            Utils.Ansi.decodeAnsi schedule.error
-                |> Array.map
-                    (\line ->
-                        Just <|
-                            Ansi.Log.viewLine line
-                    )
-                |> Array.toList
-                |> List.filterMap identity
-
         msgRow =
             tr [ class "error-data", Util.testAttribute "schedules-error" ]
                 [ td [ attribute "colspan" "6" ]
-                    [ code [ class "error-content" ]
-                        lines
+                    [ span
+                        [ class "error-content" ]
+                        [ text schedule.error ]
                     ]
                 ]
     in

--- a/src/elm/Pages/Org_/Repo_/Schedules.elm
+++ b/src/elm/Pages/Org_/Repo_/Schedules.elm
@@ -333,7 +333,7 @@ viewSchedule zone org repo schedule =
                 ]
             }
         , Components.Table.viewItemCell
-            { dataLabel = "cron expression"
+            { dataLabel = "cron-expression"
             , parentClassList = []
             , itemClassList = []
             , children =
@@ -357,7 +357,7 @@ viewSchedule zone org repo schedule =
                 ]
             }
         , Components.Table.viewItemCell
-            { dataLabel = "scheduled at"
+            { dataLabel = "scheduled-at"
             , parentClassList = []
             , itemClassList = []
             , children =
@@ -365,14 +365,14 @@ viewSchedule zone org repo schedule =
                 ]
             }
         , Components.Table.viewItemCell
-            { dataLabel = "updated by"
+            { dataLabel = "updated-by"
             , parentClassList = []
             , itemClassList = []
             , children =
                 [ text schedule.updated_by ]
             }
         , Components.Table.viewItemCell
-            { dataLabel = "updated at"
+            { dataLabel = "updated-at"
             , parentClassList = []
             , itemClassList = []
             , children =

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -357,6 +357,31 @@ type alias Repository =
     }
 
 
+emptyRepository : Repository
+emptyRepository =
+    { id = -1
+    , user_id = -1
+    , owner = emptyUser
+    , org = ""
+    , name = ""
+    , full_name = ""
+    , link = ""
+    , clone = ""
+    , branch = ""
+    , limit = 0
+    , timeout = 0
+    , counter = 0
+    , visibility = ""
+    , approve_build = ""
+    , private = False
+    , trusted = False
+    , active = False
+    , allowEvents = defaultAllowEvents
+    , enabled = Disabled
+    , pipeline_type = ""
+    }
+
+
 decodeRepository : Decoder Repository
 decodeRepository =
     Json.Decode.succeed Repository
@@ -1519,8 +1544,7 @@ decodeHooks =
 
 type alias Schedule =
     { id : Int
-    , org : String
-    , repo : String
+    , repo : Repository
     , name : String
     , entry : String
     , enabled : Bool
@@ -1561,8 +1585,7 @@ decodeSchedule : Decoder Schedule
 decodeSchedule =
     Json.Decode.succeed Schedule
         |> optional "id" int -1
-        |> optional "repo.org" string ""
-        |> optional "repo.repo" string ""
+        |> optional "repo" decodeRepository emptyRepository
         |> optional "name" string ""
         |> optional "entry" string ""
         |> optional "active" bool False

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -1523,6 +1523,7 @@ type alias Schedule =
     , updated_at : Int
     , updated_by : String
     , branch : String
+    , error : String
     }
 
 
@@ -1533,6 +1534,7 @@ type alias SchedulePayload =
     , entry : Maybe String
     , enabled : Maybe Bool
     , branch : Maybe String
+    , error : Maybe String
     }
 
 
@@ -1544,6 +1546,7 @@ defaultSchedulePayload =
     , entry = Nothing
     , enabled = Nothing
     , branch = Nothing
+    , error = Nothing
     }
 
 
@@ -1562,6 +1565,7 @@ decodeSchedule =
         |> optional "updated_at" int 0
         |> optional "updated_by" string ""
         |> optional "branch" string ""
+        |> optional "error" string ""
 
 
 decodeSchedules : Decoder (List Schedule)


### PR DESCRIPTION
### Description
Whenever a user has a YAML bug in their pipeline, or any other build-breaking error that short-circuits pipeline execution, they can usually find these error in the Audit tab, where we populate the hook with the error message.

This is currently not available for schedules. Instead, the error is just logged.

### Desired View
<img width="1701" alt="Screenshot 2024-04-26 at 10 37 57 AM" src="https://github.com/go-vela/server/assets/26553607/f7627e81-d17a-4def-b4cf-29ebdfdf7b71">

### Related
https://github.com/go-vela/community/issues/872