### PR TITLE
fix: allow starlark limit to be customized

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,6 @@ VELA_API=http://localhost:8080
 # default: 99999
 # VELA_MAX_STARLARK_EXEC_LIMIT=
 
-
 # customize the set of repos that are allowed to use schedules
 #
 # default: *

--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,12 @@ VELA_API=http://localhost:8080
 # default: 30
 # VELA_MAX_BUILD_LIMIT=
 
+# customize the max number of starlark exec steps that the UI will allow an admin to configure
+#
+# default: 99999
+# VELA_MAX_STARLARK_EXEC_LIMIT=
+
+
 # customize the set of repos that are allowed to use schedules
 #
 # default: *

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -eu
 for f in /usr/share/nginx/html/*.js
 do
     # shellcheck disable=SC2016
-    envsubst '${VELA_API},${VELA_DOCS_URL},${VELA_FEEDBACK_URL},${VELA_MAX_BUILD_LIMIT},${VELA_SCHEDULE_ALLOWLIST}' < "$f" > "$f".tmp && mv "$f".tmp "$f"
+    envsubst '${VELA_API},${VELA_DOCS_URL},${VELA_FEEDBACK_URL},${VELA_MAX_BUILD_LIMIT},${VELA_MAX_STARLARK_EXEC_LIMIT},${VELA_SCHEDULE_ALLOWLIST}' < "$f" > "$f".tmp && mv "$f".tmp "$f"
 done
 
 NGINX_CONF=/etc/nginx/conf.d/default.conf

--- a/src/elm/Pages/Admin/Settings.elm
+++ b/src/elm/Pages/Admin/Settings.elm
@@ -876,14 +876,14 @@ view shared route model =
                 [ viewFieldHeader "Starlark Exec Limit"
                 , viewFieldDescription "The number of executions allowed for Starlark scripts."
                 , viewFieldEnvKeyValue "VELA_COMPILER_STARLARK_EXEC_LIMIT"
-                , viewFieldLimits <| text <| numberBoundsToString starlarkExecLimitMin starlarkExecLimitMax
+                , viewFieldLimits <| text <| numberBoundsToString starlarkExecLimitMin <| starlarkExecLimitMax shared
                 , div [ class "form-controls" ]
                     [ Components.Form.viewNumberInput
                         { title = Nothing
                         , subtitle = Nothing
                         , id_ = starlarkExecLimitHtmlId
                         , val = model.starlarkExecLimitIn
-                        , placeholder_ = numberBoundsToString starlarkExecLimitMin starlarkExecLimitMax
+                        , placeholder_ = numberBoundsToString starlarkExecLimitMin <| starlarkExecLimitMax shared
                         , wrapperClassList = [ ( "-wide", True ) ]
                         , classList_ = []
                         , rows_ = Nothing
@@ -891,7 +891,7 @@ view shared route model =
                         , msg = StarlarkExecLimitOnInput
                         , disabled_ = False
                         , min = Just starlarkExecLimitMin
-                        , max = Just starlarkExecLimitMax
+                        , max = Just <| starlarkExecLimitMax shared
                         }
                     , Components.Form.viewButton
                         { id_ = starlarkExecLimitHtmlId ++ "-update"
@@ -908,7 +908,7 @@ view shared route model =
                                             limit
                                                 == s.compiler.starlarkExecLimit
                                                 || (limit < starlarkExecLimitMin)
-                                                || (limit > starlarkExecLimitMax)
+                                                || (limit > starlarkExecLimitMax shared)
 
                                         Nothing ->
                                             True
@@ -1269,6 +1269,6 @@ starlarkExecLimitMin =
 
 {-| starlarkExecLimitMax : returns the maximum value for the starlark exec limit
 -}
-starlarkExecLimitMax : Int
-starlarkExecLimitMax =
-    99999
+starlarkExecLimitMax : Shared.Model -> Int
+starlarkExecLimitMax shared =
+    shared.velaMaxStarlarkExecLimit

--- a/src/elm/Pages/Admin/Settings.elm
+++ b/src/elm/Pages/Admin/Settings.elm
@@ -1271,4 +1271,4 @@ starlarkExecLimitMin =
 -}
 starlarkExecLimitMax : Int
 starlarkExecLimitMax =
-    9999
+    99999

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -57,6 +57,7 @@ type alias Flags =
     , velaRedirect : String
     , velaLogBytesLimit : Int
     , velaMaxBuildLimit : Int
+    , velaMaxStarlarkExecLimit : Int
     , velaScheduleAllowlist : String
     }
 
@@ -72,6 +73,7 @@ decoder =
         |> required "velaRedirect" Json.Decode.string
         |> required "velaLogBytesLimit" Json.Decode.int
         |> required "velaMaxBuildLimit" Json.Decode.int
+        |> required "velaMaxStarlarkExecLimit" Json.Decode.int
         |> required "velaScheduleAllowlist" Json.Decode.string
 
 
@@ -95,6 +97,7 @@ init flagsResult route =
                     , velaRedirect = ""
                     , velaLogBytesLimit = 0
                     , velaMaxBuildLimit = 0
+                    , velaMaxStarlarkExecLimit = 0
                     , velaScheduleAllowlist = ""
                     }
 
@@ -134,6 +137,7 @@ init flagsResult route =
       , velaRedirect = flags.velaRedirect
       , velaLogBytesLimit = flags.velaLogBytesLimit
       , velaMaxBuildLimit = flags.velaMaxBuildLimit
+      , velaMaxStarlarkExecLimit = flags.velaMaxStarlarkExecLimit
       , velaScheduleAllowlist = Util.stringToAllowlist flags.velaScheduleAllowlist
 
       -- BASE URL

--- a/src/elm/Shared/Model.elm
+++ b/src/elm/Shared/Model.elm
@@ -26,6 +26,7 @@ type alias Model =
     , velaRedirect : String
     , velaLogBytesLimit : Int
     , velaMaxBuildLimit : Int
+    , velaMaxStarlarkExecLimit : Int
     , velaScheduleAllowlist : List ( String, String )
 
     -- BASE URL

--- a/src/static/index.d.ts
+++ b/src/static/index.d.ts
@@ -56,6 +56,8 @@ export type Flags = {
   readonly velaLogBytesLimit: number;
   /** @property velaMaxBuildLimit: number */
   readonly velaMaxBuildLimit: number;
+  /** @property velaMaxStarlarkExecLimit: number */
+  readonly velaMaxStarlarkExecLimit: number;
   /** @property velaScheduleAllowlist: string */
   readonly velaScheduleAllowlist: string;
 };

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -16,6 +16,7 @@ const feedbackURL: string =
 const docsURL: string = 'https://go-vela.github.io/docs';
 const defaultLogBytesLimit: number = 2000000; // 2mb
 const maximumBuildLimit: number = 30;
+const maximumStarlarkExecLimit: number = 99999;
 const scheduleAllowlist: string = '*';
 
 // setup for auth redirect
@@ -51,10 +52,14 @@ const flags: Flags = {
   ),
   velaMaxBuildLimit: Number(
     process.env.VELA_MAX_BUILD_LIMIT ||
-      envOrNull('VELA_MAX_BUILD_LIMIT', 'VELA_MAX_BUILD_LIMIT') ||
+      envOrNull('VELA_MAX_BUILD_LIMIT', '$VELA_MAX_BUILD_LIMIT') ||
       maximumBuildLimit,
   ),
-
+  velaMaxStarlarkExecLimit: Number(
+    process.env.VELA_MAX_STARLARK_EXEC_LIMIT ||
+      envOrNull('VELA_MAX_STARLARK_EXEC_LIMIT', '$VELA_MAX_STARLARK_EXEC_LIMIT') ||
+      maximumStarlarkExecLimit,
+  ),
   velaScheduleAllowlist:
     (window.Cypress && window.Cypress.env('VELA_SCHEDULE_ALLOWLIST')) ||
     process.env.VELA_SCHEDULE_ALLOWLIST ||

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -57,7 +57,10 @@ const flags: Flags = {
   ),
   velaMaxStarlarkExecLimit: Number(
     process.env.VELA_MAX_STARLARK_EXEC_LIMIT ||
-      envOrNull('VELA_MAX_STARLARK_EXEC_LIMIT', '$VELA_MAX_STARLARK_EXEC_LIMIT') ||
+      envOrNull(
+        'VELA_MAX_STARLARK_EXEC_LIMIT',
+        '$VELA_MAX_STARLARK_EXEC_LIMIT',
+      ) ||
       maximumStarlarkExecLimit,
   ),
   velaScheduleAllowlist:


### PR DESCRIPTION
i knew this would come back to bite. we tried updating it LIVE to 20k but had to use the API.

this PR bumps the default limit to `99999` and also adds `VELA_MAX_STARLARK_EXEC_LIMIT` as an available variable to allow this to be decreased or increased based on how admins have their server installed.
