### PR TITLE
fix: stop double log fetch on steps/services

### DIFF
--- a/src/elm/Pages/Org_/Repo_/Build_.elm
+++ b/src/elm/Pages/Org_/Repo_/Build_.elm
@@ -460,16 +460,13 @@ update shared route msg model =
 
         ExpandStep options ->
             let
-                isFromHashChanged =
-                    options.previousFocus /= Nothing
-
-                focusChanged =
+                ( isFromHashChanged, didFocusChange ) =
                     case options.previousFocus of
                         Just f ->
-                            f.group /= model.focus.group
+                            ( True, f.group /= model.focus.group )
 
                         Nothing ->
-                            False
+                            ( False, False )
 
                 isLogLoaded =
                     Dict.get options.step.id model.logs
@@ -511,7 +508,7 @@ update shared route msg model =
                 runEffects =
                     [ -- fetch logs when the resource is expanded via header click
                       -- OR when the hash changes and the requested log is not loaded
-                      if (focusChanged && not isLogLoaded) || not isFromHashChanged then
+                      if (didFocusChange && not isLogLoaded) || not isFromHashChanged then
                         getLogEffect
 
                       else

--- a/src/elm/Pages/Org_/Repo_/Build_.elm
+++ b/src/elm/Pages/Org_/Repo_/Build_.elm
@@ -487,7 +487,7 @@ update shared route msg model =
 
                 -- hash will change when no line is selected and the selected group changes
                 -- this means expansion msg will double up on fetching logs unless instructed not to
-                willHashChange =
+                willFocusChange =
                     case ( model.focus.group, model.focus.a, model.focus.b ) of
                         ( Just g, Nothing, _ ) ->
                             g /= options.step.number
@@ -504,7 +504,7 @@ update shared route msg model =
                 -- triggered by a click that will change the hash
                 -- the focus changes and the logs are not loaded
                 fetchLogs =
-                    not (options.triggeredFromClick && willHashChange)
+                    not (options.triggeredFromClick && willFocusChange)
                         && ((didFocusChange && not isLogLoaded) || not isFromHashChanged)
 
                 getLogEffect =

--- a/src/elm/Pages/Org_/Repo_/Build_/Services.elm
+++ b/src/elm/Pages/Org_/Repo_/Build_/Services.elm
@@ -478,7 +478,7 @@ update shared route msg model =
 
                 -- hash will change when no line is selected and the selected group changes
                 -- this means the expansion msg will double up on fetching logs unless instructed not to
-                willHashChange =
+                willFocusChange =
                     case ( model.focus.group, model.focus.a, model.focus.b ) of
                         ( Just g, Nothing, _ ) ->
                             g /= options.service.number
@@ -495,7 +495,7 @@ update shared route msg model =
                 -- triggered by a click that will change the hash
                 -- the focus changes and the logs are not loaded
                 fetchLogs =
-                    not (options.triggeredFromClick && willHashChange)
+                    not (options.triggeredFromClick && willFocusChange)
                         && ((didFocusChange && not isLogLoaded) || not isFromHashChanged)
 
                 getLogEffect =

--- a/src/elm/Pages/Org_/Repo_/Build_/Services.elm
+++ b/src/elm/Pages/Org_/Repo_/Build_/Services.elm
@@ -451,16 +451,13 @@ update shared route msg model =
 
         ExpandService options ->
             let
-                isFromHashChanged =
-                    options.previousFocus /= Nothing
-
-                focusChanged =
+                ( isFromHashChanged, didFocusChange ) =
                     case options.previousFocus of
                         Just f ->
-                            f.group /= model.focus.group
+                            ( True, f.group /= model.focus.group )
 
                         Nothing ->
-                            False
+                            ( False, False )
 
                 isLogLoaded =
                     Dict.get options.service.id model.logs
@@ -502,7 +499,7 @@ update shared route msg model =
                 runEffects =
                     [ -- fetch logs when the resource is expanded via header click
                       -- OR when the hash changes and the requested log is not loaded
-                      if (focusChanged && not isLogLoaded) || not isFromHashChanged then
+                      if (didFocusChange && not isLogLoaded) || not isFromHashChanged then
                         getLogEffect
 
                       else

--- a/src/elm/Utils/Helpers.elm
+++ b/src/elm/Utils/Helpers.elm
@@ -26,7 +26,7 @@ module Utils.Helpers exposing
     , humanReadableDateTimeFormatter
     , humanReadableDateTimeWithDefault
     , humanReadableDateWithDefault
-    , isLoading
+    , isLoaded
     , isSuccess
     , mergeListsById
     , noBlanks
@@ -375,16 +375,19 @@ fiveSecondsMillis =
     oneSecondMillis * 5
 
 
-{-| isLoading : takes WebData and returns true if it is in a Loading state.
+{-| isLoaded : takes WebData and returns true if it is in a 'loaded' state, meaning its anything but NotAsked or Loading.
 -}
-isLoading : WebData a -> Bool
-isLoading status =
+isLoaded : WebData a -> Bool
+isLoaded status =
     case status of
         RemoteData.Loading ->
-            True
+            False
+
+        RemoteData.NotAsked ->
+            False
 
         _ ->
-            False
+            True
 
 
 {-| isSuccess : takes WebData and returns true if it is in a Success state.


### PR DESCRIPTION
while testing #810 i noticed that logs are called twice when you click on a step/service header, this is unintended side effect of tracking `OnHashChanged` events and using that to fetch logs without an extra check

does not impact refreshes, but still better than doing double calls for no reason. 