### PR TITLE
enhance(workers): render a more descriptive build link

### DIFF
--- a/cypress/integration/status_workers.spec.js
+++ b/cypress/integration/status_workers.spec.js
@@ -60,7 +60,9 @@ context('Workers', () => {
       it('should show status', () => {
         cy.get('@firstWorker').within(() => {
           cy.get('[data-test=cell-status]').contains('busy');
-          cy.get('[data-test=cell-running-builds]').contains('github/octocat/1');
+          cy.get('[data-test=cell-running-builds]').contains(
+            'github/octocat/1',
+          );
         });
       });
       context('error', () => {

--- a/cypress/integration/status_workers.spec.js
+++ b/cypress/integration/status_workers.spec.js
@@ -60,6 +60,7 @@ context('Workers', () => {
       it('should show status', () => {
         cy.get('@firstWorker').within(() => {
           cy.get('[data-test=cell-status]').contains('busy');
+          cy.get('[data-test=cell-running-builds]').contains('github/octocat/1');
         });
       });
       context('error', () => {

--- a/src/elm/Pages/Status/Workers.elm
+++ b/src/elm/Pages/Status/Workers.elm
@@ -328,7 +328,7 @@ viewWorker shared worker =
                 ]
             }
         , Components.Table.viewItemCell
-            { dataLabel = "running builds"
+            { dataLabel = "running-builds"
             , parentClassList = []
             , itemClassList = []
             , children =
@@ -383,9 +383,9 @@ viewWorkerBuildsLinks worker =
                         (build.link
                             |> String.split "/"
                             |> List.reverse
-                            |> List.head
-                            |> Maybe.withDefault ""
-                            |> String.append "#"
+                            |> List.take 3
+                            |> List.reverse
+                            |> String.join "/"
                         )
                     ]
             )


### PR DESCRIPTION
Was thinking it would be nice to be able to see the repo that is running the build in the workers table rather than just the build number