### PR TITLE
feat(admin): add max dashboard repos to platform settings page

### DIFF
--- a/cypress/fixtures/settings.json
+++ b/cypress/fixtures/settings.json
@@ -10,6 +10,7 @@
   },
   "repo_allowlist": ["octocat/hello-world"],
   "schedule_allowlist": ["*"],
+  "max_dashboard_repos": 10,
   "created_at": 1572980375,
   "updated_at": 1572980675,
   "updated_by": "octocat"

--- a/cypress/fixtures/settings_updated.json
+++ b/cypress/fixtures/settings_updated.json
@@ -10,6 +10,7 @@
   },
   "repo_allowlist": ["octocat/hello-world"],
   "schedule_allowlist": [],
+  "max_dashboard_repos": 20,
   "created_at": 1572980375,
   "updated_at": 1572980675,
   "updated_by": "octocat"

--- a/cypress/integration/admin_settings.spec.js
+++ b/cypress/integration/admin_settings.spec.js
@@ -54,6 +54,9 @@ context('Admin Settings', () => {
           );
         });
     });
+    it('max dashboard repos should show', () => {
+      cy.get('[data-test=input-max-dashboard-repos]').should('be.visible');
+    });
 
     context('form should allow editing', () => {
       beforeEach(() => {
@@ -88,6 +91,21 @@ context('Admin Settings', () => {
           .should('be.visible')
           .type('0');
         cy.get('[data-test=button-template-depth-update]').should(
+          'be.disabled',
+        );
+
+        cy.get('[data-test=input-max-dashboard-repos]')
+          .should('be.visible')
+          .clear()
+          .type('999999');
+        cy.get('[data-test=button-max-dashboard-repos-update]').should(
+          'be.disabled',
+        );
+
+        cy.get('[data-test=input-max-dashboard-repos]')
+          .should('be.visible')
+          .type('0');
+        cy.get('[data-test=button-max-dashboard-repos-update]').should(
           'be.disabled',
         );
       });

--- a/src/elm/Pages/Admin/Settings.elm
+++ b/src/elm/Pages/Admin/Settings.elm
@@ -801,7 +801,7 @@ update shared route msg model =
               }
             , Effect.none
             )
-        
+
         -- DASHBOARDS
         MaxDashboardReposOnInput val ->
             ( { model

--- a/src/elm/Pages/Admin/Settings.elm
+++ b/src/elm/Pages/Admin/Settings.elm
@@ -85,6 +85,7 @@ type alias Model =
     , queueRoutes : Components.Form.EditableListForm
     , repoAllowlist : Components.Form.EditableListForm
     , scheduleAllowlist : Components.Form.EditableListForm
+    , maxDashboardReposIn : String
     }
 
 
@@ -101,6 +102,7 @@ init shared () =
       , queueRoutes = { val = "", editing = Dict.empty }
       , repoAllowlist = { val = "", editing = Dict.empty }
       , scheduleAllowlist = { val = "", editing = Dict.empty }
+      , maxDashboardReposIn = ""
       }
     , Effect.getSettings
         { baseUrl = shared.velaAPIBaseURL
@@ -149,6 +151,9 @@ type Msg
     | ScheduleAllowlistSaveOnClick { id : String, val : String }
     | ScheduleAllowlistEditOnInput { id : String } String
     | ScheduleAllowlistRemoveOnClick String
+      -- DASHBOARDS
+    | MaxDashboardReposOnInput String
+    | MaxDashboardReposOnUpdate String
       -- REFRESH
     | Tick { time : Time.Posix, interval : Interval.Interval }
 
@@ -167,6 +172,7 @@ update shared route msg model =
                         , cloneImage = settings.compiler.cloneImage
                         , starlarkExecLimitIn = String.fromInt settings.compiler.starlarkExecLimit
                         , templateDepthIn = String.fromInt settings.compiler.templateDepth
+                        , maxDashboardReposIn = String.fromInt settings.maxDashboardRepos
                       }
                     , Effect.none
                     )
@@ -795,6 +801,38 @@ update shared route msg model =
               }
             , Effect.none
             )
+        
+        -- DASHBOARDS
+        MaxDashboardReposOnInput val ->
+            ( { model
+                | maxDashboardReposIn = Components.Form.handleNumberInputString model.maxDashboardReposIn val
+              }
+            , Effect.none
+            )
+
+        MaxDashboardReposOnUpdate val ->
+            let
+                payload =
+                    { defaultSettingsPayload
+                        | maxDashboardRepos = String.toInt val
+                    }
+
+                body =
+                    Http.jsonBody <| Vela.encodeSettingsPayload payload
+            in
+            ( { model
+                | maxDashboardReposIn = val
+              }
+            , Effect.updateSettings
+                { baseUrl = shared.velaAPIBaseURL
+                , session = shared.session
+                , onResponse =
+                    UpdateSettingsResponse
+                        { field = Vela.MaxDashboardRepos
+                        }
+                , body = body
+                }
+            )
 
         -- REFRESH
         Tick options ->
@@ -974,6 +1012,55 @@ view shared route model =
                 , viewFieldPreviousValue model
                     (\s -> String.fromInt s.compiler.templateDepth)
                     (\ms -> Maybe.Extra.unwrap "" (.compiler >> .templateDepth >> String.fromInt) ms)
+                ]
+            , section
+                [ class "settings"
+                ]
+                [ viewFieldHeader "Max Dashboard Repos"
+                , viewFieldDescription "The maximum number of repos a dashboard can have."
+                , div [ class "form-controls" ]
+                    [ Components.Form.viewNumberInput
+                        { title = Nothing
+                        , subtitle = Nothing
+                        , id_ = "max-dashboard-repos"
+                        , val = model.maxDashboardReposIn
+                        , placeholder_ = ""
+                        , wrapperClassList = [ ( "-wide", True ) ]
+                        , classList_ = []
+                        , rows_ = Nothing
+                        , wrap_ = Nothing
+                        , msg = MaxDashboardReposOnInput
+                        , disabled_ = False
+                        , min = Just 0
+                        , max = Just 100
+                        , required = False
+                        }
+                    , Components.Form.viewButton
+                        { id_ = "max-dashboard-repos-update"
+                        , msg = MaxDashboardReposOnUpdate model.maxDashboardReposIn
+                        , text_ = "update"
+                        , classList_ =
+                            [ ( "-outline", True )
+                            ]
+                        , disabled_ =
+                            RemoteData.unwrap True
+                                (\s ->
+                                    case String.toInt model.maxDashboardReposIn of
+                                        Just limit ->
+                                            limit
+                                                == s.maxDashboardRepos
+                                                || (limit < 1)
+                                                || (limit > 99)
+
+                                        Nothing ->
+                                            True
+                                )
+                                model.settings
+                        }
+                    ]
+                , viewFieldPreviousValue model
+                    (\s -> String.fromInt s.maxDashboardRepos)
+                    (\ms -> Maybe.Extra.unwrap "" (.maxDashboardRepos >> String.fromInt) ms)
                 ]
             , section
                 [ class "settings"

--- a/src/elm/Vela.elm
+++ b/src/elm/Vela.elm
@@ -2159,6 +2159,7 @@ type alias PlatformSettings =
     , queue : Queue
     , repoAllowlist : List String
     , scheduleAllowlist : List String
+    , maxDashboardRepos : Int
     , createdAt : Int
     , updatedAt : Int
     , updatedBy : String
@@ -2173,6 +2174,7 @@ decodeSettings =
         |> required "queue" decodeQueue
         |> required "repo_allowlist" (Json.Decode.list Json.Decode.string)
         |> required "schedule_allowlist" (Json.Decode.list Json.Decode.string)
+        |> required "max_dashboard_repos" int
         |> required "created_at" int
         |> required "updated_at" int
         |> required "updated_by" string
@@ -2251,6 +2253,7 @@ type alias SettingsPayload =
     , queue : Maybe QueuePayload
     , repoAllowlist : Maybe (List String)
     , scheduleAllowlist : Maybe (List String)
+    , maxDashboardRepos : Maybe Int
     }
 
 
@@ -2260,6 +2263,7 @@ defaultSettingsPayload =
     , queue = Nothing
     , repoAllowlist = Nothing
     , scheduleAllowlist = Nothing
+    , maxDashboardRepos = Nothing
     }
 
 
@@ -2270,6 +2274,7 @@ encodeSettingsPayload settings =
         , ( "queue", encodeOptional encodeQueuePayload settings.queue )
         , ( "repo_allowlist", encodeOptional (Json.Encode.list Json.Encode.string) settings.repoAllowlist )
         , ( "schedule_allowlist", encodeOptional (Json.Encode.list Json.Encode.string) settings.scheduleAllowlist )
+        , ( "max_dashboard_repos", encodeOptional Json.Encode.int settings.maxDashboardRepos )
         ]
 
 
@@ -2277,6 +2282,7 @@ type PlatformSettingsFieldUpdate
     = CompilerCloneImage
     | CompilerTemplateDepth
     | CompilerStarlarkExecLimit
+    | MaxDashboardRepos
     | QueueRouteAdd String
     | QueueRouteUpdate String String
     | QueueRouteRemove String
@@ -2317,6 +2323,14 @@ platformSettingsFieldUpdateToResponseConfig field =
                 \settings ->
                     "Compiler Starlark exec limit set to '"
                         ++ String.fromInt settings.compiler.starlarkExecLimit
+                        ++ "'."
+            }
+
+        MaxDashboardRepos ->
+            { successAlert =
+                \settings ->
+                    "Max dashboard repos set to '"
+                        ++ String.fromInt settings.maxDashboardRepos
                         ++ "'."
             }
 


### PR DESCRIPTION
Follow up from https://github.com/go-vela/server/pull/1303

There isn't a max for the max enforced by the code base since it's an admin field. I did add 0-100 limits though. You could theoretically get around this using the API, so I figured it's ok. Not sure why any platform admin would set this higher.