### PR TITLE
chore(ci): separate elm deps into own PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,10 @@
     {
       "allowedVersions": "!/nightly\\.\\d+$/",
       "matchPackageNames": ["/^@?parcel/"]
+    },
+    {
+      "matchFileNames": ["elm.json"],
+      "groupName": "elm"
     }
   ]
 }


### PR DESCRIPTION
AI Generated Description:

This pull request adds a new configuration to the Renovate bot setup to group updates for Elm dependencies together. This will help keep Elm-related updates organized in a single pull request.

Dependency management:

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3R27-R30): Added a new rule to group updates for packages defined in `elm.json` under the group name "elm".