### PR TITLE
fix(ci/renovate): add proper regex delimiter

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["(^|/|\\.)elm\\.json$"],
+      "managerFilePatterns": ["/(^|/|\\.)elm\\.json$/"],
       "matchStrings": ["\"elm-version\"\\s*:\\s*\"(?<currentValue>.*)\""],
       "depNameTemplate": "elm/compiler",
       "datasourceTemplate": "github-tags",
@@ -12,7 +12,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["(^|/|\\.)elm\\.json$"],
+      "managerFilePatterns": ["/(^|/|\\.)elm\\.json$/"],
       "matchStrings": [
         "\"(?<depName>.*/.*?)\"\\s*:\\s*\"(?<currentValue>.*)\""
       ],


### PR DESCRIPTION
follow-up to https://github.com/go-vela/ui/pull/865. noticed that the elm.json file (or the regex matcher) wasn't picked up on the dependency dashboard and used the `renovate` CLI to validate that i needed to surround the regex with "/" for it to get picked up properly.