### PR TITLE
feat: Clarifies in placeholder what deployment Ref field loads

### DIFF
--- a/src/elm/Pages/Org_/Repo_/Deployments/Add.elm
+++ b/src/elm/Pages/Org_/Repo_/Deployments/Add.elm
@@ -437,7 +437,10 @@ view shared route model =
                             , id_ = "ref"
                             , val = model.ref
                             , placeholder_ =
-                                "Provide the reference to deploy - this can be a branch, commit (SHA) or tag\n(default is your repo's default branch: "
+                                "Provide the git reference to deploy. This can be a branch, tag, or commit SHA hash.\n"
+                                    ++ "This is the reference from which Vela will read its configuration.\n"
+                                    ++ "\n"
+                                    ++ "(default is your repo's default branch: "
                                     ++ RemoteData.unwrap "main" .branch model.repo
                                     ++ ")"
                             , classList_ = [ ( "secret-value", True ) ]


### PR DESCRIPTION
It's my understanding that this ref field "_merely_" controls what ref Vela loads .vela.yml, etc. from  when it starts the deployment. This is _not_ "What tag you want to deploy" but rather "What ref's Vela config do you want to run" and then you give custom parameters that would set the version, if your deployment config doesn't just deploy whatever ref is specified.