### PR TITLE
fix: revert html code removal

### DIFF
--- a/src/elm/Pages/Org_/Repo_/Hooks.elm
+++ b/src/elm/Pages/Org_/Repo_/Hooks.elm
@@ -20,6 +20,7 @@ import Html
         , div
         , span
         , td
+        , code
         , text
         , tr
         )
@@ -454,7 +455,7 @@ viewHookError hook =
                 _ ->
                     tr [ class "error-data", Util.testAttribute "hooks-error" ]
                         [ td [ attribute "colspan" "6" ]
-                            [ span
+                            [ code
                                 [ class "error-content" ]
                                 [ text hook.error ]
                             ]

--- a/src/elm/Pages/Org_/Repo_/Schedules.elm
+++ b/src/elm/Pages/Org_/Repo_/Schedules.elm
@@ -14,8 +14,22 @@ import Components.Table
 import Dict
 import Effect exposing (Effect)
 import FeatherIcons
-import Html exposing (Html, a, div, span, td, text, tr)
-import Html.Attributes exposing (attribute, class)
+import Html
+    exposing
+        ( Html
+        , a
+        , code
+        , div
+        , span
+        , td
+        , text
+        , tr
+        )
+import Html.Attributes
+    exposing
+        ( attribute
+        , class
+        )
 import Http
 import Http.Detailed
 import Layouts
@@ -413,7 +427,7 @@ viewScheduleError schedule =
         msgRow =
             tr [ class "error-data", Util.testAttribute "schedules-error" ]
                 [ td [ attribute "colspan" "6" ]
-                    [ span
+                    [ code
                         [ class "error-content" ]
                         [ text schedule.error ]
                     ]


### PR DESCRIPTION
code font element formatting was removed in https://github.com/go-vela/ui/pull/795
i believe this was by mistake when removing the ANSI decoding logic

see: https://github.com/go-vela/ui/commit/b316a3a24edc41be884781a057b5d9354dbfbafb#diff-19f75d1d3cece1112e0c3bd6fb133afb10330158cef9570a65f55385cd015fa0L450-L451