### PR TITLE
fix(viz): always fetch graph when clicking refresh

### DIFF
--- a/src/elm/Pages/Org_/Repo_/Build_/Graph.elm
+++ b/src/elm/Pages/Org_/Repo_/Build_/Graph.elm
@@ -250,7 +250,7 @@ update shared route msg model =
                             False
 
                 runEffect =
-                    if isBuildRunning then
+                    if isBuildRunning || options.freshDraw then
                         Effect.getBuildGraph
                             { baseUrl = shared.velaAPIBaseURL
                             , session = shared.session


### PR DESCRIPTION
fetch the graph when the user directly asks for it, even if the build is already complete.

closes https://github.com/go-vela/community/issues/1003