### PR TITLE
fix(repo): add approval timeout setting to reflect server capability

### DIFF
--- a/cypress/fixtures/repository.json
+++ b/cypress/fixtures/repository.json
@@ -42,5 +42,6 @@
     }
   },
   "pipeline_type": "yaml",
-  "approve_build": "fork-always"
+  "approve_build": "fork-always",
+  "approval_timeout": 7
 }

--- a/cypress/fixtures/repository_updated.json
+++ b/cypress/fixtures/repository_updated.json
@@ -42,5 +42,6 @@
     }
   },
   "pipeline_type": "yaml",
-  "approve_build": "fork-no-write"
+  "approve_build": "fork-no-write",
+  "approval_timeout": 10
 }

--- a/cypress/integration/repo_settings.spec.js
+++ b/cypress/integration/repo_settings.spec.js
@@ -35,6 +35,10 @@ context('Repo Settings', () => {
       cy.login('/github/octocat/settings');
     });
 
+    it('approval timeout should show', () => {
+      cy.get('[data-test=repo-approval-timeout]').should('be.visible');
+    });
+
     it('build limit input should show', () => {
       cy.get('[data-test=repo-limit]').should('be.visible');
     });
@@ -87,6 +91,35 @@ context('Repo Settings', () => {
       cy.get('@pipelineTypeRadio').should('not.have.checked');
       cy.get('@pipelineTypeRadio').click({ force: true });
       cy.get('@pipelineTypeRadio').should('have.checked');
+    });
+
+    it('approval timeout input should allow number input', () => {
+      cy.get('[data-test=repo-approval-timeout]').as('repoApprovalTimeout');
+      cy.get('[data-test=repo-approval-timeout] input').as(
+        'repoApprovalTimeoutInput',
+      );
+      cy.get('@repoApprovalTimeoutInput').should('be.visible').type('{selectall}123');
+      cy.get('@repoApprovalTimeoutInput').should('have.value', '123');
+    })
+
+    it('approval timeout input should not allow letter/character input', () => {
+      cy.get('[data-test=repo-approval-timeout]').as('repoApprovalTimeout');
+      cy.get('[data-test=repo-approval-timeout] input').as('repoApprovalTimeoutInput');
+      cy.get('@repoApprovalTimeoutInput').should('be.visible').type('{selectall}cat');
+      cy.get('@repoApprovalTimeoutInput').should('not.have.value', 'cat');
+      cy.get('@repoApprovalTimeoutInput').type('{selectall}12cat34');
+      cy.get('@repoApprovalTimeoutInput').should('have.value', '1234');
+    });
+
+    it('clicking update on approval timeout should update timeout and hide button', () => {
+      cy.get('[data-test=repo-approval-timeout]').as('repoApprovalTimeout');
+      cy.get('[data-test=repo-approval-timeout] input').as('repoApprovalTimeoutInput');
+      cy.get('@repoApprovalTimeoutInput').should('be.visible').clear();
+      cy.get('@repoApprovalTimeoutInput').type('{selectall}80');
+      cy.get('[data-test=repo-approval-timeout] + button')
+        .should('be.visible')
+        .click({ force: true });
+      cy.get('[data-test=repo-approval-timeout] + button').should('be.disabled');
     });
 
     it('build limit input should allow number input', () => {

--- a/cypress/integration/repo_settings.spec.js
+++ b/cypress/integration/repo_settings.spec.js
@@ -98,14 +98,20 @@ context('Repo Settings', () => {
       cy.get('[data-test=repo-approval-timeout] input').as(
         'repoApprovalTimeoutInput',
       );
-      cy.get('@repoApprovalTimeoutInput').should('be.visible').type('{selectall}123');
+      cy.get('@repoApprovalTimeoutInput')
+        .should('be.visible')
+        .type('{selectall}123');
       cy.get('@repoApprovalTimeoutInput').should('have.value', '123');
-    })
+    });
 
     it('approval timeout input should not allow letter/character input', () => {
       cy.get('[data-test=repo-approval-timeout]').as('repoApprovalTimeout');
-      cy.get('[data-test=repo-approval-timeout] input').as('repoApprovalTimeoutInput');
-      cy.get('@repoApprovalTimeoutInput').should('be.visible').type('{selectall}cat');
+      cy.get('[data-test=repo-approval-timeout] input').as(
+        'repoApprovalTimeoutInput',
+      );
+      cy.get('@repoApprovalTimeoutInput')
+        .should('be.visible')
+        .type('{selectall}cat');
       cy.get('@repoApprovalTimeoutInput').should('not.have.value', 'cat');
       cy.get('@repoApprovalTimeoutInput').type('{selectall}12cat34');
       cy.get('@repoApprovalTimeoutInput').should('have.value', '1234');
@@ -113,13 +119,17 @@ context('Repo Settings', () => {
 
     it('clicking update on approval timeout should update timeout and hide button', () => {
       cy.get('[data-test=repo-approval-timeout]').as('repoApprovalTimeout');
-      cy.get('[data-test=repo-approval-timeout] input').as('repoApprovalTimeoutInput');
+      cy.get('[data-test=repo-approval-timeout] input').as(
+        'repoApprovalTimeoutInput',
+      );
       cy.get('@repoApprovalTimeoutInput').should('be.visible').clear();
       cy.get('@repoApprovalTimeoutInput').type('{selectall}80');
       cy.get('[data-test=repo-approval-timeout] + button')
         .should('be.visible')
         .click({ force: true });
-      cy.get('[data-test=repo-approval-timeout] + button').should('be.disabled');
+      cy.get('[data-test=repo-approval-timeout] + button').should(
+        'be.disabled',
+      );
     });
 
     it('build limit input should allow number input', () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
   # https://go-vela.github.io/docs/administration/server/
   server:
     container_name: server
-    image: server:local
+    image: target/vela-server:latest
     networks:
       - vela
     environment:

--- a/src/elm/Pages/Org_/Repo_/Settings.elm
+++ b/src/elm/Pages/Org_/Repo_/Settings.elm
@@ -866,6 +866,7 @@ viewForkPolicy repo msg =
             ]
         ]
 
+
 {-| viewApprovalTimeout : takes model and repo and renders the settings category for updating repo build approval timeout.
 -}
 viewApprovalTimeout : Vela.Repository -> Maybe Int -> (Int -> msg) -> (String -> msg) -> Html msg
@@ -878,6 +879,7 @@ viewApprovalTimeout repo inApprovalTimeout clickMsg inputMsg =
             , viewUpdateApprovalTimeout repo inApprovalTimeout <| clickMsg <| Maybe.withDefault 0 inApprovalTimeout
             ]
         ]
+
 
 {-| viewApprovalTimeoutInput : takes repo, user input, and button action and renders the text input for updating build approval timeout.
 -}
@@ -936,6 +938,7 @@ validApprovalTimeout maxApprovalTimeout inApprovalTimeout _ repoApprovalTimeout 
 
         Nothing ->
             False
+
 
 {-| viewLimit : takes model and repo and renders the settings category for updating repo build limit.
 -}

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -462,6 +462,7 @@ type alias Repository =
     , allowEvents : AllowEvents
     , enabled : Enabled
     , pipeline_type : String
+    , approval_timeout : Int
     }
 
 
@@ -487,6 +488,7 @@ emptyRepository =
     , allowEvents = defaultAllowEvents
     , enabled = Disabled
     , pipeline_type = ""
+    , approval_timeout = 0
     }
 
 
@@ -514,6 +516,7 @@ decodeRepository =
         -- "enabled"
         |> optional "active" enabledDecoder Disabled
         |> optional "pipeline_type" string ""
+        |> optional "approval_timeout" int 0
 
 
 decodeRepositories : Decoder (List Repository)
@@ -536,6 +539,7 @@ type alias RepoPayload =
     , timeout : Maybe Int
     , counter : Maybe Int
     , pipeline_type : Maybe String
+    , approval_timeout : Maybe Int
     }
 
 
@@ -552,6 +556,7 @@ encodeRepoPayload repo =
         , ( "timeout", encodeOptional Json.Encode.int repo.timeout )
         , ( "counter", encodeOptional Json.Encode.int repo.counter )
         , ( "pipeline_type", encodeOptional Json.Encode.string repo.pipeline_type )
+        , ( "approval_timeout", encodeOptional Json.Encode.int repo.approval_timeout)
         ]
 
 
@@ -567,6 +572,7 @@ defaultRepoPayload =
     , timeout = Nothing
     , counter = Nothing
     , pipeline_type = Nothing
+    , approval_timeout = Nothing
     }
 
 
@@ -580,6 +586,7 @@ type RepoFieldUpdate
     | Timeout
     | Counter
     | PipelineType
+    | ApprovalTimeout
 
 
 type alias RepoFieldUpdateResponseConfig =
@@ -716,6 +723,12 @@ repoFieldUpdateToResponseConfig field =
                 { successAlert =
                     \repo ->
                         "$ pipeline syntax type set to '" ++ repo.pipeline_type ++ "'."
+                }
+
+            ApprovalTimeout ->
+                { successAlert =
+                    \repo ->
+                        "$ build approval timeout set to " ++ String.fromInt repo.approval_timeout ++ " day(s)."
                 }
 
 

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -556,7 +556,7 @@ encodeRepoPayload repo =
         , ( "timeout", encodeOptional Json.Encode.int repo.timeout )
         , ( "counter", encodeOptional Json.Encode.int repo.counter )
         , ( "pipeline_type", encodeOptional Json.Encode.string repo.pipeline_type )
-        , ( "approval_timeout", encodeOptional Json.Encode.int repo.approval_timeout)
+        , ( "approval_timeout", encodeOptional Json.Encode.int repo.approval_timeout )
         ]
 
 


### PR DESCRIPTION
Modeled the build limit container for this:

![Screenshot 2025-01-13 at 4 13 42 PM](https://github.com/user-attachments/assets/ed766aec-9aba-419a-a558-cb57b79dc893)
