### PR TITLE
fix: move worker status

### DIFF
--- a/cypress/integration/status_workers.spec.js
+++ b/cypress/integration/status_workers.spec.js
@@ -9,7 +9,7 @@ context('Workers', () => {
       method: 'GET',
       url: '*api/v1/user*',
       status: 200,
-      response: 'fixture:user_admin.json',
+      response: 'fixture:user.json',
     });
   });
   context('server returning workers error', () => {
@@ -20,7 +20,7 @@ context('Workers', () => {
         status: 500,
         response: 'server error',
       });
-      cy.loginAdmin('/admin/workers');
+      cy.login('/status/workers');
     });
     it('workers table should not show', () => {
       cy.get('[data-test=workers]').should('not.be.visible');
@@ -40,7 +40,7 @@ context('Workers', () => {
       cy.route('GET', '*api/v1/workers*', 'fixture:workers_5.json').as(
         'workers',
       );
-      cy.loginAdmin('/admin/workers');
+      cy.login('/status/workers');
     });
     it('workers table should show', () => {
       cy.get('[data-test=workers-table]').should('be.visible');
@@ -73,23 +73,23 @@ context('Workers', () => {
     beforeEach(() => {
       cy.server();
       cy.workerPages();
-      cy.loginAdmin('/admin/workers');
+      cy.login('/status/workers');
     });
     it('workers table should show 10 workers', () => {
       cy.get('[data-test=workers-row]').should('have.length', 10);
     });
     it('shows page 2 of the workers', () => {
-      cy.visit('/admin/workers?page=2');
+      cy.visit('/status/workers?page=2');
       cy.get('[data-test=workers-row]').should('have.length', 10);
       cy.get('[data-test=pager-next]').should('be.disabled');
     });
     it("loads the first page when hitting the 'previous' button", () => {
-      cy.visit('/admin/workers?page=2');
+      cy.visit('/status/workers?page=2');
       cy.get('[data-test=pager-previous]')
         .should('have.length', 2)
         .first()
         .click();
-      cy.location('pathname').should('eq', '/admin/workers');
+      cy.location('pathname').should('eq', '/status/workers');
     });
     context('force 550, 750 resolution', () => {
       beforeEach(() => {

--- a/src/elm/Components/Tabs.elm
+++ b/src/elm/Components/Tabs.elm
@@ -331,11 +331,6 @@ viewAdminTabs shared props =
               , isAlerting = False
               , show = True
               }
-            , { name = "Workers"
-              , toPath = Route.Path.Admin_Workers
-              , isAlerting = False
-              , show = True
-              }
             ]
     in
     view props.tabHistory props.currentPath tabs "jump-bar-admin"

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -34,7 +34,6 @@ import Pages.Account.Logout
 import Pages.Account.Settings
 import Pages.Account.SourceRepos
 import Pages.Admin.Settings
-import Pages.Admin.Workers
 import Pages.Dash.Secrets.Engine_.Org.Org_
 import Pages.Dash.Secrets.Engine_.Org.Org_.Add
 import Pages.Dash.Secrets.Engine_.Org.Org_.Name_
@@ -64,6 +63,7 @@ import Pages.Org_.Repo_.Schedules.Add
 import Pages.Org_.Repo_.Schedules.Name_
 import Pages.Org_.Repo_.Settings
 import Pages.Org_.Repo_.Tags
+import Pages.Status.Workers
 import Route exposing (Route)
 import Route.Path
 import Shared
@@ -704,30 +704,6 @@ initPageAndLayout model =
                     }
                 )
 
-        Route.Path.Admin_Workers ->
-            runWhenAuthenticatedWithLayout
-                model
-                (\user ->
-                    let
-                        page : Page.Page Pages.Admin.Workers.Model Pages.Admin.Workers.Msg
-                        page =
-                            Pages.Admin.Workers.page user model.shared (Route.fromUrl () model.url)
-
-                        ( pageModel, pageEffect ) =
-                            Page.init page ()
-                    in
-                    { page =
-                        Tuple.mapBoth
-                            Main.Pages.Model.Admin_Workers
-                            (Effect.map Main.Pages.Msg.Admin_Workers >> fromPageEffect model)
-                            ( pageModel, pageEffect )
-                    , layout =
-                        Page.layout pageModel page
-                            |> Maybe.map (Layouts.map (Main.Pages.Msg.Admin_Workers >> Page))
-                            |> Maybe.map (initLayout model)
-                    }
-                )
-
         Route.Path.Dash_Secrets_Engine__Org_Org_ params ->
             runWhenAuthenticatedWithLayout
                 model
@@ -988,6 +964,30 @@ initPageAndLayout model =
                     , layout =
                         Page.layout pageModel page
                             |> Maybe.map (Layouts.map (Main.Pages.Msg.Dashboards_Dashboard_ >> Page))
+                            |> Maybe.map (initLayout model)
+                    }
+                )
+
+        Route.Path.Status_Workers ->
+            runWhenAuthenticatedWithLayout
+                model
+                (\user ->
+                    let
+                        page : Page.Page Pages.Status.Workers.Model Pages.Status.Workers.Msg
+                        page =
+                            Pages.Status.Workers.page user model.shared (Route.fromUrl () model.url)
+
+                        ( pageModel, pageEffect ) =
+                            Page.init page ()
+                    in
+                    { page =
+                        Tuple.mapBoth
+                            Main.Pages.Model.Status_Workers
+                            (Effect.map Main.Pages.Msg.Status_Workers >> fromPageEffect model)
+                            ( pageModel, pageEffect )
+                    , layout =
+                        Page.layout pageModel page
+                            |> Maybe.map (Layouts.map (Main.Pages.Msg.Status_Workers >> Page))
                             |> Maybe.map (initLayout model)
                     }
                 )
@@ -1670,16 +1670,6 @@ updateFromPage msg model =
                         (Page.update (Pages.Admin.Settings.page user model.shared (Route.fromUrl () model.url)) pageMsg pageModel)
                 )
 
-        ( Main.Pages.Msg.Admin_Workers pageMsg, Main.Pages.Model.Admin_Workers pageModel ) ->
-            runWhenAuthenticated
-                model
-                (\user ->
-                    Tuple.mapBoth
-                        Main.Pages.Model.Admin_Workers
-                        (Effect.map Main.Pages.Msg.Admin_Workers >> fromPageEffect model)
-                        (Page.update (Pages.Admin.Workers.page user model.shared (Route.fromUrl () model.url)) pageMsg pageModel)
-                )
-
         ( Main.Pages.Msg.Dash_Secrets_Engine__Org_Org_ pageMsg, Main.Pages.Model.Dash_Secrets_Engine__Org_Org_ params pageModel ) ->
             runWhenAuthenticated
                 model
@@ -1788,6 +1778,16 @@ updateFromPage msg model =
                         (Main.Pages.Model.Dashboards_Dashboard_ params)
                         (Effect.map Main.Pages.Msg.Dashboards_Dashboard_ >> fromPageEffect model)
                         (Page.update (Pages.Dashboards.Dashboard_.page user model.shared (Route.fromUrl params model.url)) pageMsg pageModel)
+                )
+
+        ( Main.Pages.Msg.Status_Workers pageMsg, Main.Pages.Model.Status_Workers pageModel ) ->
+            runWhenAuthenticated
+                model
+                (\user ->
+                    Tuple.mapBoth
+                        Main.Pages.Model.Status_Workers
+                        (Effect.map Main.Pages.Msg.Status_Workers >> fromPageEffect model)
+                        (Page.update (Pages.Status.Workers.page user model.shared (Route.fromUrl () model.url)) pageMsg pageModel)
                 )
 
         ( Main.Pages.Msg.Org_ pageMsg, Main.Pages.Model.Org_ params pageModel ) ->
@@ -2087,12 +2087,6 @@ toLayoutFromPage model =
                 |> Maybe.andThen (Page.layout pageModel)
                 |> Maybe.map (Layouts.map (Main.Pages.Msg.Admin_Settings >> Page))
 
-        Main.Pages.Model.Admin_Workers pageModel ->
-            Route.fromUrl () model.url
-                |> toAuthProtectedPage model Pages.Admin.Workers.page
-                |> Maybe.andThen (Page.layout pageModel)
-                |> Maybe.map (Layouts.map (Main.Pages.Msg.Admin_Workers >> Page))
-
         Main.Pages.Model.Dash_Secrets_Engine__Org_Org_ params pageModel ->
             Route.fromUrl params model.url
                 |> toAuthProtectedPage model Pages.Dash.Secrets.Engine_.Org.Org_.page
@@ -2158,6 +2152,12 @@ toLayoutFromPage model =
                 |> toAuthProtectedPage model Pages.Dashboards.Dashboard_.page
                 |> Maybe.andThen (Page.layout pageModel)
                 |> Maybe.map (Layouts.map (Main.Pages.Msg.Dashboards_Dashboard_ >> Page))
+
+        Main.Pages.Model.Status_Workers pageModel ->
+            Route.fromUrl () model.url
+                |> toAuthProtectedPage model Pages.Status.Workers.page
+                |> Maybe.andThen (Page.layout pageModel)
+                |> Maybe.map (Layouts.map (Main.Pages.Msg.Status_Workers >> Page))
 
         Main.Pages.Model.Org_ params pageModel ->
             Route.fromUrl params model.url
@@ -2357,15 +2357,6 @@ subscriptions model =
                         )
                         (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
 
-                Main.Pages.Model.Admin_Workers pageModel ->
-                    Auth.Action.subscriptions
-                        (\user ->
-                            Page.subscriptions (Pages.Admin.Workers.page user model.shared (Route.fromUrl () model.url)) pageModel
-                                |> Sub.map Main.Pages.Msg.Admin_Workers
-                                |> Sub.map Page
-                        )
-                        (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
-
                 Main.Pages.Model.Dash_Secrets_Engine__Org_Org_ params pageModel ->
                     Auth.Action.subscriptions
                         (\user ->
@@ -2461,6 +2452,15 @@ subscriptions model =
                         (\user ->
                             Page.subscriptions (Pages.Dashboards.Dashboard_.page user model.shared (Route.fromUrl params model.url)) pageModel
                                 |> Sub.map Main.Pages.Msg.Dashboards_Dashboard_
+                                |> Sub.map Page
+                        )
+                        (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
+
+                Main.Pages.Model.Status_Workers pageModel ->
+                    Auth.Action.subscriptions
+                        (\user ->
+                            Page.subscriptions (Pages.Status.Workers.page user model.shared (Route.fromUrl () model.url)) pageModel
+                                |> Sub.map Main.Pages.Msg.Status_Workers
                                 |> Sub.map Page
                         )
                         (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
@@ -2867,15 +2867,6 @@ viewPage model =
                 )
                 (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
 
-        Main.Pages.Model.Admin_Workers pageModel ->
-            Auth.Action.view (View.map never (Auth.viewCustomPage model.shared (Route.fromUrl () model.url)))
-                (\user ->
-                    Page.view (Pages.Admin.Workers.page user model.shared (Route.fromUrl () model.url)) pageModel
-                        |> View.map Main.Pages.Msg.Admin_Workers
-                        |> View.map Page
-                )
-                (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
-
         Main.Pages.Model.Dash_Secrets_Engine__Org_Org_ params pageModel ->
             Auth.Action.view (View.map never (Auth.viewCustomPage model.shared (Route.fromUrl () model.url)))
                 (\user ->
@@ -2971,6 +2962,15 @@ viewPage model =
                 (\user ->
                     Page.view (Pages.Dashboards.Dashboard_.page user model.shared (Route.fromUrl params model.url)) pageModel
                         |> View.map Main.Pages.Msg.Dashboards_Dashboard_
+                        |> View.map Page
+                )
+                (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
+
+        Main.Pages.Model.Status_Workers pageModel ->
+            Auth.Action.view (View.map never (Auth.viewCustomPage model.shared (Route.fromUrl () model.url)))
+                (\user ->
+                    Page.view (Pages.Status.Workers.page user model.shared (Route.fromUrl () model.url)) pageModel
+                        |> View.map Main.Pages.Msg.Status_Workers
                         |> View.map Page
                 )
                 (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
@@ -3238,16 +3238,6 @@ toPageUrlHookCmd model routes =
                 )
                 (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
 
-        Main.Pages.Model.Admin_Workers pageModel ->
-            Auth.Action.command
-                (\user ->
-                    Page.toUrlMessages routes (Pages.Admin.Workers.page user model.shared (Route.fromUrl () model.url))
-                        |> List.map Main.Pages.Msg.Admin_Workers
-                        |> List.map Page
-                        |> toCommands
-                )
-                (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
-
         Main.Pages.Model.Dash_Secrets_Engine__Org_Org_ params pageModel ->
             Auth.Action.command
                 (\user ->
@@ -3353,6 +3343,16 @@ toPageUrlHookCmd model routes =
                 (\user ->
                     Page.toUrlMessages routes (Pages.Dashboards.Dashboard_.page user model.shared (Route.fromUrl params model.url))
                         |> List.map Main.Pages.Msg.Dashboards_Dashboard_
+                        |> List.map Page
+                        |> toCommands
+                )
+                (Auth.onPageLoad model.shared (Route.fromUrl () model.url))
+
+        Main.Pages.Model.Status_Workers pageModel ->
+            Auth.Action.command
+                (\user ->
+                    Page.toUrlMessages routes (Pages.Status.Workers.page user model.shared (Route.fromUrl () model.url))
+                        |> List.map Main.Pages.Msg.Status_Workers
                         |> List.map Page
                         |> toCommands
                 )
@@ -3688,9 +3688,6 @@ isAuthProtected routePath =
         Route.Path.Admin_Settings ->
             True
 
-        Route.Path.Admin_Workers ->
-            True
-
         Route.Path.Dash_Secrets_Engine__Org_Org_ _ ->
             True
 
@@ -3722,6 +3719,9 @@ isAuthProtected routePath =
             True
 
         Route.Path.Dashboards_Dashboard_ _ ->
+            True
+
+        Route.Path.Status_Workers ->
             True
 
         Route.Path.Org_ _ ->

--- a/src/elm/Main/Pages/Model.elm
+++ b/src/elm/Main/Pages/Model.elm
@@ -11,7 +11,6 @@ import Pages.Account.Logout
 import Pages.Account.Settings
 import Pages.Account.SourceRepos
 import Pages.Admin.Settings
-import Pages.Admin.Workers
 import Pages.Dash.Secrets.Engine_.Org.Org_
 import Pages.Dash.Secrets.Engine_.Org.Org_.Add
 import Pages.Dash.Secrets.Engine_.Org.Org_.Name_
@@ -41,6 +40,7 @@ import Pages.Org_.Repo_.Schedules.Add
 import Pages.Org_.Repo_.Schedules.Name_
 import Pages.Org_.Repo_.Settings
 import Pages.Org_.Repo_.Tags
+import Pages.Status.Workers
 import View exposing (View)
 
 
@@ -52,7 +52,6 @@ type Model
     | Account_Settings Pages.Account.Settings.Model
     | Account_SourceRepos Pages.Account.SourceRepos.Model
     | Admin_Settings Pages.Admin.Settings.Model
-    | Admin_Workers Pages.Admin.Workers.Model
     | Dash_Secrets_Engine__Org_Org_ { engine : String, org : String } Pages.Dash.Secrets.Engine_.Org.Org_.Model
     | Dash_Secrets_Engine__Org_Org__Add { engine : String, org : String } Pages.Dash.Secrets.Engine_.Org.Org_.Add.Model
     | Dash_Secrets_Engine__Org_Org__Name_ { engine : String, org : String, name : String } Pages.Dash.Secrets.Engine_.Org.Org_.Name_.Model
@@ -64,6 +63,7 @@ type Model
     | Dash_Secrets_Engine__Shared_Org__Team__Name_ { engine : String, org : String, team : String, name : String } Pages.Dash.Secrets.Engine_.Shared.Org_.Team_.Name_.Model
     | Dashboards Pages.Dashboards.Model
     | Dashboards_Dashboard_ { dashboard : String } Pages.Dashboards.Dashboard_.Model
+    | Status_Workers Pages.Status.Workers.Model
     | Org_ { org : String } Pages.Org_.Model
     | Org__Builds { org : String } Pages.Org_.Builds.Model
     | Org__Repo_ { org : String, repo : String } Pages.Org_.Repo_.Model

--- a/src/elm/Main/Pages/Msg.elm
+++ b/src/elm/Main/Pages/Msg.elm
@@ -11,7 +11,6 @@ import Pages.Account.Logout
 import Pages.Account.Settings
 import Pages.Account.SourceRepos
 import Pages.Admin.Settings
-import Pages.Admin.Workers
 import Pages.Dash.Secrets.Engine_.Org.Org_
 import Pages.Dash.Secrets.Engine_.Org.Org_.Add
 import Pages.Dash.Secrets.Engine_.Org.Org_.Name_
@@ -41,6 +40,7 @@ import Pages.Org_.Repo_.Schedules.Add
 import Pages.Org_.Repo_.Schedules.Name_
 import Pages.Org_.Repo_.Settings
 import Pages.Org_.Repo_.Tags
+import Pages.Status.Workers
 
 
 type Msg
@@ -51,7 +51,6 @@ type Msg
     | Account_Settings Pages.Account.Settings.Msg
     | Account_SourceRepos Pages.Account.SourceRepos.Msg
     | Admin_Settings Pages.Admin.Settings.Msg
-    | Admin_Workers Pages.Admin.Workers.Msg
     | Dash_Secrets_Engine__Org_Org_ Pages.Dash.Secrets.Engine_.Org.Org_.Msg
     | Dash_Secrets_Engine__Org_Org__Add Pages.Dash.Secrets.Engine_.Org.Org_.Add.Msg
     | Dash_Secrets_Engine__Org_Org__Name_ Pages.Dash.Secrets.Engine_.Org.Org_.Name_.Msg
@@ -63,6 +62,7 @@ type Msg
     | Dash_Secrets_Engine__Shared_Org__Team__Name_ Pages.Dash.Secrets.Engine_.Shared.Org_.Team_.Name_.Msg
     | Dashboards Pages.Dashboards.Msg
     | Dashboards_Dashboard_ Pages.Dashboards.Dashboard_.Msg
+    | Status_Workers Pages.Status.Workers.Msg
     | Org_ Pages.Org_.Msg
     | Org__Builds Pages.Org_.Builds.Msg
     | Org__Repo_ Pages.Org_.Repo_.Msg

--- a/src/elm/Pages/Status/Workers.elm
+++ b/src/elm/Pages/Status/Workers.elm
@@ -54,9 +54,9 @@ toLayout : Auth.User -> Model -> Layouts.Layout Msg
 toLayout user model =
     Layouts.Default
         { helpCommands =
-            [ { name = ""
-              , content = "resources on this page not yet supported via the CLI"
-              , docs = Nothing
+            [ { name = "List Workers"
+              , content = "vela get workers"
+              , docs = Just "cli/worker/get"
               }
             ]
         }

--- a/src/elm/Route/Path.elm
+++ b/src/elm/Route/Path.elm
@@ -19,7 +19,6 @@ type Path
     | Account_Settings
     | Account_SourceRepos
     | Admin_Settings
-    | Admin_Workers
     | Dash_Secrets_Engine__Org_Org_ { engine : String, org : String }
     | Dash_Secrets_Engine__Org_Org__Add { engine : String, org : String }
     | Dash_Secrets_Engine__Org_Org__Name_ { engine : String, org : String, name : String }
@@ -31,6 +30,7 @@ type Path
     | Dash_Secrets_Engine__Shared_Org__Team__Name_ { engine : String, org : String, team : String, name : String }
     | Dashboards
     | Dashboards_Dashboard_ { dashboard : String }
+    | Status_Workers
     | Org_ { org : String }
     | Org__Builds { org : String }
     | Org__Repo_ { org : String, repo : String }
@@ -86,9 +86,6 @@ fromString urlPath =
 
         "admin" :: "settings" :: [] ->
             Just Admin_Settings
-
-        "admin" :: "workers" :: [] ->
-            Just Admin_Workers
 
         "-" :: "secrets" :: engine_ :: "org" :: org_ :: [] ->
             Dash_Secrets_Engine__Org_Org_
@@ -170,6 +167,9 @@ fromString urlPath =
                 { dashboard = dashboard_
                 }
                 |> Just
+
+        "status" :: "workers" :: [] ->
+            Just Status_Workers
 
         org_ :: [] ->
             Org_
@@ -322,9 +322,6 @@ toString path =
                 Admin_Settings ->
                     [ "admin", "settings" ]
 
-                Admin_Workers ->
-                    [ "admin", "workers" ]
-
                 Dash_Secrets_Engine__Org_Org_ params ->
                     [ "-", "secrets", params.engine, "org", params.org ]
 
@@ -357,6 +354,9 @@ toString path =
 
                 Dashboards_Dashboard_ params ->
                     [ "dashboards", params.dashboard ]
+
+                Status_Workers ->
+                    [ "status", "workers" ]
 
                 Org_ params ->
                     [ params.org ]


### PR DESCRIPTION
this was behind admin page before, but the endpoint doesn't require
special perms. this moves it from /admin/workers to /status/workers.
"status" is a reserved word at the org level (for
GitHub), so it shouldn't cause an issue.