### PR TITLE
fix(dashboards): show appropriate messaging for deleted dashboards

### DIFF
--- a/src/elm/Pages/Dashboards.elm
+++ b/src/elm/Pages/Dashboards.elm
@@ -252,18 +252,18 @@ viewDashboards dashboards =
                     , div [ class "buttons" ]
                         [ a [ class "button", dashboardLink ] [ text "View" ]
                         ]
-                    , viewDashboardRepos dashboard.repos dashboard.dashboard.id
+                    , viewDashboardRepos dashboard
                     ]
             )
 
 
 {-| viewDashboardRepos : renders a list of repos belonging to a dashboard.
 -}
-viewDashboardRepos : List Vela.DashboardRepoCard -> String -> Html Msg
-viewDashboardRepos repos dashboardId =
+viewDashboardRepos : Vela.Dashboard -> Html Msg
+viewDashboardRepos dashboard =
     div [ class "dashboard-repos", Util.testAttribute "dashboard-repos" ]
-        (if List.length repos > 0 then
-            repos
+        (if List.length dashboard.repos > 0 then
+            dashboard.repos
                 |> List.map
                     (\repo ->
                         let
@@ -282,10 +282,16 @@ viewDashboardRepos repos dashboardId =
                             ]
                     )
 
+         else if String.contains "(not found)" dashboard.dashboard.name then
+            [ text <|
+                "⚠️ This dashboard has been deleted. You can remove it from your list: vela update user --drop-dashboards "
+                    ++ dashboard.dashboard.id
+            ]
+
          else
             [ text <|
-                "⚠️ No repositories in this dashboard. Use the CLI to add some: vela update dashboard --id "
-                    ++ dashboardId
+                "ℹ️ No repositories in this dashboard. Use the CLI to add some: vela update dashboard --id "
+                    ++ dashboard.dashboard.id
                     ++ " --add-repos org/repo"
             ]
         )

--- a/src/elm/Pages/Dashboards.elm
+++ b/src/elm/Pages/Dashboards.elm
@@ -245,15 +245,25 @@ viewDashboards dashboards =
                             |> Route.Path.href
                 in
                 div [ class "item", Util.testAttribute "dashboard-item" ]
-                    [ span [ class "dashboard-item-title" ]
-                        [ a [ dashboardLink ] [ text dashboard.dashboard.name ]
-                        , code [] [ text dashboard.dashboard.id ]
+                    (if String.contains "(not found)" dashboard.dashboard.name then
+                        [ span [ class "dashboard-item-title" ]
+                            [ text dashboard.dashboard.name
+                            , code [] [ text dashboard.dashboard.id ]
+                            ]
+                        , viewDashboardRepos dashboard
                         ]
-                    , div [ class "buttons" ]
-                        [ a [ class "button", dashboardLink ] [ text "View" ]
+
+                     else
+                        [ span [ class "dashboard-item-title" ]
+                            [ a [ dashboardLink ] [ text dashboard.dashboard.name ]
+                            , code [] [ text dashboard.dashboard.id ]
+                            ]
+                        , div [ class "buttons" ]
+                            [ a [ class "button", dashboardLink ] [ text "View" ]
+                            ]
+                        , viewDashboardRepos dashboard
                         ]
-                    , viewDashboardRepos dashboard
-                    ]
+                    )
             )
 
 


### PR DESCRIPTION
see https://github.com/go-vela/server/pull/1193

also updates emoji for dashboards without any repos to ℹ️ instead of ⚠️

![image](https://github.com/user-attachments/assets/4c26db1c-e876-43ee-9eb3-71c698c0a717)

