### PR TITLE
enhance(dashboards): show user's dashboards

### DIFF
--- a/cypress/fixtures/user_dashboards.json
+++ b/cypress/fixtures/user_dashboards.json
@@ -1,0 +1,63 @@
+[
+  {
+    "dashboard": {
+      "id": "6e26a6d0-2fc3-4531-a04d-678a58135288",
+      "name": "demo dashboard",
+      "created_at": 1726757028,
+      "created_by": "CookieCat",
+      "updated_at": 1726757028,
+      "updated_by": "CookieCat",
+      "admins": [
+        {
+          "id": 1,
+          "name": "CookieCat",
+          "active": true
+        }
+      ],
+      "repos": [
+        {
+          "id": 1,
+          "name": "github/repo1"
+        }
+      ]
+    },
+    "repos": [
+      {
+        "org": "github",
+        "name": "repo1",
+        "counter": 1,
+        "active": true,
+        "builds": [
+          {
+            "number": 1,
+            "started": 1726757097,
+            "sender": "CookieCat",
+            "ref": "refs/heads/main",
+            "status": "running",
+            "event": "push",
+            "branch": "master",
+            "link": "http://vela.example.com/github/repo1/1"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "dashboard": {
+      "id": "c4e8f563-4784-4b4b-9534-3007d579dc2a",
+      "name": "another demo dashboard",
+      "created_at": 1726757636,
+      "created_by": "CookieCat",
+      "updated_at": 1726757636,
+      "updated_by": "CookieCat",
+      "admins": [
+        {
+          "id": 1,
+          "name": "CookieCat",
+          "active": true
+        }
+      ],
+      "repos": []
+    }
+  }
+]

--- a/cypress/integration/dashboards.spec.js
+++ b/cypress/integration/dashboards.spec.js
@@ -3,7 +3,7 @@
  */
 
 context('Dashboards', () => {
-  context('main dashboards page shows message', () => {
+  context('main dashboards page', () => {
     beforeEach(() => {
       cy.server();
       cy.route(
@@ -12,10 +12,6 @@ context('Dashboards', () => {
         'fixture:user_dashboards.json',
       );
       cy.login('/dashboards');
-    });
-
-    it('shows the welcome message', () => {
-      cy.get('[data-test=dashboards]').contains('Dashboards');
     });
 
     it('shows the list of dashboards', () => {
@@ -164,17 +160,6 @@ context('Dashboards', () => {
       cy.get('[data-test=dashboard]').contains(
         'Dashboard "deadbeef" not found. Please check the URL.',
       );
-    });
-  });
-
-  context('main dashboards page shows message', () => {
-    beforeEach(() => {
-      cy.server();
-      cy.login('/dashboards');
-    });
-
-    it('shows the welcome message', () => {
-      cy.get('[data-test=dashboards]').contains('Welcome to dashboards!');
     });
   });
 });

--- a/cypress/integration/dashboards.spec.js
+++ b/cypress/integration/dashboards.spec.js
@@ -3,6 +3,60 @@
  */
 
 context('Dashboards', () => {
+  context('main dashboards page shows message', () => {
+    beforeEach(() => {
+      cy.server();
+      cy.route(
+        'GET',
+        '*api/v1/user/dashboards',
+        'fixture:user_dashboards.json',
+      );
+      cy.login('/dashboards');
+    });
+
+    it('shows the welcome message', () => {
+      cy.get('[data-test=dashboards]').contains('Dashboards');
+    });
+
+    it('shows the list of dashboards', () => {
+      cy.get('[data-test=dashboard-item]').should('have.length', 2);
+    });
+
+    it('shows the repos within a dashboard', () => {
+      cy.get('[data-test=dashboard-repos]').first().contains('github/repo1');
+    });
+
+    it('shows a message when there are no repos', () => {
+      cy.get('[data-test=dashboard-repos]')
+        .eq(1)
+        .contains('No repositories in this dashboard');
+    });
+
+    it('clicking dashoard name navigates to dashboard page', () => {
+      cy.get('[data-test=dashboard-item]')
+        .first()
+        .within(() => {
+          cy.get('a').first().click();
+          cy.location('pathname').should(
+            'eq',
+            '/dashboards/6e26a6d0-2fc3-4531-a04d-678a58135288',
+          );
+        });
+    });
+  });
+
+  context('main dashboards page shows message', () => {
+    beforeEach(() => {
+      cy.server();
+      cy.route(
+        'GET',
+        '*api/v1/user/dashboards',
+        'fixture:user_dashboards.json',
+      );
+      cy.login('/dashboards');
+    });
+  });
+
   context('server returns dashboard with 3 cards, one without builds', () => {
     beforeEach(() => {
       cy.server();

--- a/src/elm/Api/Endpoint.elm
+++ b/src/elm/Api/Endpoint.elm
@@ -26,6 +26,7 @@ type Endpoint
     | Logout
     | CurrentUser
     | Dashboard String
+    | Dashboards
     | Deployment Vela.Org Vela.Repo (Maybe String)
     | Deployments (Maybe Pagination.Page) (Maybe Pagination.PerPage) Vela.Org Vela.Repo
     | Token
@@ -163,6 +164,9 @@ toUrl api endpoint =
 
         Deployments maybePage maybePerPage org repo ->
             url api [ "deployments", org, repo ] <| Pagination.toQueryParams maybePage maybePerPage
+
+        Dashboards ->
+            url api [ "user", "dashboards" ] []
 
         Dashboard dashboard ->
             url api [ "dashboards", dashboard ] []

--- a/src/elm/Api/Operations.elm
+++ b/src/elm/Api/Operations.elm
@@ -30,6 +30,7 @@ module Api.Operations exposing
     , getBuildSteps
     , getCurrentUser
     , getDashboard
+    , getDashboards
     , getOrgBuilds
     , getOrgRepos
     , getOrgSecret
@@ -1315,4 +1316,17 @@ getDashboard baseUrl session options =
             options.dashboardId
         )
         Vela.decodeDashboard
+        |> withAuth session
+
+
+{-| getDashboards : retrieves the dashboards for the current user.
+-}
+getDashboards :
+    String
+    -> Session
+    -> Request (List Vela.Dashboard)
+getDashboards baseUrl session =
+    get baseUrl
+        Api.Endpoint.Dashboards
+        Vela.decodeDashboards
         |> withAuth session

--- a/src/elm/Effect.elm
+++ b/src/elm/Effect.elm
@@ -9,7 +9,7 @@ module Effect exposing
     , sendCmd, sendMsg
     , pushRoute, replaceRoute, loadExternalUrl
     , map, toCmd
-    , addAlertError, addAlertSuccess, addDeployment, addFavorites, addOrgSecret, addRepoSchedule, addRepoSecret, addSharedSecret, alertsUpdate, approveBuild, cancelBuild, chownRepo, clearRedirect, deleteOrgSecret, deleteRepoSchedule, deleteRepoSecret, deleteSharedSecret, disableRepo, downloadFile, enableRepo, expandPipelineConfig, finishAuthentication, focusOn, getAllBuildServices, getAllBuildSteps, getBuild, getBuildGraph, getBuildServiceLog, getBuildServices, getBuildStepLog, getBuildSteps, getCurrentUser, getCurrentUserShared, getDashboard, getOrgBuilds, getOrgRepos, getOrgSecret, getOrgSecrets, getPipelineConfig, getPipelineTemplates, getRepo, getRepoBuilds, getRepoBuildsShared, getRepoDeployments, getRepoHooks, getRepoHooksShared, getRepoSchedule, getRepoSchedules, getRepoSecret, getRepoSecrets, getSettings, getSharedSecret, getSharedSecrets, getWorkers, handleHttpError, logout, pushPath, redeliverHook, repairRepo, replacePath, replaceRouteRemoveTabHistorySkipDomFocus, restartBuild, setRedirect, setTheme, updateFavicon, updateFavorite, updateOrgSecret, updateRepo, updateRepoHooksShared, updateRepoSchedule, updateRepoSecret, updateSettings, updateSharedSecret, updateSourceReposShared
+    , addAlertError, addAlertSuccess, addDeployment, addFavorites, addOrgSecret, addRepoSchedule, addRepoSecret, addSharedSecret, alertsUpdate, approveBuild, cancelBuild, chownRepo, clearRedirect, deleteOrgSecret, deleteRepoSchedule, deleteRepoSecret, deleteSharedSecret, disableRepo, downloadFile, enableRepo, expandPipelineConfig, finishAuthentication, focusOn, getAllBuildServices, getAllBuildSteps, getBuild, getBuildGraph, getBuildServiceLog, getBuildServices, getBuildStepLog, getBuildSteps, getCurrentUser, getCurrentUserShared, getDashboard, getDashboards, getOrgBuilds, getOrgRepos, getOrgSecret, getOrgSecrets, getPipelineConfig, getPipelineTemplates, getRepo, getRepoBuilds, getRepoBuildsShared, getRepoDeployments, getRepoHooks, getRepoHooksShared, getRepoSchedule, getRepoSchedules, getRepoSecret, getRepoSecrets, getSettings, getSharedSecret, getSharedSecrets, getWorkers, handleHttpError, logout, pushPath, redeliverHook, repairRepo, replacePath, replaceRouteRemoveTabHistorySkipDomFocus, restartBuild, setRedirect, setTheme, updateFavicon, updateFavorite, updateOrgSecret, updateRepo, updateRepoHooksShared, updateRepoSchedule, updateRepoSecret, updateSettings, updateSharedSecret, updateSourceReposShared
     )
 
 {-|
@@ -1382,5 +1382,21 @@ getDashboard options =
             options.baseUrl
             options.session
             options
+        )
+        |> sendCmd
+
+
+getDashboards :
+    { baseUrl : String
+    , session : Auth.Session.Session
+    , onResponse : Result (Http.Detailed.Error String) ( Http.Metadata, List Vela.Dashboard ) -> msg
+    }
+    -> Effect msg
+getDashboards options =
+    Api.try
+        options.onResponse
+        (Api.Operations.getDashboards
+            options.baseUrl
+            options.session
         )
         |> sendCmd

--- a/src/elm/Layouts/Default/Org.elm
+++ b/src/elm/Layouts/Default/Org.elm
@@ -137,6 +137,13 @@ view props shared route { toContentMsg, model, content } =
                     ++ [ a
                             [ class "button"
                             , class "-outline"
+                            , Util.testAttribute "dashboards-button"
+                            , Route.Path.href Route.Path.Dashboards
+                            ]
+                            [ text "Dashboards" ]
+                       , a
+                            [ class "button"
+                            , class "-outline"
                             , Util.testAttribute "source-repos"
                             , Route.Path.href Route.Path.Account_SourceRepos
                             ]

--- a/src/elm/Pages/Dashboards.elm
+++ b/src/elm/Pages/Dashboards.elm
@@ -281,8 +281,11 @@ viewDashboardRepos repos dashboardId =
                             , text (repo.org ++ "/" ++ repo.name ++ " (" ++ String.fromInt (List.length repo.builds) ++ ")")
                             ]
                     )
-            
-        else
-            [ text <| "⚠️ No repositories in this dashboard. Use the CLI to add some: vela update dashboard --id "
-                ++ dashboardId ++ " --add-repos org/repo" ]
+
+         else
+            [ text <|
+                "⚠️ No repositories in this dashboard. Use the CLI to add some: vela update dashboard --id "
+                    ++ dashboardId
+                    ++ " --add-repos org/repo"
+            ]
         )

--- a/src/elm/Pages/Dashboards.elm
+++ b/src/elm/Pages/Dashboards.elm
@@ -9,8 +9,9 @@ import Auth
 import Components.Crumbs
 import Components.Loading
 import Components.Nav
+import Components.Svgs
 import Effect exposing (Effect)
-import Html exposing (Html, a, code, div, h1, h2, hr, li, main_, p, span, text, ul)
+import Html exposing (Html, a, code, div, h1, h2, li, main_, p, span, text, ul)
 import Html.Attributes exposing (class)
 import Http
 import Http.Detailed
@@ -244,8 +245,10 @@ viewDashboards dashboards =
                             |> Route.Path.href
                 in
                 div [ class "item" ]
-                    [ a [ dashboardLink ]
-                        [ text dashboard.dashboard.name ]
+                    [ span [ class "dashboard-item-title" ]
+                        [ a [ dashboardLink ] [ text dashboard.dashboard.name ]
+                        , code [] [ text dashboard.dashboard.id ]
+                        ]
                     , div [ class "buttons" ]
                         [ a [ class "button", dashboardLink ] [ text "View" ]
                         ]
@@ -254,7 +257,7 @@ viewDashboards dashboards =
             )
 
 
-{-| viewDashboards : renders a list of repos belonging to a dashboard.
+{-| viewDashboardRepos : renders a list of repos belonging to a dashboard.
 -}
 viewDashboardRepos : List Vela.DashboardRepoCard -> Html Msg
 viewDashboardRepos repos =
@@ -262,6 +265,19 @@ viewDashboardRepos repos =
         (repos
             |> List.map
                 (\repo ->
-                    div [ class "dashboard-repos-item" ] [ text (repo.org ++ "/" ++ repo.name ++ " (" ++ String.fromInt (List.length repo.builds) ++ ")") ]
+                    let
+                        statusIcon =
+                            case List.head repo.builds of
+                                Just build ->
+                                    Components.Svgs.recentBuildStatusToIcon build.status 0
+
+                                Nothing ->
+                                    Components.Svgs.recentBuildStatusToIcon Vela.Pending 0
+                    in
+                    div
+                        [ class "dashboard-repos-item" ]
+                        [ statusIcon
+                        , text (repo.org ++ "/" ++ repo.name ++ " (" ++ String.fromInt (List.length repo.builds) ++ ")")
+                        ]
                 )
         )

--- a/src/elm/Pages/Dashboards.elm
+++ b/src/elm/Pages/Dashboards.elm
@@ -10,7 +10,7 @@ import Components.Crumbs
 import Components.Loading
 import Components.Nav
 import Effect exposing (Effect)
-import Html exposing (Html, a, code, div, h1, h2, li, main_, p, span, text, ul)
+import Html exposing (Html, a, code, div, h1, h2, hr, li, main_, p, span, text, ul)
 import Html.Attributes exposing (class)
 import Http
 import Http.Detailed
@@ -175,16 +175,13 @@ view shared route model =
                 case model.dashboards of
                     RemoteData.Success dashboards ->
                         if List.length dashboards > 0 then
-                            [ div []
+                            [ div [ class "dashboards" ]
                                 [ h1 [] [ text "BETA something" ]
                                 , h2 [] [ text "Dashboards" ]
                                 , p [] [ text "UI Dashboard functionality is very minimal in this Vela version." ]
                                 , ul []
                                     [ li []
                                         [ text "Manage dashboards with the CLI or API"
-                                        ]
-                                    , li []
-                                        [ text "Dashboard names do not display on this page yet"
                                         ]
                                     , li []
                                         [ text "You'll only see dashboards you created"
@@ -242,12 +239,15 @@ view shared route model =
 -}
 viewDashboards : List Vela.Dashboard -> Html Msg
 viewDashboards dashboards =
-    div []
+    div [ class "repo-list" ]
         (List.map
             (\dashboard ->
-                div []
+                div [ class "item" ]
                     [ a [ Route.Path.href <| Route.Path.Dashboards_Dashboard_ { dashboard = dashboard.dashboard.id } ]
                         [ text dashboard.dashboard.name ]
+                    , div [ class "buttons" ]
+                        [ a [ class "button", Route.Path.href <| Route.Path.Dashboards_Dashboard_ { dashboard = dashboard.dashboard.id } ] [ text "View" ]
+                        ]
                     ]
             )
             dashboards

--- a/src/elm/Pages/Dashboards.elm
+++ b/src/elm/Pages/Dashboards.elm
@@ -176,36 +176,26 @@ view shared route model =
                     RemoteData.Success dashboards ->
                         if List.length dashboards > 0 then
                             [ div [ class "dashboards" ]
-                                [ h1 [] [ text "BETA something" ]
-                                , h2 [] [ text "Dashboards" ]
-                                , p [] [ text "UI Dashboard functionality is very minimal in this Vela version." ]
+                                [ h1 [] [ text "Dashboards (beta)" ]
+                                , viewDashboards dashboards
+                                , h2 [] [ text "🧪 Beta Limitations" ]
+                                , p [] [ text "This is an early version of Dashboards. Please be aware of the following:" ]
                                 , ul []
-                                    [ li []
-                                        [ text "Manage dashboards with the CLI or API"
-                                        ]
-                                    , li []
-                                        [ text "You'll only see dashboards you created"
-                                        ]
-                                    , li []
-                                        [ text "You won't see dashboards that were shared with you, or you were added to as an admin; so you might want to save those links!"
-                                        ]
+                                    [ li [] [ text "You have to use CLI/API to manage dashboards" ]
+                                    , li [] [ text "You can only list dashboards you created" ]
+                                    , li [] [ text "Bookmark or save links to dashboards you didn't create" ]
                                     ]
                                 , h2 [] [ text "💬 Got Feedback?" ]
-                                , p [] [ text "Follow the feedback link in the top right to let us know your thoughts and ideas. We really need your feedback on the whole dashboard experience to prioritize what we'll focus on for the next version." ]
-                                , viewDashboards dashboards
+                                , p [] [ text "Help us shape Dashboards. What do you want to see? Use the \"feedback\" link in the top right!" ]
                                 ]
                             ]
 
                         else
                             [ div [ class "dashboards" ]
-                                [ h1 [] [ text "Welcome to dashboards!" ]
+                                [ h1 [] [ text "Welcome to Dashboards (beta)!" ]
                                 , h2 [] [ text "✨ Want to create a new dashboard?" ]
                                 , p [] [ text "Use the Vela CLI to add a new dashboard:" ]
                                 , code [ class "shell" ] [ text "vela add dashboard --help" ]
-                                , h2 [] [ text "🚀 Already have a dashboard?" ]
-                                , p [] [ text "Check your available dashboards with:" ]
-                                , code [ class "shell" ] [ text "vela get dashboards" ]
-                                , p [] [ text "Take note of your dashboard ID you are interested in and and add it to the current URL to view it." ]
                                 , h2 [] [ text "💬 Got Feedback?" ]
                                 , p [] [ text "Follow the link in the top right to let us know your thoughts and ideas." ]
                                 ]

--- a/src/elm/Pages/Dashboards.elm
+++ b/src/elm/Pages/Dashboards.elm
@@ -244,7 +244,7 @@ viewDashboards dashboards =
                         Route.Path.Dashboards_Dashboard_ { dashboard = dashboard.dashboard.id }
                             |> Route.Path.href
                 in
-                div [ class "item" ]
+                div [ class "item", Util.testAttribute "dashboard-item" ]
                     [ span [ class "dashboard-item-title" ]
                         [ a [ dashboardLink ] [ text dashboard.dashboard.name ]
                         , code [] [ text dashboard.dashboard.id ]
@@ -252,32 +252,37 @@ viewDashboards dashboards =
                     , div [ class "buttons" ]
                         [ a [ class "button", dashboardLink ] [ text "View" ]
                         ]
-                    , viewDashboardRepos dashboard.repos
+                    , viewDashboardRepos dashboard.repos dashboard.dashboard.id
                     ]
             )
 
 
 {-| viewDashboardRepos : renders a list of repos belonging to a dashboard.
 -}
-viewDashboardRepos : List Vela.DashboardRepoCard -> Html Msg
-viewDashboardRepos repos =
-    div [ class "dashboard-repos" ]
-        (repos
-            |> List.map
-                (\repo ->
-                    let
-                        statusIcon =
-                            case List.head repo.builds of
-                                Just build ->
-                                    Components.Svgs.recentBuildStatusToIcon build.status 0
+viewDashboardRepos : List Vela.DashboardRepoCard -> String -> Html Msg
+viewDashboardRepos repos dashboardId =
+    div [ class "dashboard-repos", Util.testAttribute "dashboard-repos" ]
+        (if List.length repos > 0 then
+            repos
+                |> List.map
+                    (\repo ->
+                        let
+                            statusIcon =
+                                case List.head repo.builds of
+                                    Just build ->
+                                        Components.Svgs.recentBuildStatusToIcon build.status 0
 
-                                Nothing ->
-                                    Components.Svgs.recentBuildStatusToIcon Vela.Pending 0
-                    in
-                    div
-                        [ class "dashboard-repos-item" ]
-                        [ statusIcon
-                        , text (repo.org ++ "/" ++ repo.name ++ " (" ++ String.fromInt (List.length repo.builds) ++ ")")
-                        ]
-                )
+                                    Nothing ->
+                                        Components.Svgs.recentBuildStatusToIcon Vela.Pending 0
+                        in
+                        div
+                            [ class "dashboard-repos-item" ]
+                            [ statusIcon
+                            , text (repo.org ++ "/" ++ repo.name ++ " (" ++ String.fromInt (List.length repo.builds) ++ ")")
+                            ]
+                    )
+            
+        else
+            [ text <| "⚠️ No repositories in this dashboard. Use the CLI to add some: vela update dashboard --id "
+                ++ dashboardId ++ " --add-repos org/repo" ]
         )

--- a/src/elm/Pages/Dashboards.elm
+++ b/src/elm/Pages/Dashboards.elm
@@ -278,7 +278,7 @@ viewDashboardRepos repos dashboardId =
                         div
                             [ class "dashboard-repos-item" ]
                             [ statusIcon
-                            , text (repo.org ++ "/" ++ repo.name ++ " (" ++ String.fromInt (List.length repo.builds) ++ ")")
+                            , text (repo.org ++ "/" ++ repo.name)
                             ]
                     )
 

--- a/src/elm/Pages/Dashboards/Dashboard_.elm
+++ b/src/elm/Pages/Dashboards/Dashboard_.elm
@@ -36,7 +36,6 @@ import Route.Path
 import Shared
 import Time
 import Utils.Errors as Errors
-import Utils.Favicons as Favicons
 import Utils.Helpers as Util
 import Utils.Interval as Interval
 import Vela

--- a/src/elm/Pages/Dashboards/Dashboard_.elm
+++ b/src/elm/Pages/Dashboards/Dashboard_.elm
@@ -201,7 +201,7 @@ view shared route model =
 
         crumbs =
             [ ( "Overview", Just Route.Path.Home_ )
-            , ( "Dashboards", Nothing )
+            , ( "Dashboards", Just Route.Path.Dashboards )
             , ( dashboardName, Nothing )
             ]
     in

--- a/src/elm/Pages/Home_.elm
+++ b/src/elm/Pages/Home_.elm
@@ -174,6 +174,13 @@ view shared route model =
                 [ a
                     [ class "button"
                     , class "-outline"
+                    , Util.testAttribute "dashboards-button"
+                    , Route.Path.href Route.Path.Dashboards
+                    ]
+                    [ text "Dashboards" ]
+                , a
+                    [ class "button"
+                    , class "-outline"
                     , Util.testAttribute "source-repos"
                     , Route.Path.href Route.Path.Account_SourceRepos
                     ]

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -259,6 +259,7 @@ type alias User =
     { id : Int
     , name : String
     , favorites : List String
+    , dashboards : List String
     , active : Bool
     , admin : Bool
     }
@@ -270,13 +271,14 @@ decodeUser =
         |> required "id" int
         |> required "name" string
         |> optional "favorites" (Json.Decode.list string) []
+        |> optional "dashboards" (Json.Decode.list string) []
         |> required "active" bool
         |> optional "admin" bool False
 
 
 emptyUser : User
 emptyUser =
-    { id = -1, name = "", favorites = [], active = False, admin = False }
+    { id = -1, name = "", favorites = [], dashboards = [], active = False, admin = False }
 
 
 type alias UpdateUserPayload =

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -210,6 +210,7 @@ type alias DashboardRepoCard =
     { org : String
     , name : String
     , counter : Int
+    , active : Bool
     , builds : List Build
     }
 
@@ -245,6 +246,7 @@ decodeDashboardRepoCard =
         |> optional "org" string ""
         |> optional "name" string ""
         |> optional "counter" int -1
+        |> optional "active" bool False
         |> optional "builds" (Json.Decode.list decodeBuild) []
 
 

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -59,6 +59,7 @@ module Vela exposing
     , decodeBuildGraph
     , decodeBuilds
     , decodeDashboard
+    , decodeDashboards
     , decodeDeployment
     , decodeDeployments
     , decodeGraphInteraction
@@ -218,6 +219,11 @@ decodeDashboard =
     Json.Decode.succeed Dashboard
         |> optional "dashboard" decodeDashboardItem (DashboardItem "" "" 0 "" 0 "" [] [])
         |> optional "repos" (Json.Decode.list decodeDashboardRepoCard) []
+
+
+decodeDashboards : Decoder (List Dashboard)
+decodeDashboards =
+    Json.Decode.list decodeDashboard
 
 
 decodeDashboardItem : Decoder DashboardItem

--- a/src/scss/_dashboards.scss
+++ b/src/scss/_dashboards.scss
@@ -17,22 +17,71 @@
 }
 
 .dashboard-repos {
+  display: flex;
   flex-basis: 100%;
+  flex-wrap: wrap;
+  gap: 1rem;
   margin-top: 1rem;
   padding: 1rem 1rem 0 0;
 
   border-top: 2px dotted var(--color-bg-light);
 }
 
+.dashboard-item-title code {
+  margin-left: 1rem;
+
+  color: var(--color-bg-light);
+  font-size: 1rem;
+}
+
 .dashboard-repos-item {
-  display: inline-block;
-  margin-right: 1rem;
-  margin-bottom: .5rem;
+  display: flex;
+  gap: .5rem;
+  align-items: center;
   padding: .25rem .5rem;
 
   font-size: .8rem;
 
   background-color: var(--color-bg-darkest);
+
+  .-icon {
+    width: 1rem;
+    height: 1rem;
+
+    fill: none;
+
+    &.-running {
+      background-color: var(--color-yellow);
+
+      stroke: var(--color-bg);
+    }
+
+    &.-failure,
+    &.-error {
+      background-color: var(--color-red);
+
+      stroke: var(--color-bg);
+    }
+
+    &.-canceled {
+      background-color: var(--color-cyan-dark);
+
+      stroke: var(--color-bg);
+    }
+
+    &.-success {
+      background-color: var(--color-green);
+
+      stroke: var(--color-bg);
+    }
+
+    &.-pending {
+      background-color: var(--color-bg-light);
+
+      fill: var(--color-bg);
+      stroke: var(--color-bg);
+    }
+  }
 }
 
 .dashboard-title {

--- a/src/scss/_dashboards.scss
+++ b/src/scss/_dashboards.scss
@@ -2,6 +2,39 @@
 
 // styles for the dashboard pages
 
+.beta {
+  margin-left: 0.5rem;
+  padding: 0.25rem 0.4rem;
+
+  font-size: 0.8rem;
+  vertical-align: top;
+
+  background-color: var(--color-green-dark);
+}
+
+.dashboards .item {
+  flex-wrap: wrap;
+}
+
+.dashboard-repos {
+  flex-basis: 100%;
+  margin-top: 1rem;
+  padding: 1rem 1rem 0 0;
+
+  border-top: 2px dotted var(--color-bg-light);
+}
+
+.dashboard-repos-item {
+  display: inline-block;
+  margin-right: 1rem;
+  margin-bottom: .5rem;
+  padding: .25rem .5rem;
+
+  font-size: .8rem;
+
+  background-color: var(--color-bg-darkest);
+}
+
 .dashboard-title {
   border-bottom: var(--line-width) solid var(--color-secondary);
 }

--- a/src/scss/_dashboards.scss
+++ b/src/scss/_dashboards.scss
@@ -36,11 +36,11 @@
 
 .dashboard-repos-item {
   display: flex;
-  gap: .5rem;
+  gap: 0.5rem;
   align-items: center;
-  padding: .25rem .5rem;
+  padding: 0.25rem 0.5rem;
 
-  font-size: .8rem;
+  font-size: 0.8rem;
 
   background-color: var(--color-bg-darkest);
 


### PR DESCRIPTION
(description by David M)
replaces the static page on `/dashboards` page to show a list of the current user's dashboards that you can navigate to. it also lists repos assigned to each dashboard and last build status for each assigned repo.

this is an incremental improvement as we explore how to evolve dashboards and gather more feedback.

Updated static page when you don't have dashboards:
![image](https://github.com/user-attachments/assets/6f121a55-3881-49d6-88e3-f0e62a177bc4)

Same page when you have added a dashboard:
![image](https://github.com/user-attachments/assets/a1e88f25-5259-45e0-9a99-359fe7954e9f)

the dashboard id is a bit faint and really only shown because it's useful to use in CLI commands. whatever the post-beta version looks like, i imagine it won't show at all. it's also not super accessible in this format.